### PR TITLE
added nextest config

### DIFF
--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,0 +1,10 @@
+[profile.default]
+retries = 3
+test-threads = 1
+
+[profile.ci]
+retries = 3
+test-threads = 1
+failure-output = "immediate-final"
+fail-fast = false
+

--- a/rust/android/tests/integration_tests.rs
+++ b/rust/android/tests/integration_tests.rs
@@ -5,7 +5,7 @@ use zingo_testutils::{self, scenarios};
 #[tokio::test]
 async fn offline_testsuite_arm32() {
     let (exit_code, output, error) =
-        test_utils::android_integration_test("armeabi-v7a", "OfflineTestSuite");
+        test_utils::android_integration_test("x86_64", "OfflineTestSuite");
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);

--- a/rust/android/tests/integration_tests.rs
+++ b/rust/android/tests/integration_tests.rs
@@ -5,7 +5,7 @@ use zingo_testutils::{self, scenarios};
 #[tokio::test]
 async fn offline_testsuite_arm32() {
     let (exit_code, output, error) =
-        test_utils::android_integration_test("x86_64", "OfflineTestSuite");
+        test_utils::android_integration_test("armeabi-v7a", "OfflineTestSuite");
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);


### PR DESCRIPTION
- removes need to run 'cargo nextest run' with flags
- retries on fail 3 times for flaky tests
- has a 'CI' profile for CI