### PR TITLE
Transparent addresses into chunks fixed

### DIFF
--- a/__tests__/__snapshots__/PrivKey.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/PrivKey.snapshot.tsx.snap
@@ -249,7 +249,21 @@ exports[`Component PrivKey - test PrivKey Private - snapshot 1`] = `
             }
           }
         >
-          priv-key-12345678901234567890
+          priv-key-123456
+        </Text>
+        <Text
+          style={
+            {
+              "color": "rgb(28, 28, 30)",
+              "flexBasis": "100%",
+              "fontFamily": "Courier",
+              "fontSize": 18,
+              "opacity": 0.65,
+              "textAlign": "center",
+            }
+          }
+        >
+          78901234567890
         </Text>
       </View>
     </View>
@@ -574,7 +588,21 @@ exports[`Component PrivKey - test PrivKey View - snapshot 1`] = `
             }
           }
         >
-          view-key-12345678901234567890
+          view-key-123456
+        </Text>
+        <Text
+          style={
+            {
+              "color": "rgb(28, 28, 30)",
+              "flexBasis": "100%",
+              "fontFamily": "Courier",
+              "fontSize": 18,
+              "opacity": 0.65,
+              "textAlign": "center",
+            }
+          }
+        >
+          78901234567890
         </Text>
       </View>
     </View>

--- a/components/History/components/TxDetail.tsx
+++ b/components/History/components/TxDetail.tsx
@@ -131,6 +131,9 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
           </View>
 
           {tx.detailedTxns.map((txd: TxDetailType) => {
+            // 30 characters per line
+            const numLines = txd.address.length < 40 ? 2 : txd.address.length / 30;
+
             return (
               <View
                 key={txd.address}
@@ -154,11 +157,11 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
                         setExpandAddress(true);
                       }
                     }}>
-                    <View style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
+                    <View style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
                       {expandAddress &&
-                        Utils.splitStringIntoChunks(txd.address, 9).map((c: string, idx: number) => {
-                          return <RegText key={idx}>{c} </RegText>;
-                        })}
+                        Utils.splitStringIntoChunks(txd.address, Number(numLines.toFixed(0))).map(
+                          (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
+                        )}
                       {!expandAddress && <RegText>{Utils.trimToSmall(txd.address, 10)}</RegText>}
                     </View>
                   </TouchableOpacity>

--- a/components/PrivKey/PrivKey.tsx
+++ b/components/PrivKey/PrivKey.tsx
@@ -28,7 +28,7 @@ const PrivKey: React.FunctionComponent<PrivKeyProps> = ({ address, keyType, priv
   const keyTypeString = keyType === 0 ? translate('privkey.privkey') : translate('privkey.viewkey');
 
   // 30 characters per line
-  const numLines = privKey.length / 30;
+  const numLines = privKey.length < 40 ? 2 : privKey.length / 30;
   const keyChunks = Utils.splitStringIntoChunks(privKey, Number(numLines.toFixed(0)));
 
   const [expandAddress, setExpandAddress] = useState(false);

--- a/components/Send/components/Confirm.tsx
+++ b/components/Send/components/Confirm.tsx
@@ -60,10 +60,14 @@ const Confirm: React.FunctionComponent<ConfirmProps> = ({ closeModal, confirmSen
           <CurrencyAmount amtZec={sendingTotal} price={zecPrice.zecPrice} currency={currency} />
         </View>
         {[sendPageState.toaddr].map(to => {
+          // 30 characters per line
+          const numLines = to.to.length < 40 ? 2 : to.to.length / 30;
           return (
             <View key={to.id} style={{ margin: 10 }}>
               <FadeText>{translate('send.to') as string}</FadeText>
-              <RegText>{Utils.splitStringIntoChunks(to.to, 8).join(' ')}</RegText>
+              {Utils.splitStringIntoChunks(to.to, Number(numLines.toFixed(0))).map((c: string, idx: number) => (
+                <RegText key={idx}>{c}</RegText>
+              ))}
 
               <FadeText style={{ marginTop: 10 }}>{translate('send.confirm-amount') as string}</FadeText>
               <View


### PR DESCRIPTION
We was splitting in chunks all the addresses, and it works for Z or UA addresses, but for T looks really weird. 
I fixed this like that:
- if the address es Transparent or < 40 characters -> split the address in 2 chunks.
- otherwise -> split in 30 characters each chunk.