### PR TITLE
change `yml` indentation to match linter suggestion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   # `npm` is used for `yarn`
   - package-ecosystem: "npm"
-      directory: "/"
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 100


### PR DESCRIPTION
When branch `init_dependabot` #17 merged in, and I enabled dependabot on the settings of this repo, I got an error from our CI:
"Dependabot couldn't parse the config file at .github/dependabot.yml" - I linted the file using a suggested online linter at https://jsonformatter.org/yaml-validator and removed an indentation.