### PR TITLE
send screen - zec rounded to 8 dec & usd rounded to 2 dec

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -164,7 +164,7 @@
     "more": "more...",
     "toaddress": "To Address",
     "invalidaddress": "Invalid Address!",
-    "addressplaceholder": "Z-Sapling or T-Transparent or Unified address",
+    "addressplaceholder": "Unified Address or Z-Sapling or T-Transparent",
     "invalidamount": "Invalid Amount!",
     "spendable": "Spendable: ",
     "somefunds": "Some funds still confirming or syncing",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -164,7 +164,7 @@
     "more": "ver más...",
     "toaddress": "A la Dirección",
     "invalidaddress": "Dirección Incorrecta!",
-    "addressplaceholder": "Z-Sapling o T-Transparent o Dirección Unificada",
+    "addressplaceholder": "Dirección Unificada o Z-Sapling o T-Transparente",
     "invalidamount": "Cantidad Incorrecta!",
     "spendable": "Disponible: ",
     "somefunds": "Algunos fondos todavía se están confirmando o sincronizando",

--- a/components/ImportKey/ImportKey.tsx
+++ b/components/ImportKey/ImportKey.tsx
@@ -148,6 +148,7 @@ const ImportKey: React.FunctionComponent<ImportKeyProps> = ({ closeModal, doImpo
             minHeight: 48,
           }}>
           <TextInput
+            placeholder="#"
             style={{
               color: colors.text,
               fontWeight: '600',

--- a/components/Seed/Seed.tsx
+++ b/components/Seed/Seed.tsx
@@ -207,6 +207,7 @@ const Seed: React.FunctionComponent<SeedProps> = ({ onClickOK, onClickCancel, ac
                   minHeight: 48,
                 }}>
                 <TextInput
+                  placeholder="#"
                   style={{
                     color: colors.text,
                     fontWeight: '600',

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -245,7 +245,7 @@ const Send: React.FunctionComponent<SendProps> = ({
     }
 
     if (amount !== null) {
-      toAddr.amount = amount.replace(decimalSeparator, '.').substring(0, 10);
+      toAddr.amount = amount.replace(decimalSeparator, '.').substring(0, 20);
       if (isNaN(Number(toAddr.amount))) {
         toAddr.amountUSD = '';
       } else if (toAddr.amount && info?.zecPrice) {
@@ -257,7 +257,7 @@ const Send: React.FunctionComponent<SendProps> = ({
     }
 
     if (amountUSD !== null) {
-      toAddr.amountUSD = amountUSD.replace(decimalSeparator, '.').substring(0, 4);
+      toAddr.amountUSD = amountUSD.replace(decimalSeparator, '.').substring(0, 15);
       if (isNaN(Number(toAddr.amountUSD))) {
         toAddr.amount = '';
       } else if (toAddr.amountUSD && info?.zecPrice) {
@@ -575,9 +575,12 @@ const Send: React.FunctionComponent<SendProps> = ({
                           marginLeft: 5,
                         }}
                         value={ta.amount.toString()}
-                        onChangeText={(text: string) => updateToField(null, text.substring(0, 10), null, null)}
+                        onChangeText={(text: string) => updateToField(null, text.substring(0, 20), null, null)}
+                        onEndEditing={(e: any) =>
+                          updateToField(null, Number(e.nativeEvent.text.substring(0, 20)).toFixed(8), null, null)
+                        }
                         editable={true}
-                        maxLength={10}
+                        maxLength={20}
                       />
                     </View>
                     <RegText style={{ marginTop: 15, marginRight: 10, marginLeft: 5 }}>ZEC</RegText>
@@ -617,9 +620,12 @@ const Send: React.FunctionComponent<SendProps> = ({
                           marginLeft: 5,
                         }}
                         value={ta.amountUSD.toString()}
-                        onChangeText={(text: string) => updateToField(null, null, text.substring(0, 4), null)}
+                        onChangeText={(text: string) => updateToField(null, null, text.substring(0, 15), null)}
+                        onEndEditing={(e: any) =>
+                          updateToField(null, null, Number(e.nativeEvent.text.substring(0, 15)).toFixed(2), null)
+                        }
                         editable={true}
-                        maxLength={4}
+                        maxLength={15}
                       />
                     </View>
                     <RegText style={{ marginTop: 15, marginLeft: 5 }}>USD</RegText>


### PR DESCRIPTION
In the Kevin Mills testing, he detect that you cannot put USD 10.25 to send, because the field only accepts 4 digits which is a huge mistake. I changed that, when to end editing the field the value is rounded to 2 decimals. I did the same with the zec field, rounded it to 8 digits when the user ends editing the value.