### PR TITLE
Clarify start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ see the [trouble-shooting notes](./TROUBLESHOOTING.md).
 1. `docker` (for building the rust library)
 2. `yarn`
 3. `nodejs` recommended version v16.16.0 LTS.
+4. Android Studio or commandline tools
 
 Carefully follow the instructions to [setup Android Studio for your
 operating system](https://reactnative.dev/docs/environment-setup).
@@ -38,6 +39,11 @@ It is not neccessary to install watchman or the Android 12 system images.
 If you do not have a physical device, you can create and start
 a new Android 11, API 30 emulator device compatible
 with the chip on your system and start the emulated device.
+
+### Bash shortcut
+It is possible emulate android with the command line.
+1. install sdkmanager (or included with androidstudio). standalone setup has a quirk as navigated in `scripts/sdkmanager_install.sh`. then sdkmanager must be added to PATH.
+2. run `scripts/start_interactive.sh -a x86` to automatically set up the android sdk, build the app, and stream it to the emulator. it will boot, then take a minute to load from a local port. outputs are generated in `android/app/build/outputs/emulator_output/`
 
 ### Building
 0. Start docker daemon

--- a/scripts/emulator_target.sh
+++ b/scripts/emulator_target.sh
@@ -15,27 +15,43 @@ valid_api_targets=("default" "google_apis" "google_apis_playstore" "google_atd" 
 while getopts 'a:l:t:h' OPTION; do
     case "$OPTION" in
         a)
-            abi="$OPTARG"
-            case "$abi" in
+            a="$OPTARG"
+            case "$a" in
                 x86_64)
                     api_level_default="30"
                     api_target_default="google_apis_playstore"
                     arch="x86_64"
+                    abi="x86_64"
                     ;;
                 x86) 
                     api_level_default="30"
                     api_target_default="google_apis_playstore"
                     arch="x86"
+                    abi="x86"
+                    ;;
+                xarm64-v8a)
+                    api_level_default="30"
+                    api_target_default="google_apis_playstore"
+                    arch="x86_64"
+                    abi="arm64_v8a"
+                    ;;
+                xarmeabi-v7a)
+                    api_level_default="30"
+                    api_target_default="google_apis_playstore"
+                    arch="x86"
+                    abi="armeabi-v7a"
                     ;;
                 arm64-v8a)
                     api_level_default="30"
                     api_target_default="google_apis_playstore"
-                    arch="x86_64"
+                    arch="arm64_v8a"
+                    abi="arm64_v8a"
                     ;;
                 armeabi-v7a)
-                    api_level_default="30"
-                    api_target_default="google_apis_playstore"
-                    arch="x86"
+                    api_level_default="25"
+                    api_target_default="google_apis"
+                    arch="armeabi-v7a"
+                    abi="armeabi-v7a"
                     ;;
                 *)
                     echo "Error: Invalid ABI" >&2

--- a/scripts/sdkmanager_install.sh
+++ b/scripts/sdkmanager_install.sh
@@ -1,0 +1,6 @@
+wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip
+unzip commandlinetools-linux-9477386_latest.zip
+mkdir latest
+mv cmdline-tools/* latest
+mv latest cmdline-tools
+

--- a/scripts/start_interactive.sh
+++ b/scripts/start_interactive.sh
@@ -8,6 +8,6 @@ cd $(git rev-parse --show-toplevel)
 
 ./scripts/rust_build_yarn_install.sh
 
-./scripts/emulator_target.sh $@
+./scripts/flow_emulator_setup.sh $@
 
 ./scripts/flow_emulate_interactive.sh

--- a/scripts/start_test_e2e.sh
+++ b/scripts/start_test_e2e.sh
@@ -11,6 +11,6 @@ shift
 
 ./scripts/rust_build_yarn_install.sh
 
-./scripts/emulator_target.sh $@
+./scripts/flow_emulator_setup.sh $@
 
 ./scripts/flow_test_e2e.sh $test_suite


### PR DESCRIPTION
i expect this to run simply with `scripts/start_interactive.sh -a x86` on any system that already runs emulation. other system may take extra setup as documented in the README