### PR TITLE
Fix for tx.amount better readability

### DIFF
--- a/components/History/components/TxDetail.tsx
+++ b/components/History/components/TxDetail.tsx
@@ -39,12 +39,12 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal }) =>
     (tx.detailedTxns && tx.detailedTxns.reduce((s: number, d: TxDetailType) => s + (d.amount ? d.amount : 0), 0)) || 0;
   let fee = 0;
   // normal case: spend 1600 fee 1000 sent 600
-  if (tx.type === 'sent' && tx.amount && Math.abs(tx.amount) > Math.abs(sum)) {
+  if (tx.type === 'sent' && Math.abs(tx.amount) > Math.abs(sum)) {
     fee = Math.abs(tx.amount) - Math.abs(sum);
   }
   // self-send case: spend 1000 fee 1000 sent 0
   // this is temporary until we have a new field in 'list' object, called: fee.
-  if (tx.type === 'sent' && tx.amount && Math.abs(tx.amount) <= Math.abs(sum)) {
+  if (tx.type === 'sent' && Math.abs(tx.amount) <= Math.abs(sum)) {
     fee = Math.abs(tx.amount);
   }
 

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -290,7 +290,7 @@ const Send: React.FunctionComponent<SendProps> = ({
       toAddr.amount = amount.replace(decimalSeparator, '.').substring(0, 20);
       if (isNaN(Number(toAddr.amount))) {
         toAddr.amountCurrency = '';
-      } else if (toAddr.amount && zecPrice && zecPrice.zecPrice > 0) {
+      } else if (zecPrice && zecPrice.zecPrice > 0) {
         toAddr.amountCurrency = Utils.toLocaleFloat((parseFloat(toAddr.amount) * zecPrice.zecPrice).toFixed(2));
       } else {
         toAddr.amountCurrency = '';

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -290,7 +290,7 @@ const Send: React.FunctionComponent<SendProps> = ({
       toAddr.amount = amount.replace(decimalSeparator, '.').substring(0, 20);
       if (isNaN(Number(toAddr.amount))) {
         toAddr.amountCurrency = '';
-      } else if (zecPrice && zecPrice.zecPrice > 0) {
+      } else if (toAddr.amount && zecPrice && zecPrice.zecPrice > 0) {
         toAddr.amountCurrency = Utils.toLocaleFloat((parseFloat(toAddr.amount) * zecPrice.zecPrice).toFixed(2));
       } else {
         toAddr.amountCurrency = '';


### PR DESCRIPTION
in `txDetail` always will be a number, no need `tx.amount &&`.
