### PR TITLE
Dependabot init

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # `npm` is used for `yarn`
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 100

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 100
+    target-branch: "dev"


### PR DESCRIPTION
Fixes #13 !

Preliminary custom config for dependabot to examine `yarn` dependencies - I have set the max notifications to 100 (default is 5) because I wanted to see _everything_ that dependabot could find right away.

However, there are distinctions in dependabot I still need to investigate between "version updates" and "security updates," so this PR should just be seen as a starting point. I intend to open another issue or two to follow up on this PR.