### PR TITLE
New version zingo 1.2.1 122

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -136,9 +136,9 @@ android {
         //applicationId 'com.ZingoMobile' // @Test
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 121 // Real
+        versionCode 122 // Real
         //versionCode 117 // @Test
-        versionName "zingo-1.2.0" // Real
+        versionName "zingo-1.2.1" // Real
         missingDimensionStrategy 'react-native-camera', 'general'
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1,6 +1,6 @@
 {
   "zingo": "Zingo!",
-  "version": "zingo-1.2.0 (121)",
+  "version": "zingo-1.2.1 (122)",
   "loading": "loading...",
   "connectingserver": "Connecting to the server...",
   "wait": "Please wait...",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -1,6 +1,6 @@
 {
   "zingo": "Zingo!",
-  "version": "zingo-1.2.0 (121)",
+  "version": "zingo-1.2.1 (122)",
   "loading": "cargando...",
   "connectingserver": "Conectando con el servidor...",
   "wait": "Por favor espere...",

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -14,7 +14,7 @@ target 'ZingoMobile' do
   use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods
-    :hermes_enabled => false
+    :hermes_enabled => true
   )
 
   target 'ZingoMobileTests' do

--- a/ios/ZingoMobile.xcodeproj/project.pbxproj
+++ b/ios/ZingoMobile.xcodeproj/project.pbxproj
@@ -521,7 +521,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ZingoMobile/ZingoMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				DEVELOPMENT_TEAM = 788KRST4S8;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
@@ -538,7 +538,7 @@
 					"$(PROJECT_DIR)",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -561,7 +561,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ZingoMobile/ZingoMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				DEVELOPMENT_TEAM = 788KRST4S8;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
@@ -578,7 +578,7 @@
 					"$(PROJECT_DIR)",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
New production version of Zingo.

I used to build the Apps:
* zingolib -> commit: https://github.com/zingolabs/zingolib/commit/a7c18204def59ab4793e6bfcdcb7c9b81d444de3
* zingo-mobile -> commit: https://github.com/zingolabs/zingo-mobile/commit/521c6e1e3ccd85de9c08e3b95f22c2492c33a11b

What's new:
*    Change custom server fixed.
*    Keyboard Animation fixed.
*    Network connectivity Info.
*    Change another wallet fixed.
*    Shield transparent funds button.
*    Keep device awake while syncing.
*    Price fetcher fixed.
*    BOBA error fixed.
*    Camera box for QR Code fixed.
*    Including zecwallet server in the list.
*    A few bugs fixed.

@AloeareV @fluidvanadium @zancas @Oscar-Pepper 