### PR TITLE
Dev create wallet fix

### DIFF
--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -270,7 +270,7 @@ class LoadingAppClass extends Component<LoadingAppClassProps, AppStateLoading> {
         this.set_wallet_option('download_memos', 'wallet');
         //await this.set_wallet_option('transaction_filter_threshold', '500');
       } else {
-        this.setState({ walletExists: false, actionButtonsDisabled: false });
+        this.setState({ actionButtonsDisabled: false });
         Alert.alert(this.props.translate('loadingapp.creatingwallet-label'), seed);
       }
     });

--- a/ios/RPCModule.m
+++ b/ios/RPCModule.m
@@ -202,8 +202,10 @@ RCT_REMAP_METHOD(createNewWallet,
 
     // RCTLogInfo(@"Got seed: %@", seedStr);
 
-    // Also save the wallet after create
-    [self saveWalletInternal];
+    if (![seedStr hasPrefix:@"Error"]) {
+      // Also save the wallet after restore
+      [self saveWalletInternal];
+    }
 
     resolve(seedStr);
   }


### PR DESCRIPTION
I realized that when you start the App and the New Wallet option fails -> The App store this wrong wallet inside the device, and after that you can not load the wallet before this. I fixed that, if the New wallet option fails, nothing happens and you can load the prior wallet normally.