### PR TITLE
Hidding the shield button with a watch-only wallet

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -106,7 +106,8 @@ const Header: React.FunctionComponent<HeaderProps> = ({
 
   const balanceColor = colors.text;
 
-  const showShieldButton = totalBalance && (totalBalance.transparentBal > 0 || totalBalance.privateBal > 0);
+  const showShieldButton =
+    !readOnly && totalBalance && (totalBalance.transparentBal > 0 || totalBalance.privateBal > 0);
 
   let poolsToShield: '' | 'all' | 'transparent' | 'sapling' = '';
 


### PR DESCRIPTION
I noticed that with a watch-only wallet with sapling or transparent funds... the shield button shows up, and this make not sense in read-only mode. I fixed that.