### PR TITLE
changing 'zecprice' to 'updatecurrentprice'

### DIFF
--- a/app/rpc.ts
+++ b/app/rpc.ts
@@ -707,15 +707,14 @@ export default class RPC {
   }
 
   async getZecPrice() {
-    const resultStr: string = await RPCModule.execute('zecprice', '');
+    const resultStr: string = await RPCModule.execute('updatecurrentprice', '');
     if (resultStr.toLowerCase().startsWith('error')) {
       //console.log(`Error fetching price ${resultStr}`);
       return;
     }
 
-    const resultJSON = JSON.parse(resultStr);
-    if (resultJSON.zec_price) {
-      this.fnSetZecPrice(resultJSON.zec_price);
+    if (resultStr) {
+      this.fnSetZecPrice(parseFloat(resultStr));
     }
   }
 }


### PR DESCRIPTION
I changed the old `zecprice` to the new `updatecurrentprice`. The return of the module has changed too:
* old:
`{
   zec_price: "00.00"
   ...
}`
* new:
`00.00`