### PR TITLE
Dev working

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -248,7 +248,7 @@ checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 [[package]]
 name = "bellman"
 version = "0.13.0"
-source = "git+https://github.com/dannasessha/bellman?rev=712337ea591cb89e031b9f203462d32de00bf7ff#712337ea591cb89e031b9f203462d32de00bf7ff"
+source = "git+https://github.com/zingolabs/bellman?rev=712337ea591cb89e031b9f203462d32de00bf7ff#712337ea591cb89e031b9f203462d32de00bf7ff"
 dependencies = [
  "bitvec",
  "blake2s_simd",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "zecwalletlitelib"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zecwalletlitelib?rev=d50ce9d618c1a2adc478ffbc3ad281512fbb0c15#d50ce9d618c1a2adc478ffbc3ad281512fbb0c15"
+source = "git+https://github.com/zingolabs/zecwalletlitelib?tag=vzing-0.0.1#d50ce9d618c1a2adc478ffbc3ad281512fbb0c15"
 dependencies = [
  "arr_macro",
  "base58",

--- a/rust/android/Cargo.toml
+++ b/rust/android/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 jni = { version = "0.19", default-features = false }
 android_logger = "0.11"
-log = "0.4"
+log = "0.4.8"
 rustlib = { path = "../lib" }
 
 [lib]

--- a/rust/android/Dockerfile
+++ b/rust/android/Dockerfile
@@ -85,7 +85,7 @@ RUN cd /opt/openssl-3.0.1 && \
     make -j$(nproc) && make -j$(nproc) install && \
     make clean && make distclean
 
-RUN cd /opt && git clone --depth=1 --branch="dev_working" https://github.com/dannasessha/zecwallet-mobile zecwalletmobile
+RUN cd /opt && git clone --depth=1 --branch="dev" https://github.com/zingolabs/zecwallet-mobile zecwalletmobile
 RUN printf '[net] \ngit-fetch-with-cli = true\n' > /root/.cargo/config.toml
 RUN cargo fetch --manifest-path /opt/zecwalletmobile/rust/android/Cargo.toml
 RUN cargo build --release --manifest-path /opt/zecwalletmobile/rust/android/Cargo.toml


### PR DESCRIPTION
Fixes #68 : updates dockerfile to point at `zingolabs/dev` when cloning this repo.

Also included, restoring dependency version number for `log` crate, in `android/Cargo.toml`