### PR TITLE
temporary fix for self-send transactions

### DIFF
--- a/components/Transactions/components/TxDetail.tsx
+++ b/components/Transactions/components/TxDetail.tsx
@@ -34,10 +34,19 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
   const [expandAddress, setExpandAddress] = useState(false);
   const [expandTxid, setExpandTxid] = useState(false);
 
-  const fee =
-    tx?.type === 'sent' &&
-    tx?.amount &&
-    Math.abs(tx?.amount) - Math.abs(tx?.detailedTxns?.reduce((s: number, d: TxDetailType) => s + d.amount, 0));
+  const sum =
+    (tx?.detailedTxns && tx?.detailedTxns?.reduce((s: number, d: TxDetailType) => s + (d.amount ? d.amount : 0), 0)) ||
+    0;
+  let fee = 0;
+  // normal case: spend 1600 fee 1000 sent 600
+  if (tx?.type === 'sent' && tx?.amount && Math.abs(tx?.amount) > Math.abs(sum)) {
+    fee = Math.abs(tx?.amount) - Math.abs(sum);
+  }
+  // self-send case: spend 1000 fee 1000 sent 0
+  // this is temporary until we have a new field in 'list' object, called: fee.
+  if (tx?.type === 'sent' && tx?.amount && Math.abs(tx?.amount) <= Math.abs(sum)) {
+    fee = Math.abs(tx?.amount);
+  }
 
   const handleTxIDClick = (txid?: string) => {
     if (!txid) {


### PR DESCRIPTION
When I read a self-send transaction from RPC `list` the data I obtain is really different, and I have to show to the user something understandable. 

Normal case, sent tx: `tx.amount` is -1600 and `tx.outgoing_metadata.value` is 600 => 
- spent: 1600
- send: 600
- fee: 1000

Weird case, auto-sent tx: `tx.amount` is -1000 and `tx.outgoing_metadata.value` is 55000 =>
- spent: 1000
- send: 0
- fee: 1000

Meanwhile the new feature for a new field in tx for `fee` https://github.com/zingolabs/zingolib/issues/209 is coming, I think this is a decent fixed.