### PR TITLE
combine version strings into one

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1,6 +1,6 @@
 {
   "zingo": "Zingo!",
-  "version": "zingo-1.2.5 (126)",
+  "version": "zingo-128",
   "loading": "loading...",
   "connectingserver": "Connecting to the server...",
   "wait": "Please wait...",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -1,6 +1,6 @@
 {
   "zingo": "Zingo!",
-  "version": "zingo-1.2.5 (126)",
+  "version": "zingo-128",
   "loading": "cargando...",
   "connectingserver": "Conectando con el servidor...",
   "wait": "Por favor espere...",


### PR DESCRIPTION
its unnecessary and confusing to have two version numbers right after the other.