### PR TITLE
Loading screen - open current wallet fixed

### DIFF
--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -332,7 +332,7 @@ class LoadingAppClass extends Component<LoadingAppClassProps, AppStateLoading> {
   };
 
   getwalletSeedToRestore = async () => {
-    this.setState({ walletSeed: {} as WalletSeedType, screen: 3, walletExists: false });
+    this.setState({ walletSeed: {} as WalletSeedType, screen: 3 });
   };
 
   doRestore = async (seed: string, birthday: number) => {


### PR DESCRIPTION
Ref: https://github.com/zingolabs/zingo-mobile/issues/234

I fixed this problem meanwhile we create a new screen for this use case. Now if you get a problem when the App trying to open the current wallet... and you click to `restore from seed` and come back to the main screen... you have the `open current wallet` button there.

@zancas I put you as a reviewer in all my PR since you decide who is the reviewer, apparently.