### PR TITLE
new feature interrupt syncing in send screen, new zingolib

### DIFF
--- a/__tests__/Send.Landscape.snapshot.tsx
+++ b/__tests__/Send.Landscape.snapshot.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import Send from '../components/Send';
 import { defaultAppStateLoaded, ContextLoadedProvider } from '../app/context';
+import { ThemeType } from '../app/types';
 
 jest.useFakeTimers();
 jest.mock('@fortawesome/react-native-fontawesome', () => ({
@@ -41,6 +42,25 @@ jest.mock('react-native', () => {
 
   return RN;
 });
+const Theme: ThemeType = {
+  dark: true,
+  colors: {
+    background: '#011401', //'#010101',
+    card: '#011401', //'#401717',
+    border: '#ffffff',
+    primary: '#18bd18', //'#df4100',
+    primaryDisabled: 'rgba(90, 140, 90, 1)',
+    text: '#c3c3c3',
+    zingo: '#888888',
+    placeholder: '#888888',
+    money: '#ffffff',
+    notification: '',
+  },
+};
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: jest.fn(),
+  useTheme: () => Theme,
+}));
 
 // test suite
 describe('Component Send - test', () => {

--- a/__tests__/Send.Portrait.snapshot.tsx
+++ b/__tests__/Send.Portrait.snapshot.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import Send from '../components/Send';
 import { defaultAppStateLoaded, ContextLoadedProvider } from '../app/context';
+import { ThemeType } from '../app/types';
 
 jest.useFakeTimers();
 jest.mock('@fortawesome/react-native-fontawesome', () => ({
@@ -41,6 +42,25 @@ jest.mock('react-native', () => {
 
   return RN;
 });
+const Theme: ThemeType = {
+  dark: true,
+  colors: {
+    background: '#011401', //'#010101',
+    card: '#011401', //'#401717',
+    border: '#ffffff',
+    primary: '#18bd18', //'#df4100',
+    primaryDisabled: 'rgba(90, 140, 90, 1)',
+    text: '#c3c3c3',
+    zingo: '#888888',
+    placeholder: '#888888',
+    money: '#ffffff',
+    notification: '',
+  },
+};
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: jest.fn(),
+  useTheme: () => Theme,
+}));
 
 // test suite
 describe('Component Send - test', () => {

--- a/__tests__/__snapshots__/Receive.Lanscape.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Receive.Lanscape.snapshot.tsx.snap
@@ -179,6 +179,58 @@ exports[`Component Receive - test Receive Landscape - snapshot 1`] = `
               text translated
             </Text>
           </View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "borderColor": "rgb(0, 122, 255)",
+                "borderRadius": 10,
+                "borderWidth": 1,
+                "justifyContent": "center",
+                "margin": 0,
+                "minHeight": 20,
+                "minWidth": 20,
+                "padding": 1,
+              }
+            }
+          >
+            <View
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "opacity": 1,
+                }
+              }
+            >
+              <
+                icon={
+                  {
+                    "icon": [
+                      384,
+                      512,
+                      [
+                        9209,
+                      ],
+                      "f04d",
+                      "M0 128C0 92.7 28.7 64 64 64H320c35.3 0 64 28.7 64 64V384c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128z",
+                    ],
+                    "iconName": "stop",
+                    "prefix": "fas",
+                  }
+                }
+                size={12}
+              />
+            </View>
+          </View>
         </View>
         <View
           style={

--- a/__tests__/__snapshots__/Send.Landscape.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Send.Landscape.snapshot.tsx.snap
@@ -42,7 +42,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "rgb(255, 255, 255)",
+            "backgroundColor": "#011401",
             "display": "flex",
             "zIndex": -1,
           }
@@ -52,7 +52,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "backgroundColor": "rgb(255, 255, 255)",
+              "backgroundColor": "#011401",
               "display": "flex",
               "padding": 10,
               "width": "100%",
@@ -103,7 +103,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 style={
                   {
                     "alignItems": "flex-end",
-                    "backgroundColor": "rgb(255, 255, 255)",
+                    "backgroundColor": "#011401",
                     "borderRadius": 10,
                     "display": "flex",
                     "flexDirection": "row",
@@ -118,7 +118,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": "rgb(0, 122, 255)",
+                      "color": "#18bd18",
                       "fontSize": 18,
                       "fontWeight": "600",
                       "opacity": 1,
@@ -128,7 +128,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   text translated
                 </Text>
                 <
-                  color="rgb(0, 122, 255)"
+                  color="#18bd18"
                   icon={
                     {
                       "icon": [
@@ -162,7 +162,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": undefined,
+                    "color": "#ffffff",
                     "fontSize": 36,
                   }
                 }
@@ -172,7 +172,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": undefined,
+                    "color": "#ffffff",
                     "fontSize": 36,
                     "fontWeight": "700",
                   }
@@ -183,7 +183,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": undefined,
+                    "color": "#ffffff",
                     "fontSize": 18,
                     "paddingBottom": 0,
                   }
@@ -194,7 +194,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": undefined,
+                    "color": "#ffffff",
                     "fontSize": 36,
                   }
                 }
@@ -221,7 +221,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": undefined,
+                      "color": "#ffffff",
                       "fontSize": 20,
                       "marginBottom": 5,
                       "marginTop": 0,
@@ -233,7 +233,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": undefined,
+                      "color": "#ffffff",
                       "fontSize": 20,
                       "fontWeight": "700",
                       "marginBottom": 5,
@@ -246,7 +246,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": undefined,
+                      "color": "#ffffff",
                       "fontSize": 20,
                       "marginBottom": 5,
                       "marginTop": 0,
@@ -284,7 +284,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     style={
                       {
                         "alignItems": "center",
-                        "backgroundColor": "rgb(255, 255, 255)",
+                        "backgroundColor": "#011401",
                         "borderRadius": 10,
                         "flexDirection": "row",
                         "justifyContent": "center",
@@ -296,7 +296,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     }
                   >
                     <
-                      color="rgb(0, 122, 255)"
+                      color="#18bd18"
                       icon={
                         {
                           "icon": [
@@ -324,7 +324,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
           <View
             style={
               {
-                "backgroundColor": "rgb(0, 122, 255)",
+                "backgroundColor": "#18bd18",
                 "height": 1,
                 "marginTop": 5,
                 "width": "100%",
@@ -357,7 +357,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": "rgb(28, 28, 30)",
+                    "color": "#ffffff",
                     "fontSize": 18,
                     "fontWeight": "600",
                     "opacity": 1,
@@ -368,11 +368,64 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 text translated
               </Text>
             </View>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "borderColor": "#18bd18",
+                  "borderRadius": 10,
+                  "borderWidth": 1,
+                  "justifyContent": "center",
+                  "margin": 0,
+                  "minHeight": 20,
+                  "minWidth": 20,
+                  "padding": 1,
+                }
+              }
+            >
+              <View
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <
+                  color="#888888"
+                  icon={
+                    {
+                      "icon": [
+                        384,
+                        512,
+                        [
+                          9209,
+                        ],
+                        "f04d",
+                        "M0 128C0 92.7 28.7 64 64 64H320c35.3 0 64 28.7 64 64V384c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128z",
+                      ],
+                      "iconName": "stop",
+                      "prefix": "fas",
+                    }
+                  }
+                  size={12}
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
               {
-                "backgroundColor": "rgb(0, 122, 255)",
+                "backgroundColor": "#18bd18",
                 "height": 1,
                 "width": "100%",
               }
@@ -384,7 +437,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
     <View
       style={
         {
-          "backgroundColor": "rgb(255, 255, 255)",
+          "backgroundColor": "#011401",
           "padding": 10,
           "position": "absolute",
         }
@@ -409,7 +462,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
         }
       >
         <
-          color="rgb(216, 216, 216)"
+          color="#ffffff"
           icon={
             {
               "icon": [
@@ -434,7 +487,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
     style={
       {
         "alignItems": "center",
-        "borderLeftColor": "rgb(216, 216, 216)",
+        "borderLeftColor": "#ffffff",
         "borderLeftWidth": 1,
         "height": "100%",
         "padding": 0,
@@ -476,7 +529,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": "rgb(28, 28, 30)",
+                    "color": "#c3c3c3",
                     "fontSize": 18,
                     "fontWeight": "600",
                     "opacity": 1,
@@ -489,7 +542,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
             <View
               style={
                 {
-                  "borderColor": "rgb(28, 28, 30)",
+                  "borderColor": "#c3c3c3",
                   "borderRadius": 5,
                   "borderWidth": 1,
                   "flex": 1,
@@ -518,9 +571,10 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     editable={true}
                     onChangeText={[Function]}
                     placeholder="text translated"
+                    placeholderTextColor="#888888"
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "fontSize": 16,
                         "fontWeight": "600",
                         "marginLeft": 5,
@@ -555,7 +609,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     }
                   >
                     <
-                      color="rgb(216, 216, 216)"
+                      color="#ffffff"
                       icon={
                         {
                           "icon": [
@@ -617,7 +671,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "opacity": 0.65,
                       }
                     }
@@ -629,7 +683,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": "rgb(0, 122, 255)",
+                    "color": "#18bd18",
                   }
                 }
               >
@@ -667,7 +721,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "fontSize": 20,
                         "fontWeight": "600",
                         "marginRight": 5,
@@ -683,7 +737,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     accessible={true}
                     style={
                       {
-                        "borderColor": "rgb(28, 28, 30)",
+                        "borderColor": "#c3c3c3",
                         "borderRadius": 5,
                         "borderWidth": 1,
                         "flexGrow": 1,
@@ -701,9 +755,10 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                       onChangeText={[Function]}
                       onEndEditing={[Function]}
                       placeholder="#.########"
+                      placeholderTextColor="#888888"
                       style={
                         {
-                          "color": "rgb(28, 28, 30)",
+                          "color": "#c3c3c3",
                           "fontSize": 18,
                           "fontWeight": "600",
                           "marginLeft": 5,
@@ -717,7 +772,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "fontSize": 18,
                         "fontWeight": "600",
                         "marginLeft": 5,
@@ -752,7 +807,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     <Text
                       style={
                         {
-                          "color": "rgb(28, 28, 30)",
+                          "color": "#c3c3c3",
                           "fontSize": 14,
                           "fontWeight": "600",
                           "opacity": 1,
@@ -833,7 +888,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     <View
                       style={
                         {
-                          "backgroundColor": "rgb(255, 255, 255)",
+                          "backgroundColor": "#011401",
                           "borderRadius": 10,
                           "display": "flex",
                           "flexDirection": "row",
@@ -843,7 +898,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                       }
                     >
                       <
-                        color="rgb(0, 122, 255)"
+                        color="#18bd18"
                         icon={
                           {
                             "icon": [
@@ -862,7 +917,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                       <Text
                         style={
                           {
-                            "color": "rgb(28, 28, 30)",
+                            "color": "#c3c3c3",
                             "opacity": 0.65,
                           }
                         }
@@ -895,7 +950,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "fontSize": 18,
                         "fontWeight": "600",
                         "marginRight": 5,
@@ -911,7 +966,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     accessible={true}
                     style={
                       {
-                        "borderColor": "rgb(28, 28, 30)",
+                        "borderColor": "#c3c3c3",
                         "borderRadius": 5,
                         "borderWidth": 1,
                         "flexGrow": 1,
@@ -929,9 +984,10 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                       onChangeText={[Function]}
                       onEndEditing={[Function]}
                       placeholder="#.##"
+                      placeholderTextColor="#888888"
                       style={
                         {
-                          "color": "rgb(28, 28, 30)",
+                          "color": "#c3c3c3",
                           "fontSize": 18,
                           "fontWeight": "600",
                           "marginLeft": 5,
@@ -945,7 +1001,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "fontSize": 18,
                         "fontWeight": "600",
                         "marginLeft": 5,
@@ -976,7 +1032,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     <Text
                       style={
                         {
-                          "color": undefined,
+                          "color": "#ffffff",
                           "fontSize": 13,
                           "marginTop": 10,
                         }
@@ -987,7 +1043,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     <Text
                       style={
                         {
-                          "color": undefined,
+                          "color": "#ffffff",
                           "fontSize": 13,
                           "fontWeight": "700",
                           "marginTop": 10,
@@ -999,7 +1055,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     <Text
                       style={
                         {
-                          "color": undefined,
+                          "color": "#ffffff",
                           "fontSize": 13,
                           "marginTop": 10,
                         }
@@ -1036,7 +1092,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                         style={
                           {
                             "alignItems": "center",
-                            "backgroundColor": "rgb(255, 255, 255)",
+                            "backgroundColor": "#011401",
                             "borderRadius": 10,
                             "flexDirection": "row",
                             "justifyContent": "center",
@@ -1048,7 +1104,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                         }
                       >
                         <
-                          color="rgb(0, 122, 255)"
+                          color="#18bd18"
                           icon={
                             {
                               "icon": [
@@ -1101,8 +1157,8 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "backgroundColor": undefined,
-                  "borderColor": "rgb(0, 122, 255)",
+                  "backgroundColor": "rgba(90, 140, 90, 1)",
+                  "borderColor": "#18bd18",
                   "borderRadius": 10,
                   "borderWidth": 2,
                   "justifyContent": "center",
@@ -1133,7 +1189,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": "rgb(242, 242, 242)",
+                      "color": "#011401",
                       "fontSize": 16,
                       "fontWeight": "bold",
                       "textTransform": "uppercase",
@@ -1158,7 +1214,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               style={
                 {
                   "alignItems": "center",
-                  "borderColor": "rgb(0, 122, 255)",
+                  "borderColor": "#18bd18",
                   "borderRadius": 10,
                   "borderWidth": 2,
                   "justifyContent": "center",
@@ -1190,7 +1246,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": "rgb(0, 122, 255)",
+                      "color": "#18bd18",
                       "fontSize": 16,
                       "fontWeight": "bold",
                       "textTransform": "uppercase",

--- a/__tests__/__snapshots__/Send.Portrait.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Send.Portrait.snapshot.tsx.snap
@@ -31,7 +31,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
   <View
     style={
       {
-        "backgroundColor": "rgb(0, 122, 255)",
+        "backgroundColor": "#18bd18",
         "height": 1,
         "width": "100%",
       }
@@ -70,7 +70,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
             <Text
               style={
                 {
-                  "color": "rgb(28, 28, 30)",
+                  "color": "#c3c3c3",
                   "fontSize": 18,
                   "fontWeight": "600",
                   "opacity": 1,
@@ -83,7 +83,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
           <View
             style={
               {
-                "borderColor": "rgb(28, 28, 30)",
+                "borderColor": "#c3c3c3",
                 "borderRadius": 5,
                 "borderWidth": 1,
                 "flex": 1,
@@ -112,9 +112,10 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   editable={true}
                   onChangeText={[Function]}
                   placeholder="text translated"
+                  placeholderTextColor="#888888"
                   style={
                     {
-                      "color": "rgb(28, 28, 30)",
+                      "color": "#c3c3c3",
                       "fontSize": 16,
                       "fontWeight": "600",
                       "marginLeft": 5,
@@ -149,7 +150,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   }
                 >
                   <
-                    color="rgb(216, 216, 216)"
+                    color="#ffffff"
                     icon={
                       {
                         "icon": [
@@ -211,7 +212,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": "rgb(28, 28, 30)",
+                      "color": "#c3c3c3",
                       "opacity": 0.65,
                     }
                   }
@@ -223,7 +224,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
             <Text
               style={
                 {
-                  "color": "rgb(0, 122, 255)",
+                  "color": "#18bd18",
                 }
               }
             >
@@ -261,7 +262,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": "rgb(28, 28, 30)",
+                      "color": "#c3c3c3",
                       "fontSize": 20,
                       "fontWeight": "600",
                       "marginRight": 5,
@@ -277,7 +278,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   accessible={true}
                   style={
                     {
-                      "borderColor": "rgb(28, 28, 30)",
+                      "borderColor": "#c3c3c3",
                       "borderRadius": 5,
                       "borderWidth": 1,
                       "flexGrow": 1,
@@ -295,9 +296,10 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     onChangeText={[Function]}
                     onEndEditing={[Function]}
                     placeholder="#.########"
+                    placeholderTextColor="#888888"
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "fontSize": 18,
                         "fontWeight": "600",
                         "marginLeft": 5,
@@ -311,7 +313,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": "rgb(28, 28, 30)",
+                      "color": "#c3c3c3",
                       "fontSize": 18,
                       "fontWeight": "600",
                       "marginLeft": 5,
@@ -346,7 +348,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "fontSize": 14,
                         "fontWeight": "600",
                         "opacity": 1,
@@ -427,7 +429,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <View
                     style={
                       {
-                        "backgroundColor": "rgb(255, 255, 255)",
+                        "backgroundColor": "#011401",
                         "borderRadius": 10,
                         "display": "flex",
                         "flexDirection": "row",
@@ -437,7 +439,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     }
                   >
                     <
-                      color="rgb(0, 122, 255)"
+                      color="#18bd18"
                       icon={
                         {
                           "icon": [
@@ -456,7 +458,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     <Text
                       style={
                         {
-                          "color": "rgb(28, 28, 30)",
+                          "color": "#c3c3c3",
                           "opacity": 0.65,
                         }
                       }
@@ -489,7 +491,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": "rgb(28, 28, 30)",
+                      "color": "#c3c3c3",
                       "fontSize": 18,
                       "fontWeight": "600",
                       "marginRight": 5,
@@ -505,7 +507,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   accessible={true}
                   style={
                     {
-                      "borderColor": "rgb(28, 28, 30)",
+                      "borderColor": "#c3c3c3",
                       "borderRadius": 5,
                       "borderWidth": 1,
                       "flexGrow": 1,
@@ -523,9 +525,10 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                     onChangeText={[Function]}
                     onEndEditing={[Function]}
                     placeholder="#.##"
+                    placeholderTextColor="#888888"
                     style={
                       {
-                        "color": "rgb(28, 28, 30)",
+                        "color": "#c3c3c3",
                         "fontSize": 18,
                         "fontWeight": "600",
                         "marginLeft": 5,
@@ -539,7 +542,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                 <Text
                   style={
                     {
-                      "color": "rgb(28, 28, 30)",
+                      "color": "#c3c3c3",
                       "fontSize": 18,
                       "fontWeight": "600",
                       "marginLeft": 5,
@@ -570,7 +573,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": undefined,
+                        "color": "#ffffff",
                         "fontSize": 13,
                         "marginTop": 10,
                       }
@@ -581,7 +584,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": undefined,
+                        "color": "#ffffff",
                         "fontSize": 13,
                         "fontWeight": "700",
                         "marginTop": 10,
@@ -593,7 +596,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                   <Text
                     style={
                       {
-                        "color": undefined,
+                        "color": "#ffffff",
                         "fontSize": 13,
                         "marginTop": 10,
                       }
@@ -630,7 +633,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                       style={
                         {
                           "alignItems": "center",
-                          "backgroundColor": "rgb(255, 255, 255)",
+                          "backgroundColor": "#011401",
                           "borderRadius": 10,
                           "flexDirection": "row",
                           "justifyContent": "center",
@@ -642,7 +645,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
                       }
                     >
                       <
-                        color="rgb(0, 122, 255)"
+                        color="#18bd18"
                         icon={
                           {
                             "icon": [
@@ -695,8 +698,8 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
             style={
               {
                 "alignItems": "center",
-                "backgroundColor": undefined,
-                "borderColor": "rgb(0, 122, 255)",
+                "backgroundColor": "rgba(90, 140, 90, 1)",
+                "borderColor": "#18bd18",
                 "borderRadius": 10,
                 "borderWidth": 2,
                 "justifyContent": "center",
@@ -727,7 +730,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": "rgb(242, 242, 242)",
+                    "color": "#011401",
                     "fontSize": 16,
                     "fontWeight": "bold",
                     "textTransform": "uppercase",
@@ -752,7 +755,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
             style={
               {
                 "alignItems": "center",
-                "borderColor": "rgb(0, 122, 255)",
+                "borderColor": "#18bd18",
                 "borderRadius": 10,
                 "borderWidth": 2,
                 "justifyContent": "center",
@@ -784,7 +787,7 @@ exports[`Component Send - test Send Landscape - snapshot 1`] = `
               <Text
                 style={
                   {
-                    "color": "rgb(0, 122, 255)",
+                    "color": "#18bd18",
                     "fontSize": 16,
                     "fontWeight": "bold",
                     "textTransform": "uppercase",

--- a/__tests__/__snapshots__/Transactions.Landscape.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Transactions.Landscape.snapshot.tsx.snap
@@ -159,6 +159,44 @@ exports[`Component Transactions - test Transactions Landscape - snapshot 1`] = `
             text translated
           </Text>
         </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "borderColor": "rgb(0, 122, 255)",
+              "borderRadius": 10,
+              "borderWidth": 1,
+              "justifyContent": "center",
+              "margin": 0,
+              "minHeight": 20,
+              "minWidth": 20,
+              "padding": 1,
+            }
+          }
+        >
+          <View
+            onPress={[Function]}
+          >
+            <
+              icon={
+                {
+                  "icon": [
+                    384,
+                    512,
+                    [
+                      9209,
+                    ],
+                    "f04d",
+                    "M0 128C0 92.7 28.7 64 64 64H320c35.3 0 64 28.7 64 64V384c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128z",
+                  ],
+                  "iconName": "stop",
+                  "prefix": "fas",
+                }
+              }
+              size={12}
+            />
+          </View>
+        </View>
       </View>
       <View
         style={

--- a/__tests__/__snapshots__/Transactions.Portrait.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Transactions.Portrait.snapshot.tsx.snap
@@ -142,6 +142,44 @@ exports[`Component Transactions - test Transactions Portrait - snapshot 1`] = `
           text translated
         </Text>
       </View>
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "borderColor": "rgb(0, 122, 255)",
+            "borderRadius": 10,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "margin": 0,
+            "minHeight": 20,
+            "minWidth": 20,
+            "padding": 1,
+          }
+        }
+      >
+        <View
+          onPress={[Function]}
+        >
+          <
+            icon={
+              {
+                "icon": [
+                  384,
+                  512,
+                  [
+                    9209,
+                  ],
+                  "f04d",
+                  "M0 128C0 92.7 28.7 64 64 64H320c35.3 0 64 28.7 64 64V384c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128z",
+                ],
+                "iconName": "stop",
+                "prefix": "fas",
+              }
+            }
+            size={12}
+          />
+        </View>
+      </View>
     </View>
   </View>
   <View

--- a/app/AppState/types/SyncingStatusType.ts
+++ b/app/AppState/types/SyncingStatusType.ts
@@ -2,5 +2,6 @@ export default interface SyncingStatusType {
   inProgress: boolean;
   progress: number;
   blocks: string;
+  synced: boolean;
   // eslint-disable-next-line semi
 }

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -10,6 +10,7 @@ import {
   ScaledSize,
   AppState,
   NativeEventSubscription,
+  Platform,
 } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
@@ -154,10 +155,13 @@ export default function LoadedApp(props: LoadedAppProps) {
     }
 
     // reading background task info
-    const backgroundJson = await BackgroundFileImpl.readBackground();
-    //console.log('background', backgroundJson);
-    if (backgroundJson) {
-      setBackground(backgroundJson);
+    if (Platform.OS === 'ios') {
+      // this file only exists in IOS BS.
+      const backgroundJson = await BackgroundFileImpl.readBackground();
+      //console.log('background', backgroundJson);
+      if (backgroundJson) {
+        setBackground(backgroundJson);
+      }
     }
   }, [currency, file, i18n, sendAll, server]);
 
@@ -270,12 +274,17 @@ class LoadedAppClass extends Component<LoadedAppClassProps, AppStateLoaded> {
       if (this.state.appState.match(/inactive|background/) && nextAppState === 'active') {
         console.log('App has come to the foreground!');
         // reading background task info
-        this.fetchBackgroundSyncing();
+        if (Platform.OS === 'ios') {
+          // this file only exists in IOS BS.
+          this.fetchBackgroundSyncing();
+        }
         this.rpc.setInRefresh(false);
         this.rpc.configure();
       }
       if (nextAppState.match(/inactive|background/) && this.state.appState === 'active') {
         console.log('App is gone to the background!');
+        // if the App go to the background, we don't want to stop the syncing, mostly in Android.
+        await RPC.rpc_setInterruptSyncAfterBatch('false');
         this.setState({
           syncingStatusReport: new SyncingStatusReportClass(),
           syncingStatus: {} as SyncingStatusType,
@@ -369,11 +378,12 @@ class LoadedAppClass extends Component<LoadedAppClassProps, AppStateLoaded> {
     this.setState({ sendPageState });
   };
 
-  refreshUpdates = (inProgress: boolean, progress: number, blocks: string) => {
+  refreshUpdates = (inProgress: boolean, progress: number, blocks: string, synced: boolean) => {
     const syncingStatus: SyncingStatusType = {
       inProgress,
       progress,
       blocks,
+      synced,
     };
     if (!isEqual(this.state.syncingStatus, syncingStatus)) {
       this.setState({ syncingStatus });

--- a/app/LoadedApp/components/Menu.tsx
+++ b/app/LoadedApp/components/Menu.tsx
@@ -7,6 +7,7 @@ import FadeText from '../../../components/Components/FadeText';
 
 import { useTheme } from '@react-navigation/native';
 import { ContextLoaded } from '../../context';
+import RPC from '../../rpc';
 
 const window = Dimensions.get('window');
 
@@ -24,6 +25,12 @@ const Menu: React.FunctionComponent<MenuProps> = ({ onItemSelected }) => {
     color: colors.text,
   };
 
+  const onItemSelectedWrapper = (value: string) => {
+    // if the user click on a screen in the menu the sync is going to continue
+    (async () => await RPC.rpc_setInterruptSyncAfterBatch('false'))();
+    onItemSelected(value);
+  };
+
   return (
     <ScrollView
       scrollsToTop={false}
@@ -38,39 +45,39 @@ const Menu: React.FunctionComponent<MenuProps> = ({ onItemSelected }) => {
       <View style={{ height: 1, backgroundColor: colors.primary }} />
 
       <View style={{ display: 'flex', marginLeft: 20 }}>
-        <RegText onPress={() => onItemSelected('About')} style={item}>
+        <RegText onPress={() => onItemSelectedWrapper('About')} style={item}>
           {translate('loadedapp.about')}
         </RegText>
 
-        <RegText onPress={() => onItemSelected('Info')} style={item}>
+        <RegText onPress={() => onItemSelectedWrapper('Info')} style={item}>
           {translate('loadedapp.info')}
         </RegText>
 
-        <RegText onPress={() => onItemSelected('Settings')} style={item}>
+        <RegText onPress={() => onItemSelectedWrapper('Settings')} style={item}>
           {translate('loadedapp.settings')}
         </RegText>
 
-        <RegText onPress={() => onItemSelected('Wallet Seed')} style={item}>
+        <RegText onPress={() => onItemSelectedWrapper('Wallet Seed')} style={item}>
           {translate('loadedapp.walletseed')}
         </RegText>
 
-        <RegText onPress={() => onItemSelected('Rescan')} style={item}>
+        <RegText onPress={() => onItemSelectedWrapper('Rescan')} style={item}>
           {translate('loadedapp.rescanwallet')}
         </RegText>
 
-        <RegText onPress={() => onItemSelected('Sync Report')} style={item}>
+        <RegText onPress={() => onItemSelectedWrapper('Sync Report')} style={item}>
           {translate('loadedapp.report')}
         </RegText>
 
-        <RegText onPress={() => onItemSelected('Fund Pools')} style={item} color={colors.primary}>
+        <RegText onPress={() => onItemSelectedWrapper('Fund Pools')} style={item} color={colors.primary}>
           {translate('loadedapp.fundpools')}
         </RegText>
 
-        <RegText onPress={() => onItemSelected('Change Wallet')} style={item}>
+        <RegText onPress={() => onItemSelectedWrapper('Change Wallet')} style={item}>
           {translate('loadedapp.changewallet')}
         </RegText>
 
-        <RegText onPress={() => onItemSelected('Restore Wallet Backup')} style={item}>
+        <RegText onPress={() => onItemSelectedWrapper('Restore Wallet Backup')} style={item}>
           {translate('loadedapp.restorebackupwallet')}
         </RegText>
       </View>

--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -14,6 +14,7 @@ import {
   ScaledSize,
   AppState,
   NativeEventSubscription,
+  Platform,
 } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 import { I18n, TranslateOptions } from 'i18n-js';
@@ -250,11 +251,14 @@ class LoadingAppClass extends Component<LoadingAppClassProps, AppStateLoading> {
       if (this.state.appState.match(/inactive|background/) && nextAppState === 'active') {
         console.log('App has come to the foreground!');
         // reading background task info
-        const backgroundJson = await BackgroundFileImpl.readBackground();
-        if (backgroundJson) {
-          this.setState({
-            background: backgroundJson,
-          });
+        if (Platform.OS === 'ios') {
+          // this file only exists in IOS BS.
+          const backgroundJson = await BackgroundFileImpl.readBackground();
+          if (backgroundJson) {
+            this.setState({
+              background: backgroundJson,
+            });
+          }
         }
       }
       if (nextAppState.match(/inactive|background/) && this.state.appState === 'active') {

--- a/app/rpc/RPC.ts
+++ b/app/rpc/RPC.ts
@@ -30,7 +30,7 @@ export default class RPC {
   fnSetTotalBalance: (totalBalance: TotalBalanceClass) => void;
   fnSetTransactionsList: (txList: TransactionType[]) => void;
   fnSetAllAddresses: (allAddresses: AddressClass[]) => void;
-  fnSetRefreshUpdates: (inProgress: boolean, progress: number, blocks: string) => void;
+  fnSetRefreshUpdates: (inProgress: boolean, progress: number, blocks: string, synced: boolean) => void;
   fnSetWalletSettings: (settings: WalletSettingsClass) => void;
   translate: (key: string, config?: TranslateOptions) => string;
   fetchBackgroundSyncing: () => void;
@@ -64,7 +64,7 @@ export default class RPC {
     fnSetAllAddresses: (addresses: AddressClass[]) => void,
     fnSetWalletSettings: (settings: WalletSettingsClass) => void,
     fnSetInfo: (info: InfoType) => void,
-    fnSetRefreshUpdates: (inProgress: boolean, progress: number, blocks: string) => void,
+    fnSetRefreshUpdates: (inProgress: boolean, progress: number, blocks: string, synced: boolean) => void,
     translate: (key: string, config?: TranslateOptions) => string,
     fetchBackgroundSyncing: () => void,
   ) {
@@ -97,6 +97,11 @@ export default class RPC {
     this.batches = 0;
     this.message = '';
     this.process_end_block = -1;
+  }
+
+  static async rpc_setInterruptSyncAfterBatch(value: string): Promise<void> {
+    const resp = await RPCModule.execute('interrupt_sync_after_batch', value);
+    console.log('interrupt sync', value, resp);
   }
 
   static async rpc_getZecPrice(): Promise<number> {
@@ -627,6 +632,7 @@ export default class RPC {
           `${current_block ? current_block.toFixed(0).toString() : ''} ${this.translate('rpc.of')} ${
             this.lastServerBlockHeight ? this.lastServerBlockHeight.toString() : ''
           }`,
+          this.lastServerBlockHeight === this.lastWalletBlockHeight,
         );
 
         // store SyncStatusReport object for a new screen
@@ -672,7 +678,7 @@ export default class RPC {
           this.message = this.translate('rpc.syncend-message');
 
           // I know it's finished.
-          this.fnSetRefreshUpdates(false, 0, '');
+          this.fnSetRefreshUpdates(false, 0, '', this.lastServerBlockHeight === this.lastWalletBlockHeight);
 
           // store SyncStatusReport object for a new screen
           const statusFinished: SyncingStatusReportClass = {

--- a/components/Pools/Pools.tsx
+++ b/components/Pools/Pools.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-inline-styles */
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { View, ScrollView, SafeAreaView, Image } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 
@@ -10,6 +10,7 @@ import Button from '../Button';
 import DetailLine from './components/DetailLine';
 import { ThemeType } from '../../app/types';
 import { ContextLoaded } from '../../app/context';
+import RPC from '../../app/rpc';
 
 type PoolsProps = {
   closeModal: () => void;
@@ -19,6 +20,10 @@ const Pools: React.FunctionComponent<PoolsProps> = ({ closeModal }) => {
   const context = useContext(ContextLoaded);
   const { totalBalance, info, translate } = context;
   const { colors } = useTheme() as unknown as ThemeType;
+
+  useEffect(() => {
+    (async () => await RPC.rpc_setInterruptSyncAfterBatch('false'))();
+  }, []);
 
   //console.log(totalBalance);
 

--- a/components/Receive/Receive.tsx
+++ b/components/Receive/Receive.tsx
@@ -5,10 +5,9 @@ import { TabView, TabBar, SceneRendererProps, Route, NavigationState } from 'rea
 import Toast from 'react-native-simple-toast';
 import { useTheme } from '@react-navigation/native';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faBars, faEllipsisV, faInfo } from '@fortawesome/free-solid-svg-icons';
+import { faBars, faCheck, faPlay, faStop, faInfo, faEllipsisV } from '@fortawesome/free-solid-svg-icons';
 import OptionsMenu from 'react-native-option-menu';
 
-import FadeText from '../Components/FadeText';
 import ZecAmount from '../Components/ZecAmount';
 import CurrencyAmount from '../Components/CurrencyAmount';
 import RegText from '../Components/RegText';
@@ -344,7 +343,7 @@ const Receive: React.FunctionComponent<ReceiveProps> = ({
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexWrap: 'wrap',
-                marginVertical: syncStatusDisplayLine ? 0 : 5,
+                marginVertical: 5,
               }}>
               <View
                 style={{
@@ -355,13 +354,44 @@ const Receive: React.FunctionComponent<ReceiveProps> = ({
                   flexWrap: 'wrap',
                 }}>
                 <RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
+                  {translate('receive.title')}
+                </RegText>
+                {/*<RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
                   {syncStatusDisplayLine ? translate('receive.title-syncing') : translate('receive.title')}
                 </RegText>
                 {!!syncStatusDisplayLine && (
                   <FadeText style={{ margin: 0, padding: 0 }}>{syncStatusDisplayLine}</FadeText>
+                )}*/}
+              </View>
+              <View
+                style={{
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  margin: 0,
+                  padding: 1,
+                  borderColor: colors.primary,
+                  borderWidth: 1,
+                  borderRadius: 10,
+                  minWidth: 20,
+                  minHeight: 20,
+                }}>
+                {!syncStatusDisplayLine && syncingStatus.synced && (
+                  <View style={{ margin: 0, padding: 0 }}>
+                    <FontAwesomeIcon icon={faCheck} color={colors.primary} />
+                  </View>
+                )}
+                {!syncStatusDisplayLine && !syncingStatus.synced && (
+                  <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                    <FontAwesomeIcon icon={faStop} color={colors.zingo} size={12} />
+                  </TouchableOpacity>
+                )}
+                {syncStatusDisplayLine && (
+                  <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                    <FontAwesomeIcon icon={faPlay} color={colors.primary} size={10} />
+                  </TouchableOpacity>
                 )}
               </View>
-              {!!syncStatusDisplayLine && (
+              {/*!!syncStatusDisplayLine && (
                 <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
                   <View
                     style={{
@@ -381,7 +411,7 @@ const Receive: React.FunctionComponent<ReceiveProps> = ({
                     <FontAwesomeIcon icon={faInfo} size={14} color={colors.primary} />
                   </View>
                 </TouchableOpacity>
-              )}
+                )*/}
             </View>
           </View>
         </View>
@@ -553,7 +583,7 @@ const Receive: React.FunctionComponent<ReceiveProps> = ({
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexWrap: 'wrap',
-                marginVertical: syncStatusDisplayLine ? 0 : 5,
+                marginVertical: 5,
               }}>
               <View
                 style={{
@@ -564,13 +594,44 @@ const Receive: React.FunctionComponent<ReceiveProps> = ({
                   flexWrap: 'wrap',
                 }}>
                 <RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
+                  {translate('receive.title')}
+                </RegText>
+                {/*<RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
                   {syncStatusDisplayLine ? translate('receive.title-syncing') : translate('receive.title')}
                 </RegText>
                 {!!syncStatusDisplayLine && (
                   <FadeText style={{ margin: 0, padding: 0 }}>{syncStatusDisplayLine}</FadeText>
+                )}*/}
+              </View>
+              <View
+                style={{
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  margin: 0,
+                  padding: 1,
+                  borderColor: colors.primary,
+                  borderWidth: 1,
+                  borderRadius: 10,
+                  minWidth: 20,
+                  minHeight: 20,
+                }}>
+                {!syncStatusDisplayLine && syncingStatus.synced && (
+                  <View style={{ margin: 0, padding: 0 }}>
+                    <FontAwesomeIcon icon={faCheck} color={colors.primary} />
+                  </View>
+                )}
+                {!syncStatusDisplayLine && !syncingStatus.synced && (
+                  <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                    <FontAwesomeIcon icon={faStop} color={colors.zingo} size={12} />
+                  </TouchableOpacity>
+                )}
+                {syncStatusDisplayLine && (
+                  <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                    <FontAwesomeIcon icon={faPlay} color={colors.primary} size={10} />
+                  </TouchableOpacity>
                 )}
               </View>
-              {!!syncStatusDisplayLine && (
+              {/*!!syncStatusDisplayLine && (
                 <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
                   <View
                     style={{
@@ -590,7 +651,7 @@ const Receive: React.FunctionComponent<ReceiveProps> = ({
                     <FontAwesomeIcon icon={faInfo} size={14} color={colors.primary} />
                   </View>
                 </TouchableOpacity>
-              )}
+                )*/}
             </View>
 
             <View style={{ width: '100%', height: 1, backgroundColor: colors.primary }} />

--- a/components/Seed/Seed.tsx
+++ b/components/Seed/Seed.tsx
@@ -15,6 +15,7 @@ import { ThemeType } from '../../app/types';
 import { ContextLoaded, ContextLoading } from '../../app/context';
 import { InfoType, TotalBalanceClass, WalletSeedType } from '../../app/AppState';
 import RPCModule from '../RPCModule';
+import RPC from '../../app/rpc';
 
 type TextsType = {
   new: string[];
@@ -117,7 +118,11 @@ const Seed: React.FunctionComponent<SeedProps> = ({ onClickOK, onClickCancel, ac
         }
       })();
     }
-  }, [info.latestBlock, latestBlock]);
+  }, [info.latestBlock, latestBlock, server]);
+
+  useEffect(() => {
+    (async () => await RPC.rpc_setInterruptSyncAfterBatch('false'))();
+  }, []);
 
   //console.log('=================================');
   //console.log(walletSeed.seed, walletSeed.birthday);
@@ -258,10 +263,7 @@ const Seed: React.FunctionComponent<SeedProps> = ({ onClickOK, onClickCancel, ac
           ) : (
             <>
               <FadeText style={{ textAlign: 'center' }}>
-                {translate('seed.birthday-no-readonly') +
-                  ' (1, ' +
-                  (latestBlock ? latestBlock.toString() : '--') +
-                  ')'}
+                {translate('seed.birthday-no-readonly') + ' (1, ' + (latestBlock ? latestBlock.toString() : '--') + ')'}
               </FadeText>
               <View
                 accessible={true}

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react-native/no-inline-styles */
 import React, { useState, useEffect, useRef, useCallback, useContext } from 'react';
 import { View, ScrollView, Modal, Image, Alert, Keyboard, TextInput, TouchableOpacity } from 'react-native';
-import { faQrcode, faCheck, faInfo } from '@fortawesome/free-solid-svg-icons';
+import { faQrcode, faCheck, faInfo, faPlay, faStop } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { useTheme } from '@react-navigation/native';
+import { useTheme, useIsFocused } from '@react-navigation/native';
 import Toast from 'react-native-simple-toast';
 import { getNumberFormatSettings } from 'react-native-localize';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
@@ -24,6 +24,7 @@ import Confirm from './components/Confirm';
 import { ThemeType } from '../../app/types';
 import { ContextLoaded } from '../../app/context';
 import PriceFetcher from '../Components/PriceFetcher';
+import RPC from '../../app/rpc';
 
 type SendProps = {
   setSendPageState: (sendPageState: SendPageStateClass) => void;
@@ -69,6 +70,7 @@ const Send: React.FunctionComponent<SendProps> = ({
   const [validAddress, setValidAddress] = useState(0); // 1 - OK, 0 - Empty, -1 - KO
   const [validAmount, setValidAmount] = useState(0); // 1 - OK, 0 - Empty, -1 - KO
   const [sendButtonEnabled, setSendButtonEnabled] = useState(false);
+  const isFocused = useIsFocused();
 
   const slideAnim = useRef(new Animated.Value(0)).current;
   const defaultFee = info.defaultFee || Utils.getFallbackDefaultFee();
@@ -340,6 +342,16 @@ const Send: React.FunctionComponent<SendProps> = ({
     });
   };
 
+  useEffect(() => {
+    (async () => {
+      if (isFocused) {
+        await RPC.rpc_setInterruptSyncAfterBatch('true');
+      } else {
+        await RPC.rpc_setInterruptSyncAfterBatch('false');
+      }
+    })();
+  }, [isFocused]);
+
   //console.log('render send', 'w', dimensions.width, 'h', dimensions.height);
 
   const returnPortrait = (
@@ -456,7 +468,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexWrap: 'wrap',
-                marginVertical: syncStatusDisplayLine ? 0 : 5,
+                marginVertical: 5,
               }}>
               <View
                 style={{
@@ -467,13 +479,44 @@ const Send: React.FunctionComponent<SendProps> = ({
                   flexWrap: 'wrap',
                 }}>
                 <RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
+                  {translate('send.title')}
+                </RegText>
+                {/*<RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
                   {syncStatusDisplayLine ? translate('send.title-syncing') : translate('send.title')}
                 </RegText>
                 {!!syncStatusDisplayLine && (
                   <FadeText style={{ margin: 0, padding: 0 }}>{syncStatusDisplayLine}</FadeText>
+                )}*/}
+              </View>
+              <View
+                style={{
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  margin: 0,
+                  padding: 1,
+                  borderColor: colors.primary,
+                  borderWidth: 1,
+                  borderRadius: 10,
+                  minWidth: 20,
+                  minHeight: 20,
+                }}>
+                {!syncStatusDisplayLine && syncingStatus.synced && (
+                  <View style={{ margin: 0, padding: 0 }}>
+                    <FontAwesomeIcon icon={faCheck} color={colors.primary} />
+                  </View>
+                )}
+                {!syncStatusDisplayLine && !syncingStatus.synced && (
+                  <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                    <FontAwesomeIcon icon={faStop} color={colors.zingo} size={12} />
+                  </TouchableOpacity>
+                )}
+                {syncStatusDisplayLine && (
+                  <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                    <FontAwesomeIcon icon={faPlay} color={colors.primary} size={10} />
+                  </TouchableOpacity>
                 )}
               </View>
-              {!!syncStatusDisplayLine && (
+              {/*!!syncStatusDisplayLine && (
                 <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
                   <View
                     style={{
@@ -493,7 +536,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                     <FontAwesomeIcon icon={faInfo} size={14} color={colors.primary} />
                   </View>
                 </TouchableOpacity>
-              )}
+                )*/}
             </View>
           </View>
         </View>
@@ -966,7 +1009,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                   alignItems: 'center',
                   justifyContent: 'center',
                   flexWrap: 'wrap',
-                  marginVertical: syncStatusDisplayLine ? 0 : 5,
+                  marginVertical: 5,
                 }}>
                 <View
                   style={{
@@ -977,13 +1020,44 @@ const Send: React.FunctionComponent<SendProps> = ({
                     flexWrap: 'wrap',
                   }}>
                   <RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
+                    {translate('send.title')}
+                  </RegText>
+                  {/*<RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
                     {syncStatusDisplayLine ? translate('send.title-syncing') : translate('send.title')}
                   </RegText>
                   {!!syncStatusDisplayLine && (
                     <FadeText style={{ margin: 0, padding: 0 }}>{syncStatusDisplayLine}</FadeText>
+                  )}*/}
+                </View>
+                <View
+                  style={{
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    margin: 0,
+                    padding: 1,
+                    borderColor: colors.primary,
+                    borderWidth: 1,
+                    borderRadius: 10,
+                    minWidth: 20,
+                    minHeight: 20,
+                  }}>
+                  {!syncStatusDisplayLine && syncingStatus.synced && (
+                    <View style={{ margin: 0, padding: 0 }}>
+                      <FontAwesomeIcon icon={faCheck} color={colors.primary} />
+                    </View>
+                  )}
+                  {!syncStatusDisplayLine && !syncingStatus.synced && (
+                    <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                      <FontAwesomeIcon icon={faStop} color={colors.zingo} size={12} />
+                    </TouchableOpacity>
+                  )}
+                  {syncStatusDisplayLine && (
+                    <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                      <FontAwesomeIcon icon={faPlay} color={colors.primary} size={10} />
+                    </TouchableOpacity>
                   )}
                 </View>
-                {!!syncStatusDisplayLine && (
+                {/*!!syncStatusDisplayLine && (
                   <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
                     <View
                       style={{
@@ -1003,7 +1077,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                       <FontAwesomeIcon icon={faInfo} size={14} color={colors.primary} />
                     </View>
                   </TouchableOpacity>
-                )}
+                  )*/}
               </View>
 
               <View style={{ width: '100%', height: 1, backgroundColor: colors.primary }} />

--- a/components/SyncReport/SyncReport.tsx
+++ b/components/SyncReport/SyncReport.tsx
@@ -10,6 +10,7 @@ import DetailLine from './components/DetailLine';
 import { ContextLoaded } from '../../app/context';
 import moment from 'moment';
 import 'moment/locale/es';
+import RPC from '../../app/rpc';
 
 type SyncReportProps = {
   closeModal: () => void;
@@ -45,6 +46,10 @@ const SyncReport: React.FunctionComponent<SyncReportProps> = ({ closeModal }) =>
   useEffect(() => {
     setBirthday_plus_1((walletSeed.birthday || 0) + 1);
   }, [walletSeed.birthday]);
+
+  useEffect(() => {
+    (async () => await RPC.rpc_setInterruptSyncAfterBatch('false'))();
+  }, []);
 
   const server_1: number = birthday_plus_1 || 0;
   const server_2: number =

--- a/components/Transactions/Transactions.tsx
+++ b/components/Transactions/Transactions.tsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 import 'moment/locale/es';
 import { useTheme } from '@react-navigation/native';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faBars, faInfo } from '@fortawesome/free-solid-svg-icons';
+import { faBars, faInfo, faCheck, faPlay, faStop } from '@fortawesome/free-solid-svg-icons';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import RPC from '../../app/rpc';
@@ -170,7 +170,7 @@ const Transactions: React.FunctionComponent<TransactionsProps> = ({
             alignItems: 'center',
             justifyContent: 'center',
             flexWrap: 'wrap',
-            marginVertical: syncStatusDisplayLine ? 0 : 5,
+            marginVertical: 5,
           }}>
           <View
             style={{
@@ -181,11 +181,42 @@ const Transactions: React.FunctionComponent<TransactionsProps> = ({
               flexWrap: 'wrap',
             }}>
             <RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
+              {translate('transactions.title')}
+            </RegText>
+            {/*<RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
               {syncStatusDisplayLine ? translate('transactions.title-syncing') : translate('transactions.title')}
             </RegText>
-            {!!syncStatusDisplayLine && <FadeText style={{ margin: 0, padding: 0 }}>{syncStatusDisplayLine}</FadeText>}
+          {!!syncStatusDisplayLine && <FadeText style={{ margin: 0, padding: 0 }}>{syncStatusDisplayLine}</FadeText>}*/}
           </View>
-          {!!syncStatusDisplayLine && (
+          <View
+            style={{
+              alignItems: 'center',
+              justifyContent: 'center',
+              margin: 0,
+              padding: 1,
+              borderColor: colors.primary,
+              borderWidth: 1,
+              borderRadius: 10,
+              minWidth: 20,
+              minHeight: 20,
+            }}>
+            {!syncStatusDisplayLine && syncingStatus.synced && (
+              <View style={{ margin: 0, padding: 0 }}>
+                <FontAwesomeIcon icon={faCheck} color={colors.primary} />
+              </View>
+            )}
+            {!syncStatusDisplayLine && !syncingStatus.synced && (
+              <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                <FontAwesomeIcon icon={faStop} color={colors.zingo} size={12} />
+              </TouchableOpacity>
+            )}
+            {syncStatusDisplayLine && (
+              <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                <FontAwesomeIcon icon={faPlay} color={colors.primary} size={10} />
+              </TouchableOpacity>
+            )}
+          </View>
+          {/*!!syncStatusDisplayLine && (
             <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
               <View
                 style={{
@@ -205,7 +236,7 @@ const Transactions: React.FunctionComponent<TransactionsProps> = ({
                 <FontAwesomeIcon icon={faInfo} size={14} color={colors.primary} />
               </View>
             </TouchableOpacity>
-          )}
+            )*/}
         </View>
       </View>
 
@@ -369,7 +400,7 @@ const Transactions: React.FunctionComponent<TransactionsProps> = ({
               alignItems: 'center',
               justifyContent: 'center',
               flexWrap: 'wrap',
-              marginVertical: syncStatusDisplayLine ? 0 : 5,
+              marginVertical: 5,
             }}>
             <View
               style={{
@@ -380,13 +411,44 @@ const Transactions: React.FunctionComponent<TransactionsProps> = ({
                 flexWrap: 'wrap',
               }}>
               <RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
+                {translate('transactions.title')}
+              </RegText>
+              {/*<RegText color={colors.money} style={{ paddingHorizontal: 5 }}>
                 {syncStatusDisplayLine ? translate('transactions.title-syncing') : translate('transactions.title')}
               </RegText>
               {!!syncStatusDisplayLine && (
                 <FadeText style={{ margin: 0, padding: 0 }}>{syncStatusDisplayLine}</FadeText>
+              )}*/}
+            </View>
+            <View
+              style={{
+                alignItems: 'center',
+                justifyContent: 'center',
+                margin: 0,
+                padding: 1,
+                borderColor: colors.primary,
+                borderWidth: 1,
+                borderRadius: 10,
+                minWidth: 20,
+                minHeight: 20,
+              }}>
+              {!syncStatusDisplayLine && syncingStatus.synced && (
+                <View style={{ margin: 0, padding: 0 }}>
+                  <FontAwesomeIcon icon={faCheck} color={colors.primary} />
+                </View>
+              )}
+              {!syncStatusDisplayLine && !syncingStatus.synced && (
+                <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                  <FontAwesomeIcon icon={faStop} color={colors.zingo} size={12} />
+                </TouchableOpacity>
+              )}
+              {syncStatusDisplayLine && (
+                <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
+                  <FontAwesomeIcon icon={faPlay} color={colors.primary} size={10} />
+                </TouchableOpacity>
               )}
             </View>
-            {!!syncStatusDisplayLine && (
+            {/*!!syncStatusDisplayLine && (
               <TouchableOpacity onPress={() => syncingStatusMoreInfoOnClick()}>
                 <View
                   style={{
@@ -406,7 +468,7 @@ const Transactions: React.FunctionComponent<TransactionsProps> = ({
                   <FontAwesomeIcon icon={faInfo} size={14} color={colors.primary} />
                 </View>
               </TouchableOpacity>
-            )}
+              )*/}
           </View>
 
           <View style={{ width: '100%', height: 1, backgroundColor: colors.primary }} />

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -130,7 +130,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "bitflags",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-util",
  "http",
  "http-body",
@@ -157,7 +157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
 dependencies = [
  "async-trait",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-util",
  "http",
  "http-body",
@@ -397,15 +397,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cesu8"
@@ -493,7 +493,7 @@ version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "memchr",
 ]
 
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+checksum = "bc831ee6a32dd495436e317595e639a587aa9907bef96fe6e6abc290ab6204e9"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+checksum = "94331d54f1b1a8895cd81049f7eaaaef9d05a7dcb4d1fd08bf3ff0806246789d"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -632,15 +632,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+checksum = "48dcd35ba14ca9b40d6e4b4b39961f23d835dbb8eed74565ded361d93e1feb8a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+checksum = "81bbeb29798b407ccd82a3324ade1a7286e0d29851475990b612670f6f5124d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -736,9 +736,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -848,9 +848,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -873,15 +873,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -890,15 +890,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -907,21 +907,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -973,7 +973,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1089,7 +1089,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "fnv",
  "itoa",
 ]
@@ -1100,7 +1100,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "http",
  "pin-project-lite",
 ]
@@ -1135,7 +1135,7 @@ version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1186,7 +1186,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "hyper",
  "native-tls",
  "tokio",
@@ -1307,9 +1307,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1481,7 +1481,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1695,15 +1695,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1874,7 +1874,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "prost-derive",
 ]
 
@@ -1884,7 +1884,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "cfg-if",
  "cmake",
  "heck",
@@ -1919,7 +1919,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "prost",
 ]
 
@@ -2122,7 +2122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
  "base64 0.21.0",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2327,7 +2327,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2372,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2661,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -2812,12 +2812,12 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "libc",
  "memchr",
  "mio",
@@ -2827,7 +2827,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2889,7 +2889,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2907,7 +2907,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.13.1",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-util",
  "h2",
@@ -2973,7 +2973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
 dependencies = [
  "bitflags",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-util",
  "http",
@@ -2991,7 +2991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
  "bitflags",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-util",
  "http",
@@ -3248,9 +3248,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3258,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -3273,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3308,15 +3308,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3407,6 +3407,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -3629,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "zingoconfig"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#e3522c6976d1181c115752ffa15919fd0baa88fa"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#a3821f9726af22bc27c7f5547bcce2f4b9f6348d"
 dependencies = [
  "dirs",
  "http",
@@ -3642,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#e3522c6976d1181c115752ffa15919fd0baa88fa"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#a3821f9726af22bc27c7f5547bcce2f4b9f6348d"
 dependencies = [
  "base58",
  "base64 0.13.1",


### PR DESCRIPTION
Features:
* background.json for IOS BS using only in `ios`.
* changed the syncing UI (blocks) for 3 tiny icons: running (play icon), not running (stop icon) and fully synced (check icon). I think looks really good, and Matilda doesn't bother with them.
* interrupt sync working. For now (it's experimental) when the `send` screen got focus -> true, and when lost focus -> false. We have to test it, but could be a good start.

would be nice if someone test this branch... @AloeareV @Oscar-Pepper with the android emulator.