### PR TITLE
UI fixed When the txs don't have id, date, address...

### DIFF
--- a/app/utils/Utils.ts
+++ b/app/utils/Utils.ts
@@ -2,9 +2,11 @@ import { getNumberFormatSettings } from 'react-native-localize';
 import { ZecAmountSplitType } from './ZecAmountSplitType';
 
 export default class Utils {
-  static trimToSmall(addr: string, numChars?: number): string {
+  static trimToSmall(addr?: string, numChars?: number): string {
+    if (!addr) {
+      return '';
+    }
     const trimSize = numChars || 5;
-
     return `${addr.slice(0, trimSize)}...${addr.slice(addr.length - trimSize)}`;
   }
 

--- a/components/History/History.tsx
+++ b/components/History/History.tsx
@@ -90,7 +90,7 @@ const History: React.FunctionComponent<HistoryProps> = ({
           .slice(0, numTx)
           .sort((a, b) => b.time - a.time)
           .flatMap((t, index) => {
-            let txmonth = moment(t.time * 1000).format('MMM YYYY');
+            let txmonth = t.time ? moment(t.time * 1000).format('MMM YYYY') : '--- ----';
 
             var month = '';
             if (txmonth !== lastMonth) {

--- a/components/History/components/TxDetail.tsx
+++ b/components/History/components/TxDetail.tsx
@@ -162,6 +162,7 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
                       {!tx.address && <RegText>{'Unknown'}</RegText>}
                       {!expandAddress && !!tx.address && <RegText>{Utils.trimToSmall(txd.address, 10)}</RegText>}
                       {expandAddress &&
+                        !!tx.address &&
                         Utils.splitStringIntoChunks(txd.address, Number(numLines.toFixed(0))).map(
                           (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
                         )}

--- a/components/History/components/TxDetail.tsx
+++ b/components/History/components/TxDetail.tsx
@@ -98,11 +98,11 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
           <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', marginTop: 10 }}>
             <View style={{ display: 'flex' }}>
               <FadeText>{translate('history.time') as string}</FadeText>
-              <RegText>{moment((tx.time || 0) * 1000).format('YYYY MMM D h:mm a')}</RegText>
+              <RegText>{tx.time ? moment((tx.time || 0) * 1000).format('YYYY MMM D h:mm a') : '--'}</RegText>
             </View>
             <View style={{ display: 'flex', alignItems: 'flex-end' }}>
               <FadeText>{translate('history.confirmations') as string}</FadeText>
-              <RegText>{tx.confirmations.toString()}</RegText>
+              <RegText>{tx.confirmations ? tx.confirmations.toString() : '-'}</RegText>
             </View>
           </View>
 
@@ -116,8 +116,9 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
                   setExpandTxid(true);
                 }
               }}>
-              {!expandTxid && <RegText>{Utils.trimToSmall(tx.txid, 10)}</RegText>}
-              {expandTxid && (
+              {!tx.txid && <RegText>{'Unknown'}</RegText>}
+              {!expandTxid && !!tx.txid && <RegText>{Utils.trimToSmall(tx.txid, 10)}</RegText>}
+              {expandTxid && !!tx.txid && (
                 <>
                   <RegText>{tx.txid}</RegText>
                   <TouchableOpacity onPress={() => handleTxIDClick(tx.txid)}>
@@ -158,11 +159,12 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
                       }
                     }}>
                     <View style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
+                      {!tx.address && <RegText>{'Unknown'}</RegText>}
+                      {!expandAddress && !!tx.address && <RegText>{Utils.trimToSmall(txd.address, 10)}</RegText>}
                       {expandAddress &&
                         Utils.splitStringIntoChunks(txd.address, Number(numLines.toFixed(0))).map(
                           (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
                         )}
-                      {!expandAddress && <RegText>{Utils.trimToSmall(txd.address, 10)}</RegText>}
                     </View>
                   </TouchableOpacity>
                 </View>

--- a/components/History/components/TxSummaryLine.tsx
+++ b/components/History/components/TxSummaryLine.tsx
@@ -38,7 +38,9 @@ const TxSummaryLine: React.FunctionComponent<TxSummaryLineProps> = ({
   moment.locale(language);
 
   const displayAddress =
-    tx.detailedTxns && tx.detailedTxns.length > 0 ? Utils.trimToSmall(tx.detailedTxns[0].address, 7) : 'Unknown';
+    tx.detailedTxns && tx.detailedTxns.length > 0 && tx.detailedTxns[0].address
+      ? Utils.trimToSmall(tx.detailedTxns[0].address, 7)
+      : 'Unknown';
 
   return (
     <View testID={`transactionList.${index + 1}`} style={{ display: 'flex', flexDirection: 'column' }}>
@@ -82,7 +84,7 @@ const TxSummaryLine: React.FunctionComponent<TxSummaryLineProps> = ({
               <FadeText>
                 {tx.type === 'sent' ? (translate('history.sent') as string) : (translate('history.receive') as string)}
               </FadeText>
-              <FadeText>{moment((tx.time || 0) * 1000).format('MMM D, h:mm a')}</FadeText>
+              <FadeText>{tx.time ? moment((tx.time || 0) * 1000).format('MMM D, h:mm a') : '--'}</FadeText>
             </View>
           </View>
           <ZecAmount

--- a/components/Send/components/Confirm.tsx
+++ b/components/Send/components/Confirm.tsx
@@ -43,7 +43,9 @@ const Confirm: React.FunctionComponent<ConfirmProps> = ({ closeModal, confirmSen
         noSyncingStatus={true}
         noDrawMenu={true}
       />
-      <ScrollView contentContainerStyle={{ display: 'flex', justifyContent: 'flex-start' }} testID="send.confirm.scrollView">
+      <ScrollView
+        contentContainerStyle={{ display: 'flex', justifyContent: 'flex-start' }}
+        testID="send.confirm.scrollView">
         <View
           style={{
             display: 'flex',


### PR DESCRIPTION
The UI is working well even If the transactions JSON is something like this:
```
{
"amount": 100000,
"memo": "Enviado desde YWallet, Enviado desde YWallet",
"zec_price": null
}
```
No date, id, address, blockheight.....