### PR TITLE
Sync report screen - first sections margin fixed

### DIFF
--- a/__tests__/__snapshots__/SyncReport.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/SyncReport.snapshot.tsx.snap
@@ -144,8 +144,8 @@ exports[`Component SyncReport - test Matches the snapshot SyncReport 1`] = `
         style={
           {
             "display": "flex",
-            "margin": 20,
             "marginBottom": 30,
+            "marginHorizontal": 20,
           }
         }
       >

--- a/components/SyncReport/SyncReport.tsx
+++ b/components/SyncReport/SyncReport.tsx
@@ -221,7 +221,7 @@ const SyncReport: React.FunctionComponent<SyncReportProps> = ({ closeModal }) =>
               display: 'flex',
               flexDirection: 'row',
               alignItems: 'flex-end',
-              margin: 20,
+              marginHorizontal: 20,
             }}>
             <DetailLine
               label={translate('report.lastbackgroundsync') as string}
@@ -235,7 +235,7 @@ const SyncReport: React.FunctionComponent<SyncReportProps> = ({ closeModal }) =>
         )}
         {maxBlocks && netInfo.isConnected ? (
           <>
-            <View style={{ display: 'flex', margin: 20, marginBottom: 30 }}>
+            <View style={{ display: 'flex', marginHorizontal: 20, marginBottom: 30 }}>
               <DetailLine
                 label="Sync ID"
                 value={


### PR DESCRIPTION
Ref: #340. 

Usually those two sections are hidden:
- internet connection info.
- last batches in BS, only IOS.