### PR TITLE
Adding a box to qr scanner screen

### DIFF
--- a/components/Send/components/ScannerAddress.tsx
+++ b/components/Send/components/ScannerAddress.tsx
@@ -90,6 +90,7 @@ const ScannerAddress: React.FunctionComponent<ScannerAddressProps> = ({ updateTo
         height: '100%',
       }}>
       <QRCodeScanner
+        showMarker={true}
         onRead={onRead}
         reactivate={true}
         containerStyle={{


### PR DESCRIPTION
Ref: https://github.com/zingolabs/zingo-mobile/issues/373

This is the default marker from this library, in my device looks good.