### PR TITLE
Fix: using platform.OS to read background.json only in IOS

### DIFF
--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -126,9 +126,12 @@ export default function LoadingApp(props: LoadingAppProps) {
     }
 
     // reading background task info
-    const backgroundJson = await BackgroundFileImpl.readBackground();
-    if (backgroundJson) {
-      setBackground(backgroundJson);
+    if (Platform.OS === 'ios') {
+      // this file only exists in IOS BS.
+      const backgroundJson = await BackgroundFileImpl.readBackground();
+      if (backgroundJson) {
+        setBackground(backgroundJson);
+      }
     }
   }, [currency, file, i18n, sendAll, server]);
 

--- a/app/rpc/RPC.ts
+++ b/app/rpc/RPC.ts
@@ -23,6 +23,7 @@ import { RPCSaplingNoteType } from './types/RPCSaplingNoteType';
 import { RPCUtxoNoteType } from './types/RPCUtxoNoteType';
 import { RPCTransactionType } from './types/RPCTransationType';
 import { RPCOutgoingMetadataType } from './types/RPCOutgoingMetadataType';
+import { Platform } from 'react-native';
 
 export default class RPC {
   fnSetSyncingStatusReport: (syncingStatusReport: SyncingStatusReportClass) => void;
@@ -457,7 +458,10 @@ export default class RPC {
     // And fetch the rest of the data.
     await this.loadWalletData();
 
-    this.fetchBackgroundSyncing();
+    if (Platform.OS === 'ios') {
+      // this file only exists in IOS BS.
+      this.fetchBackgroundSyncing();
+    }
 
     //console.log(`Finished update data at ${lastServerBlockHeight}`);
     this.updateDataLock = false;


### PR DESCRIPTION
I need to exclude of reading this file in Android, only make sense in IOS.