### PR TITLE
New field in info screen for zingolib version-commit

### DIFF
--- a/__tests__/__snapshots__/Info.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Info.snapshot.tsx.snap
@@ -340,6 +340,32 @@ exports[`Component Info - test Info - snapshot 1`] = `
             2000100
           </Text>
         </View>
+        <View
+          style={
+            {
+              "display": "flex",
+              "marginTop": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "rgb(28, 28, 30)",
+                "opacity": 0.65,
+              }
+            }
+          >
+            translated text
+          </Text>
+          <View
+            style={
+              {
+                "width": 10,
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </RCTScrollView>

--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/OfflineTestSuite.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/OfflineTestSuite.kt
@@ -7,6 +7,6 @@ import org.junit.runners.Suite.SuiteClasses
 
 @RunWith(Categories::class)
 @IncludeCategory(OfflineTest::class)
-@SuiteClasses(ExecuteAddressesFromSeed::class, ExecuteAddressesFromUfvk::class)
+@SuiteClasses(ExecuteAddressesFromSeed::class, ExecuteAddressesFromUfvk::class, ExecuteVersionFromSeed::class)
 class OfflineTestSuite {
 }

--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
@@ -137,6 +137,33 @@ class ExecuteAddressesFromUfvk {
     }    
 }
 
+@Category(OfflineTest::class)
+class ExecuteVersionFromSeed {
+    @Test
+    fun executeVersionFromSeed() {
+        val mapper = jacksonObjectMapper()
+
+        val server = "http://10.0.2.2:20000"
+        val chainhint = "main"
+        val seed = Seeds.ABANDON
+        val birthday = "1"
+        val datadir = MainApplication.getAppContext()!!.filesDir.path
+        val monitorMempool = "false"
+
+        var initFromSeedJson = RustFFI.initfromseed(server, seed, birthday, datadir, chainhint, monitorMempool)
+        System.out.println("\nInit from seed:")
+        System.out.println(initFromSeedJson)
+        val initFromSeed: InitFromSeed = mapper.readValue(initFromSeedJson)
+        assertThat(initFromSeed.seed).isEqualTo(Seeds.ABANDON)
+        assertThat(initFromSeed.birthday).isEqualTo(1)
+
+        var version = RustFFI.execute("version", "")
+        System.out.println("\nVersion:")
+        System.out.println(version)
+        assertThat(version).startsWith("mob-release")
+    }
+}
+
 class ExecuteSyncFromSeed {
     @Test
     fun executeSyncFromSeed() {

--- a/app/AppState/types/InfoType.ts
+++ b/app/AppState/types/InfoType.ts
@@ -8,5 +8,6 @@ export default interface InfoType {
   currencyName: string;
   solps: number;
   defaultFee: number;
+  zingolib: string;
   // eslint-disable-next-line semi
 }

--- a/app/rpc/RPC.ts
+++ b/app/rpc/RPC.ts
@@ -205,6 +205,18 @@ export default class RPC {
       }
       const defaultFeeJSON: RPCDefaultFeeType = await JSON.parse(defaultFeeStr);
 
+      let zingolibStr: string = await RPCModule.execute('version', '');
+      if (zingolibStr) {
+        if (zingolibStr.toLowerCase().startsWith('error')) {
+          console.log(`Error zingolib version ${zingolibStr}`);
+          zingolibStr = '<error>';
+        }
+      } else {
+        console.log('Internal Error zingolib version');
+        zingolibStr = '<none>';
+      }
+      //const zingolibJSON = await JSON.parse(zingolibStr);
+
       const info: InfoType = {
         chain_name: infoJSON.chain_name,
         latestBlock: infoJSON.latest_block_height,
@@ -215,6 +227,7 @@ export default class RPC {
         currencyName: infoJSON.chain_name === 'main' ? 'ZEC' : 'TAZ',
         solps: 0,
         defaultFee: defaultFeeJSON.defaultfee / 10 ** 8 || Utils.getFallbackDefaultFee(),
+        zingolib: zingolibStr,
       };
 
       return info;

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -215,7 +215,8 @@
     "tablet": "Tablet",
     "phone": "Phone",
     "errorgemini": "Error fetching the price from the Internet.",
-    "errorrpcmodule": "Internal Error fetching the price from the Internet"
+    "errorrpcmodule": "Internal Error fetching the price from the Internet",
+    "zingolib": "Zingolib version"
   },
   "rescan": {
     "title": "Rescan",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -215,7 +215,8 @@
     "tablet": "Tableta",
     "phone": "Teléfono",
     "errorgemini": "Error extrayendo el precio de Internet.",
-    "errorrpcmodule": "Error Interno extrayendo el precio de Internet."
+    "errorrpcmodule": "Error Interno extrayendo el precio de Internet.",
+    "zingolib": "Versión de Zingolib"
   },
   "rescan": {
     "title": "Re-Escanear",

--- a/components/Info/Info.tsx
+++ b/components/Info/Info.tsx
@@ -93,6 +93,7 @@ const Info: React.FunctionComponent<InfoProps> = ({ closeModal, setZecPrice }) =
               </View>
             </View>
           )}
+          <DetailLine label={translate('info.zingolib') as string} value={info.zingolib} />
         </View>
       </ScrollView>
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#408826c5cd6ab0cce04d8e1853465a69a09621f7"
 
 [[package]]
 name = "bumpalo"
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "zingo-memo"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#408826c5cd6ab0cce04d8e1853465a69a09621f7"
 dependencies = [
  "zcash_address",
  "zcash_client_backend",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "zingo-testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#408826c5cd6ab0cce04d8e1853465a69a09621f7"
 dependencies = [
  "http",
  "incrementalmerkletree",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "zingoconfig"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#408826c5cd6ab0cce04d8e1853465a69a09621f7"
 dependencies = [
  "dirs",
  "http",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#408826c5cd6ab0cce04d8e1853465a69a09621f7"
 dependencies = [
  "append-only-vec",
  "base58",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2543,6 +2543,7 @@ dependencies = [
  "base64 0.11.0",
  "http",
  "lazy_static",
+ "tokio",
  "zingoconfig",
  "zingolib",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#587d485aee9d53c1369cd202aa3077c6ffd7e34b"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
 
 [[package]]
 name = "bumpalo"
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "zingo-memo"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#587d485aee9d53c1369cd202aa3077c6ffd7e34b"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
 dependencies = [
  "zcash_address",
  "zcash_client_backend",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "zingo-testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#587d485aee9d53c1369cd202aa3077c6ffd7e34b"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
 dependencies = [
  "http",
  "incrementalmerkletree",
@@ -3979,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "zingoconfig"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#587d485aee9d53c1369cd202aa3077c6ffd7e34b"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
 dependencies = [
  "dirs",
  "http",
@@ -3992,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#587d485aee9d53c1369cd202aa3077c6ffd7e34b"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#ffdf069f34be3f93d893572c1b91cb2afe40b429"
 dependencies = [
  "append-only-vec",
  "base58",

--- a/rust/ios/src/lib.rs
+++ b/rust/ios/src/lib.rs
@@ -7,7 +7,7 @@ pub extern "C" fn rust_free(s: *mut c_char) {
         if s.is_null() {
             return;
         }
-        CString::from_raw(s)
+        let _ = CString::from_raw(s);
     };
 }
 

--- a/rust/lib/Cargo.toml
+++ b/rust/lib/Cargo.toml
@@ -10,3 +10,6 @@ zingoconfig = { workspace = true }
 http = "*"
 lazy_static = "1.4.0"
 base64 = "0.11.0"
+
+[dev-dependencies]
+tokio = "1.32.0"

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -8,7 +8,7 @@ use base64::{decode, encode};
 
 use zingoconfig::construct_lightwalletd_uri;
 use zingolib::wallet::WalletBase;
-use zingolib::{commands, lightclient::LightClient};
+use zingolib::{commands, git_description, lightclient::LightClient};
 
 // We'll use a MUTEX to store a global lightclient instance,
 // so we don't have to keep creating it. We need to store it here, in rust
@@ -255,5 +255,9 @@ mod tests {
         let test_client = LightClient::create_unconnected(&config, wallet_base, 1)
             .expect("To create a lightclient.");
         dbg!(test_client.do_info().await);
+    }
+    #[test]
+    fn report_git_decription() {
+        assert_eq!(git_description(), "foo");
     }
 }

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -243,7 +243,7 @@ mod tests {
     async fn report_zingolib_build_version() {
         // Use test in RustFFITest.kt as template
         let server = "http://10.0.2.2:20000".to_string();
-        let datadir = "somedatadir".to_string();
+        let datadir = "testdata".to_string();
         let chain_hint = "main".to_string();
         let abandon_art_seed =  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art".to_string();
         let wallet_base = WalletBase::from_string(abandon_art_seed);

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -235,3 +235,56 @@ pub fn get_latest_block(server_uri: String) -> String {
         Err(e) => e,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    async fn async_test_init_from_seed(
+        server_uri: String,
+        seed: String,
+        birthday: u64,
+        data_dir: String,
+        chain_hint: String,
+        monitor_mempool: bool,
+    ) -> LightClient {
+        let (config, _lightwalletd_uri);
+        match construct_uri_load_config(server_uri, data_dir, chain_hint, monitor_mempool) {
+            Ok((c, h)) => (config, _lightwalletd_uri) = (c, h),
+            Err(_) => panic!(),
+        }
+        let lightclient = match LightClient::create_from_wallet_base_async(
+            WalletBase::MnemonicPhrase(seed),
+            &config,
+            birthday,
+            false,
+        )
+        .await
+        {
+            Ok(l) => l,
+            Err(_) => {
+                panic!();
+            }
+        };
+        lightclient
+    }
+    #[tokio::test]
+    async fn report_zingolib_build_version() {
+        // Use test in RustFFITest.kt as template
+        let abandon_art_seed =  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art".to_string();
+        let server = "http://10.0.2.2:20000".to_string();
+        let chainhint = "main".to_string();
+        let birthday = 1u64;
+        let datadir = "somedatadir".to_string();
+        let monitor_mempool = false;
+        let test_client = async_test_init_from_seed(
+            server,
+            abandon_art_seed,
+            birthday,
+            datadir,
+            chainhint,
+            monitor_mempool,
+        )
+        .await;
+        dbg!(test_client.do_info().await);
+    }
+}

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -239,52 +239,21 @@ pub fn get_latest_block(server_uri: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    async fn async_test_init_from_seed(
-        server_uri: String,
-        seed: String,
-        birthday: u64,
-        data_dir: String,
-        chain_hint: String,
-        monitor_mempool: bool,
-    ) -> LightClient {
-        let (config, _lightwalletd_uri);
-        match construct_uri_load_config(server_uri, data_dir, chain_hint, monitor_mempool) {
-            Ok((c, h)) => (config, _lightwalletd_uri) = (c, h),
-            Err(_) => panic!(),
-        }
-        let lightclient = match LightClient::create_from_wallet_base_async(
-            WalletBase::MnemonicPhrase(seed),
-            &config,
-            birthday,
-            false,
-        )
-        .await
-        {
-            Ok(l) => l,
-            Err(_) => {
-                panic!();
-            }
-        };
-        lightclient
-    }
     #[tokio::test]
     async fn report_zingolib_build_version() {
         // Use test in RustFFITest.kt as template
-        let abandon_art_seed =  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art".to_string();
         let server = "http://10.0.2.2:20000".to_string();
-        let chainhint = "main".to_string();
-        let birthday = 1u64;
         let datadir = "somedatadir".to_string();
-        let monitor_mempool = false;
-        let test_client = async_test_init_from_seed(
-            server,
-            abandon_art_seed,
-            birthday,
-            datadir,
-            chainhint,
-            monitor_mempool,
-        )
-        .await;
+        let chain_hint = "main".to_string();
+        let abandon_art_seed =  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art".to_string();
+        let wallet_base = WalletBase::from_string(abandon_art_seed);
+        let (config, _lightwalletd_uri);
+        match construct_uri_load_config(server, datadir, chain_hint, false) {
+            Ok((c, h)) => (config, _lightwalletd_uri) = (c, h),
+            Err(_) => panic!(),
+        }
+        let test_client = LightClient::create_unconnected(&config, wallet_base, 1)
+            .expect("To create a lightclient.");
         dbg!(test_client.do_info().await);
     }
 }

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -240,6 +240,7 @@ pub fn get_latest_block(server_uri: String) -> String {
 mod tests {
     use super::*;
     use zingolib::git_description;
+    #[ignore]
     #[tokio::test]
     async fn unconnected_client_framework() {
         // Use test in RustFFITest.kt as template

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -260,6 +260,6 @@ mod tests {
     }
     #[test]
     fn report_git_description() {
-        assert_eq!(git_description(), "foo");
+        assert!(git_description().starts_with("mob-release-"));
     }
 }

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -8,7 +8,7 @@ use base64::{decode, encode};
 
 use zingoconfig::construct_lightwalletd_uri;
 use zingolib::wallet::WalletBase;
-use zingolib::{commands, git_description, lightclient::LightClient};
+use zingolib::{commands, lightclient::LightClient};
 
 // We'll use a MUTEX to store a global lightclient instance,
 // so we don't have to keep creating it. We need to store it here, in rust
@@ -239,8 +239,9 @@ pub fn get_latest_block(server_uri: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zingolib::git_description;
     #[tokio::test]
-    async fn report_zingolib_build_version() {
+    async fn unconnected_client_framework() {
         // Use test in RustFFITest.kt as template
         let server = "http://10.0.2.2:20000".to_string();
         let datadir = "testdata".to_string();
@@ -257,7 +258,7 @@ mod tests {
         dbg!(test_client.do_info().await);
     }
     #[test]
-    fn report_git_decription() {
+    fn report_git_description() {
         assert_eq!(git_description(), "foo");
     }
 }


### PR DESCRIPTION
Running the new `command` in `zingolib` called: `version`.
But, for now `zingolib` gives an empty string... from mobile env.

@Oscar-Pepper did a integration test for this. We need to pass this test in order to merge this PR. The fix should come from `zingolib`.