### PR TITLE
temporary fix for self-send transactions & Test

### DIFF
--- a/__tests__/Transactions.TxDetail.unit.tsx
+++ b/__tests__/Transactions.TxDetail.unit.tsx
@@ -1,0 +1,165 @@
+/**
+ * @format
+ */
+
+import 'react-native';
+import React from 'react';
+
+import { render } from '@testing-library/react-native';
+import TxDetail from '../components/Transactions/components/TxDetail';
+import { ContextLoadedProvider } from '../app/context';
+
+import {
+  ErrorModalData,
+  InfoType,
+  ReceivePageState,
+  SendPageState,
+  SendProgress,
+  SyncStatusReport,
+  ToAddr,
+  TotalBalance,
+  Transaction,
+  TxDetailType,
+  WalletSettings,
+} from '../app/AppState';
+
+jest.useFakeTimers();
+jest.mock('@fortawesome/react-native-fontawesome', () => ({
+  FontAwesomeIcon: '',
+}));
+jest.mock('react-native-localize', () => ({
+  getNumberFormatSettings: () => {
+    return {
+      decimalSeparator: '.',
+      groupingSeparator: ',',
+    };
+  },
+}));
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+jest.mock('moment', () => () => ({
+  format: (p: string) => {
+    if (p === 'MMM YYYY') {
+      return 'Dec 2022';
+    } else if (p === 'YYYY MMM D h:mm a') {
+      return '2022 Dec 13 8:00 am';
+    } else if (p === 'MMM D, h:mm a') {
+      return 'Dec 13, 8:00 am';
+    }
+  },
+}));
+
+// test suite
+describe('Component Transactions TxDetail - test', () => {
+  //unit test
+  const state = {
+    navigation: null,
+    route: null,
+    dimensions: {} as {
+      width: number;
+      height: number;
+      orientation: 'portrait' | 'landscape';
+      deviceType: 'tablet' | 'phone';
+      scale: number;
+    },
+
+    syncStatusReport: new SyncStatusReport(),
+    addressPrivateKeys: new Map(),
+    addresses: [],
+    addressBook: [],
+    transactions: null,
+    sendPageState: new SendPageState(new ToAddr(0)),
+    receivePageState: new ReceivePageState(),
+    rescanning: false,
+    wallet_settings: new WalletSettings(),
+    syncingStatus: null,
+    errorModalData: new ErrorModalData(),
+    txBuildProgress: new SendProgress(),
+    walletSeed: null,
+    isMenuDrawerOpen: false,
+    selectedMenuDrawerItem: '',
+    aboutModalVisible: false,
+    computingModalVisible: false,
+    settingsModalVisible: false,
+    infoModalVisible: false,
+    rescanModalVisible: false,
+    seedViewModalVisible: false,
+    seedChangeModalVisible: false,
+    seedBackupModalVisible: false,
+    seedServerModalVisible: false,
+    syncReportModalVisible: false,
+    poolsModalVisible: false,
+    newServer: null,
+    uaAddress: null,
+    info: {} as InfoType,
+    translate: () => 'translated text',
+    totalBalance: new TotalBalance(),
+  };
+  const onClose = jest.fn();
+  test('Transactions TxDetail - normal sent transaction', () => {
+    state.info.currencyName = 'ZEC';
+    state.totalBalance.total = 1.12345678;
+    const tx = {
+      type: 'sent',
+      address: 'UA-12345678901234567890',
+      amount: -0.000065,
+      position: '',
+      confirmations: 20,
+      txid: 'txid-1234567890',
+      time: Date.now(),
+      zec_price: 33.33,
+      detailedTxns: [
+        {
+          address: 'other-UA-12345678901234567890',
+          amount: 0.000055,
+          memo: 'memo-abcdefgh',
+        },
+      ] as TxDetailType[],
+    } as Transaction;
+    const text: any = render(
+      <ContextLoadedProvider value={state}>
+        <TxDetail tx={tx} closeModal={onClose} />
+      </ContextLoadedProvider>,
+    ).toJSON();
+    expect(text.type).toBe('RCTSafeAreaView');
+    expect(text.children[0].children[0].children[2].children[3].children[1].children[0].children[1].children[0]).toBe(
+      ' 0.0000',
+    );
+    expect(text.children[0].children[0].children[2].children[3].children[1].children[0].children[2].children[0]).toBe(
+      '1000',
+    );
+  });
+
+  test('Transactions TxDetail - self sent transaction', () => {
+    state.info.currencyName = 'ZEC';
+    state.totalBalance.total = 1.12345678;
+    const txSelfSend = {
+      type: 'sent',
+      address: 'UA-12345678901234567890',
+      amount: -0.00001,
+      position: '',
+      confirmations: 20,
+      txid: 'txid-1234567890',
+      time: Date.now(),
+      zec_price: 33.33,
+      detailedTxns: [
+        {
+          address: 'other-UA-12345678901234567890',
+          amount: 0.00055,
+          memo: 'memo-abcdefgh',
+        },
+      ] as TxDetailType[],
+    } as Transaction;
+    const textSelfSend: any = render(
+      <ContextLoadedProvider value={state}>
+        <TxDetail tx={txSelfSend} closeModal={onClose} />
+      </ContextLoadedProvider>,
+    ).toJSON();
+    expect(textSelfSend.type).toBe('RCTSafeAreaView');
+    expect(
+      textSelfSend.children[0].children[0].children[2].children[3].children[1].children[0].children[1].children[0],
+    ).toBe(' 0.0000');
+    expect(
+      textSelfSend.children[0].children[0].children[2].children[3].children[1].children[0].children[2].children[0],
+    ).toBe('1000');
+  });
+});

--- a/components/Transactions/components/TxDetail.tsx
+++ b/components/Transactions/components/TxDetail.tsx
@@ -194,7 +194,7 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
             );
           })}
 
-          {fee && (
+          {fee > 0 && (
             <View style={{ display: 'flex', marginTop: 10 }}>
               <FadeText>{translate('transactions.txfee')}</FadeText>
               <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>

--- a/components/Transactions/components/TxDetail.tsx
+++ b/components/Transactions/components/TxDetail.tsx
@@ -34,10 +34,19 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
   const [expandAddress, setExpandAddress] = useState(false);
   const [expandTxid, setExpandTxid] = useState(false);
 
-  const fee =
-    tx?.type === 'sent' &&
-    tx?.amount &&
-    Math.abs(tx?.amount) - Math.abs(tx?.detailedTxns?.reduce((s: number, d: TxDetailType) => s + d.amount, 0));
+  const sum =
+    (tx?.detailedTxns && tx?.detailedTxns?.reduce((s: number, d: TxDetailType) => s + (d.amount ? d.amount : 0), 0)) ||
+    0;
+  let fee = 0;
+  // normal case: spend 1600 fee 1000 sent 600
+  if (tx?.type === 'sent' && tx?.amount && Math.abs(tx?.amount) > Math.abs(sum)) {
+    fee = Math.abs(tx?.amount) - Math.abs(sum);
+  }
+  // self-send case: spend 1000 fee 1000 sent 0
+  // this is temporary until we have a new field in 'list' object, called: fee.
+  if (tx?.type === 'sent' && tx?.amount && Math.abs(tx?.amount) <= Math.abs(sum)) {
+    fee = Math.abs(tx?.amount);
+  }
 
   const handleTxIDClick = (txid?: string) => {
     if (!txid) {


### PR DESCRIPTION
When I read a self-send transaction from RPC `list` the data I obtain is really different, and I have to show to the user something understandable. 

Normal case, sent tx: `tx.amount` is -1600 and `tx.outgoing_metadata.value` is 600 => 
- spent: 1600
- send: 600
- fee: 1000

Weird case, auto-sent tx: `tx.amount` is -1000 and `tx.outgoing_metadata.value` is 55000 =>
- spent: 1000
- send: 0
- fee: 1000

Meanwhile the new feature for a new field in tx for `fee` https://github.com/zingolabs/zingolib/issues/209 is coming, I think this is a decent fixed.