### PR TITLE
Adding tx summaries

### DIFF
--- a/__tests__/History.TxDetail.unit.tsx
+++ b/__tests__/History.TxDetail.unit.tsx
@@ -79,41 +79,62 @@ describe('Component History TxDetail - test', () => {
   state.translate = () => 'translated text';
   const onClose = jest.fn();
   const onSetOption = jest.fn();
-  test('History TxDetail - normal sent transaction', () => {
+
+  test('History TxDetail - sent transaction with 2 addresses', () => {
     state.info.currencyName = 'ZEC';
     state.totalBalance.total = 1.12345678;
     const tx = {
       type: 'Sent',
-      address: 'UA-12345678901234567890',
-      amount: 0.0064,
       fee: 0.0001,
-      confirmations: 20,
-      txid: 'txid-1234567890',
+      confirmations: 22,
+      txid: 'sent-txid-1234567890',
       time: Date.now(),
       zec_price: 33.33,
+      txDetails: [
+        {
+          address: 'sent-address-1-12345678901234567890',
+          amount: 0.12345678,
+          memos: ['hola', '  & ', 'hello'],
+        },
+        {
+          address: 'sent-address-2-09876543210987654321',
+          amount: 0.1,
+          memos: ['hello', '  & ', 'hola'],
+        },
+      ],
     } as TransactionType;
     render(
       <ContextAppLoadedProvider value={state}>
         <TxDetail tx={tx} closeModal={onClose} set_privacy_option={onSetOption} />
       </ContextAppLoadedProvider>,
     ).toJSON();
-    const num = screen.getAllByText('0.0064');
-    expect(num.length).toBe(2);
+    screen.getByText('0.2234');
+    screen.getByText('0.1234');
+    screen.getByText('0.1000');
     screen.getByText('0.0001');
+    screen.getByText('hola & hello');
+    screen.getByText('hello & hola');
+    const txt = screen.queryByText('hola & hellohello & hola');
+    expect(txt).toBe(null);
   });
 
   test('History TxDetail - self sent transaction', () => {
     state.info.currencyName = 'ZEC';
     state.totalBalance.total = 1.12345678;
     const txSelfSend = {
-      type: 'Sent',
-      address: 'UA-12345678901234567890',
-      amount: 0,
+      type: 'SendToSelf',
       fee: 0.0001,
-      confirmations: 20,
-      txid: 'txid-1234567890',
+      confirmations: 12,
+      txid: 'sendtoself-txid-1234567890',
       time: Date.now(),
       zec_price: 33.33,
+      txDetails: [
+        {
+          address: '',
+          amount: 0,
+          memos: ['orchard memo', 'sapling memo'],
+        },
+      ],
     } as TransactionType;
     render(
       <ContextAppLoadedProvider value={state}>
@@ -122,7 +143,45 @@ describe('Component History TxDetail - test', () => {
     );
     const num = screen.getAllByText('0.0000');
     expect(num.length).toBe(2);
-    // because the negative symbol is not there.
     screen.getByText('0.0001');
+    screen.getByText('orchard memosapling memo');
+  });
+
+  test('History TxDetail - received transaction with 2 pools', () => {
+    state.info.currencyName = 'ZEC';
+    state.totalBalance.total = 1.12345678;
+    const txSelfSend = {
+      type: 'Received',
+      confirmations: 133,
+      txid: 'receive-txid-1234567890',
+      time: Date.now(),
+      zec_price: 66.66,
+      txDetails: [
+        {
+          address: '',
+          amount: 0.77654321,
+          pool: 'Orchard',
+          memos: ['hola', '  & ', 'hello'],
+        },
+        {
+          address: '',
+          amount: 0.1,
+          pool: 'Sapling',
+          memos: ['hello', '  & ', 'hola'],
+        },
+      ],
+    } as TransactionType;
+    render(
+      <ContextAppLoadedProvider value={state}>
+        <TxDetail tx={txSelfSend} closeModal={onClose} set_privacy_option={onSetOption} />
+      </ContextAppLoadedProvider>,
+    );
+    screen.getByText('0.8765');
+    screen.getByText('0.7765');
+    screen.getByText('0.1000');
+    screen.getByText('hola & hello');
+    screen.getByText('hello & hola');
+    const txt = screen.queryByText('hola & hellohello & hola');
+    expect(txt).toBe(null);
   });
 });

--- a/__tests__/History.TxDetail.unit.tsx
+++ b/__tests__/History.TxDetail.unit.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react-native';
 import TxDetail from '../components/History/components/TxDetail';
 import { defaultAppStateLoaded, ContextAppLoadedProvider } from '../app/context';
-import { TransactionType, TxDetailType } from '../app/AppState';
+import { TransactionType } from '../app/AppState';
 
 jest.useFakeTimers();
 jest.mock('@fortawesome/react-native-fontawesome', () => ({
@@ -83,28 +83,22 @@ describe('Component History TxDetail - test', () => {
     state.info.currencyName = 'ZEC';
     state.totalBalance.total = 1.12345678;
     const tx = {
-      type: 'sent',
+      type: 'Sent',
       address: 'UA-12345678901234567890',
-      amount: -0.0065,
-      position: '',
+      amount: 0.0064,
+      fee: 0.0001,
       confirmations: 20,
       txid: 'txid-1234567890',
       time: Date.now(),
       zec_price: 33.33,
-      detailedTxns: [
-        {
-          address: 'other-UA-12345678901234567890',
-          amount: 0.0064,
-          memo: 'memo-abcdefgh',
-        },
-      ] as TxDetailType[],
     } as TransactionType;
     render(
       <ContextAppLoadedProvider value={state}>
         <TxDetail tx={tx} closeModal={onClose} set_privacy_option={onSetOption} />
       </ContextAppLoadedProvider>,
     ).toJSON();
-    screen.getByText('0.0064');
+    const num = screen.getAllByText('0.0064');
+    expect(num.length).toBe(2);
     screen.getByText('0.0001');
   });
 
@@ -112,30 +106,23 @@ describe('Component History TxDetail - test', () => {
     state.info.currencyName = 'ZEC';
     state.totalBalance.total = 1.12345678;
     const txSelfSend = {
-      type: 'sent',
+      type: 'Sent',
       address: 'UA-12345678901234567890',
-      amount: -0.0001,
-      position: '',
+      amount: 0,
+      fee: 0.0001,
       confirmations: 20,
       txid: 'txid-1234567890',
       time: Date.now(),
       zec_price: 33.33,
-      detailedTxns: [
-        {
-          address: 'other-UA-12345678901234567890',
-          amount: 0.0064,
-          memo: 'memo-abcdefgh',
-        },
-      ] as TxDetailType[],
     } as TransactionType;
     render(
       <ContextAppLoadedProvider value={state}>
         <TxDetail tx={txSelfSend} closeModal={onClose} set_privacy_option={onSetOption} />
       </ContextAppLoadedProvider>,
     );
-    screen.getByText('0.0064');
-    // because the negative symbol is not there.
-    const num = screen.getAllByText('0.0001');
+    const num = screen.getAllByText('0.0000');
     expect(num.length).toBe(2);
+    // because the negative symbol is not there.
+    screen.getByText('0.0001');
   });
 });

--- a/__tests__/History.snapshot.tsx
+++ b/__tests__/History.snapshot.tsx
@@ -77,26 +77,24 @@ describe('Component History - test', () => {
   const state = defaultAppStateLoaded;
   state.transactions = [
     {
-      type: 'sent',
+      type: 'Sent',
       address: 'sent-address-12345678901234567890',
       amount: 0.12345678,
-      position: '',
+      fee: 0.0001,
       confirmations: 22,
       txid: 'sent-txid-1234567890',
       time: Date.now(),
       zec_price: 33.33,
-      detailedTxns: [],
     },
     {
-      type: 'receive',
+      type: 'Received',
       address: 'receive-address-12345678901234567890',
       amount: 0.87654321,
-      position: '',
+      pool: 'Orchard',
       confirmations: 133,
       txid: 'receive-txid-1234567890',
       time: Date.now(),
       zec_price: 66.66,
-      detailedTxns: [],
     },
   ];
   state.uaAddress = 'UA-12345678901234567890';

--- a/__tests__/History.snapshot.tsx
+++ b/__tests__/History.snapshot.tsx
@@ -78,23 +78,59 @@ describe('Component History - test', () => {
   state.transactions = [
     {
       type: 'Sent',
-      address: 'sent-address-12345678901234567890',
-      amount: 0.12345678,
       fee: 0.0001,
       confirmations: 22,
       txid: 'sent-txid-1234567890',
       time: Date.now(),
       zec_price: 33.33,
+      txDetails: [
+        {
+          address: 'sent-address-1-12345678901234567890',
+          amount: 0.12345678,
+          memos: ['hola', '  & ', 'hello'],
+        },
+        {
+          address: 'sent-address-2-09876543210987654321',
+          amount: 0,
+          memos: ['hello', '  & ', 'hola'],
+        },
+      ],
+    },
+    {
+      type: 'SendToSelf',
+      fee: 0.0001,
+      confirmations: 12,
+      txid: 'sendtoself-txid-1234567890',
+      time: Date.now(),
+      zec_price: 33.33,
+      txDetails: [
+        {
+          address: '',
+          amount: 0,
+          memos: ['orchard memo', 'sapling memo'],
+        },
+      ],
     },
     {
       type: 'Received',
-      address: 'receive-address-12345678901234567890',
-      amount: 0.87654321,
-      pool: 'Orchard',
       confirmations: 133,
       txid: 'receive-txid-1234567890',
       time: Date.now(),
       zec_price: 66.66,
+      txDetails: [
+        {
+          address: '',
+          amount: 0.77654321,
+          pool: 'Orchard',
+          memos: ['hola', '  & ', 'hello'],
+        },
+        {
+          address: '',
+          amount: 0.1,
+          pool: 'Sapling',
+          memos: ['hello', '  & ', 'hola'],
+        },
+      ],
     },
   ];
   state.uaAddress = 'UA-12345678901234567890';

--- a/__tests__/Send.snapshot.tsx
+++ b/__tests__/Send.snapshot.tsx
@@ -79,26 +79,24 @@ describe('Component Send - test', () => {
   const state = defaultAppStateLoaded;
   state.transactions = [
     {
-      type: 'sent',
+      type: 'Sent',
       address: 'sent-address-12345678901234567890',
       amount: 0.12345678,
-      position: '',
+      fee: 0.0001,
       confirmations: 22,
       txid: 'sent-txid-1234567890',
       time: Date.now(),
       zec_price: 33.33,
-      detailedTxns: [],
     },
     {
-      type: 'receive',
+      type: 'Received',
       address: 'receive-address-12345678901234567890',
       amount: 0.87654321,
-      position: '',
+      pool: 'Orchard',
       confirmations: 133,
       txid: 'receive-txid-1234567890',
       time: Date.now(),
       zec_price: 66.66,
-      detailedTxns: [],
     },
   ];
   state.uaAddress = 'UA-12345678901234567890';

--- a/__tests__/Send.snapshot.tsx
+++ b/__tests__/Send.snapshot.tsx
@@ -80,23 +80,59 @@ describe('Component Send - test', () => {
   state.transactions = [
     {
       type: 'Sent',
-      address: 'sent-address-12345678901234567890',
-      amount: 0.12345678,
       fee: 0.0001,
       confirmations: 22,
       txid: 'sent-txid-1234567890',
       time: Date.now(),
       zec_price: 33.33,
+      txDetails: [
+        {
+          address: 'sent-address-1-12345678901234567890',
+          amount: 0.12345678,
+          memos: ['hola', '  & ', 'hello'],
+        },
+        {
+          address: 'sent-address-2-09876543210987654321',
+          amount: 0,
+          memos: ['hello', '  & ', 'hola'],
+        },
+      ],
+    },
+    {
+      type: 'SendToSelf',
+      fee: 0.0001,
+      confirmations: 12,
+      txid: 'sendtoself-txid-1234567890',
+      time: Date.now(),
+      zec_price: 33.33,
+      txDetails: [
+        {
+          address: '',
+          amount: 0,
+          memos: ['orchard memo', 'sapling memo'],
+        },
+      ],
     },
     {
       type: 'Received',
-      address: 'receive-address-12345678901234567890',
-      amount: 0.87654321,
-      pool: 'Orchard',
       confirmations: 133,
       txid: 'receive-txid-1234567890',
       time: Date.now(),
       zec_price: 66.66,
+      txDetails: [
+        {
+          address: '',
+          amount: 0.77654321,
+          pool: 'Orchard',
+          memos: ['hola', '  & ', 'hello'],
+        },
+        {
+          address: '',
+          amount: 0.1,
+          pool: 'Sapling',
+          memos: ['hello', '  & ', 'hola'],
+        },
+      ],
     },
   ];
   state.uaAddress = 'UA-12345678901234567890';

--- a/__tests__/__snapshots__/History.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/History.snapshot.tsx.snap
@@ -728,7 +728,7 @@ exports[`Component History - test History currency USD, privacy high & mode adva
                   }
                 }
               >
-                sent-ad...4567890
+                sent-tx...4567890
               </Text>
               <View
                 style={
@@ -909,6 +909,245 @@ exports[`Component History - test History currency USD, privacy high & mode adva
           }
         }
         testID="transactionList.2"
+      >
+        <View
+          onPress={[Function]}
+        >
+          <View
+            style={
+              {
+                "borderBottomColor": "rgb(216, 216, 216)",
+                "borderBottomWidth": 1,
+                "display": "flex",
+                "flexDirection": "row",
+                "marginTop": 15,
+                "paddingBottom": 15,
+              }
+            }
+          >
+            <
+              color="rgb(28, 28, 30)"
+              icon={
+                {
+                  "icon": [
+                    384,
+                    512,
+                    [
+                      8593,
+                    ],
+                    "f062",
+                    "M214.6 41.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 141.2V448c0 17.7 14.3 32 32 32s32-14.3 32-32V141.2L329.4 246.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z",
+                  ],
+                  "iconName": "arrow-up",
+                  "prefix": "fas",
+                }
+              }
+              size={24}
+              style={
+                {
+                  "marginLeft": 5,
+                  "marginRight": 5,
+                  "marginTop": 5,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "display": "flex",
+                }
+              }
+            >
+              <Text
+                style={
+                  {
+                    "color": "rgb(28, 28, 30)",
+                    "fontSize": 18,
+                    "opacity": 0.65,
+                  }
+                }
+              >
+                sendtos...4567890
+              </Text>
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "opacity": 0.65,
+                    }
+                  }
+                >
+                  text translated
+                </Text>
+                <Text
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "opacity": 0.65,
+                    }
+                  }
+                >
+                  Dec 13, 8:00 am
+                </Text>
+              </View>
+            </View>
+            <View
+              style={
+                {
+                  "alignSelf": "baseline",
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "justifyContent": "flex-end",
+                  "margin": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <View
+                accessibilityState={
+                  {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "flex-end",
+                      "flexDirection": "row",
+                      "margin": 0,
+                      "padding": 0,
+                    }
+                  }
+                >
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight="18"
+                    bbWidth="36"
+                    fill="rgb(28, 28, 30)"
+                    focusable={false}
+                    height={18}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        {
+                          "marginBottom": 0.9,
+                        },
+                        {
+                          "flex": 0,
+                          "height": 18,
+                          "width": 36,
+                        },
+                      ]
+                    }
+                    vbHeight={147.85}
+                    vbWidth={282.84}
+                    width={36}
+                    xml="<?xml version="1.0" encoding="UTF-8"?>
+  <svg viewBox="0 0 282.84 147.85">
+    <polygon points="34.44 107.62 34.44 106.98 87.19 34.17 87.19 20.12 56.09 20.12 56.09 0 35.98 0 35.98 20.12 5.04 20.12 5.04 40.24 53.93 40.24 53.93 40.88 0 114.64 0 127.73 35.98 127.73 35.98 147.85 56.09 147.85 56.09 127.73 88.03 127.73 88.03 107.62 34.44 107.62"/>
+    <polygon points="180.89 39.03 180.89 19.35 124.56 19.35 110.48 19.35 102.52 19.35 102.52 127.75 110.48 127.75 124.56 127.75 180.89 127.75 180.89 108.07 124.56 108.07 124.56 83.77 172.04 83.77 172.04 64.09 124.56 64.09 124.56 39.03 180.89 39.03"/>
+    <path d="m240.92,128.87c-8.96,0-16.59-1.58-22.89-4.73-6.3-3.16-11.12-7.75-14.44-13.79-3.33-6.04-4.99-13.33-4.99-21.88v-29.75c0-8.6,1.66-15.9,4.99-21.92,3.33-6.01,8.14-10.61,14.44-13.79,6.3-3.18,13.93-4.77,22.89-4.77,7.4,0,13.99,1.47,19.75,4.4,5.77,2.93,10.54,7.18,14.32,12.75,3.78,5.57,6.4,12.33,7.85,20.28h-22.85c-.86-3.63-2.19-6.7-3.98-9.21-1.8-2.51-3.97-4.44-6.52-5.78-2.55-1.34-5.41-2.01-8.57-2.01-6.17,0-10.96,1.75-14.36,5.26-3.41,3.5-5.11,8.44-5.11,14.8v29.75c0,6.36,1.7,11.28,5.11,14.76,3.41,3.48,8.19,5.22,14.36,5.22,4.83,0,8.9-1.48,12.23-4.44,3.33-2.96,5.61-7.14,6.84-12.56h22.85c-1.5,7.9-4.14,14.65-7.93,20.24-3.78,5.59-8.54,9.85-14.28,12.79-5.74,2.93-12.31,4.4-19.71,4.4Z"/>
+  </svg>"
+                  >
+                    <RNSVGGroup
+                      fill={
+                        {
+                          "payload": 4280032286,
+                          "type": 0,
+                        }
+                      }
+                      propList={
+                        [
+                          "fill",
+                        ]
+                      }
+                    >
+                      <RNSVGPath
+                        d="M34.44 107.62 34.44 106.98 87.19 34.17 87.19 20.12 56.09 20.12 56.09 0 35.98 0 35.98 20.12 5.04 20.12 5.04 40.24 53.93 40.24 53.93 40.88 0 114.64 0 127.73 35.98 127.73 35.98 147.85 56.09 147.85 56.09 127.73 88.03 127.73 88.03 107.62 34.44 107.62z"
+                        fill={
+                          {
+                            "payload": 4278190080,
+                            "type": 0,
+                          }
+                        }
+                      />
+                      <RNSVGPath
+                        d="M180.89 39.03 180.89 19.35 124.56 19.35 110.48 19.35 102.52 19.35 102.52 127.75 110.48 127.75 124.56 127.75 180.89 127.75 180.89 108.07 124.56 108.07 124.56 83.77 172.04 83.77 172.04 64.09 124.56 64.09 124.56 39.03 180.89 39.03z"
+                        fill={
+                          {
+                            "payload": 4278190080,
+                            "type": 0,
+                          }
+                        }
+                      />
+                      <RNSVGPath
+                        d="m240.92,128.87c-8.96,0-16.59-1.58-22.89-4.73-6.3-3.16-11.12-7.75-14.44-13.79-3.33-6.04-4.99-13.33-4.99-21.88v-29.75c0-8.6,1.66-15.9,4.99-21.92,3.33-6.01,8.14-10.61,14.44-13.79,6.3-3.18,13.93-4.77,22.89-4.77,7.4,0,13.99,1.47,19.75,4.4,5.77,2.93,10.54,7.18,14.32,12.75,3.78,5.57,6.4,12.33,7.85,20.28h-22.85c-.86-3.63-2.19-6.7-3.98-9.21-1.8-2.51-3.97-4.44-6.52-5.78-2.55-1.34-5.41-2.01-8.57-2.01-6.17,0-10.96,1.75-14.36,5.26-3.41,3.5-5.11,8.44-5.11,14.8v29.75c0,6.36,1.7,11.28,5.11,14.76,3.41,3.48,8.19,5.22,14.36,5.22,4.83,0,8.9-1.48,12.23-4.44,3.33-2.96,5.61-7.14,6.84-12.56h22.85c-1.5,7.9-4.14,14.65-7.93,20.24-3.78,5.59-8.54,9.85-14.28,12.79-5.74,2.93-12.31,4.4-19.71,4.4Z"
+                        fill={
+                          {
+                            "payload": 4278190080,
+                            "type": 0,
+                          }
+                        }
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                  <Text
+                    style={
+                      {
+                        "color": "rgb(28, 28, 30)",
+                        "fontSize": 18,
+                        "fontWeight": "700",
+                        "margin": 0,
+                        "padding": 0,
+                      }
+                    }
+                  >
+                     -.----
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+        testID="transactionList.3"
       >
         <View
           onPress={[Function]}
@@ -1654,7 +1893,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                   }
                 }
               >
-                sent-ad...4567890
+                sent-tx...4567890
               </Text>
               <View
                 style={
@@ -1819,7 +2058,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                       }
                     }
                   >
-                     0.1234
+                     0.1235
                   </Text>
                   <Text
                     style={
@@ -1848,6 +2087,245 @@ exports[`Component History - test History no currency, privacy normal & mode bas
           }
         }
         testID="transactionList.2"
+      >
+        <View
+          onPress={[Function]}
+        >
+          <View
+            style={
+              {
+                "borderBottomColor": "rgb(216, 216, 216)",
+                "borderBottomWidth": 1,
+                "display": "flex",
+                "flexDirection": "row",
+                "marginTop": 15,
+                "paddingBottom": 15,
+              }
+            }
+          >
+            <
+              color="rgb(28, 28, 30)"
+              icon={
+                {
+                  "icon": [
+                    384,
+                    512,
+                    [
+                      8593,
+                    ],
+                    "f062",
+                    "M214.6 41.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 141.2V448c0 17.7 14.3 32 32 32s32-14.3 32-32V141.2L329.4 246.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z",
+                  ],
+                  "iconName": "arrow-up",
+                  "prefix": "fas",
+                }
+              }
+              size={24}
+              style={
+                {
+                  "marginLeft": 5,
+                  "marginRight": 5,
+                  "marginTop": 5,
+                }
+              }
+            />
+            <View
+              style={
+                {
+                  "display": "flex",
+                }
+              }
+            >
+              <Text
+                style={
+                  {
+                    "color": "rgb(28, 28, 30)",
+                    "fontSize": 18,
+                    "opacity": 0.65,
+                  }
+                }
+              >
+                sendtos...4567890
+              </Text>
+              <View
+                style={
+                  {
+                    "display": "flex",
+                    "flexDirection": "row",
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "opacity": 0.65,
+                    }
+                  }
+                >
+                  text translated
+                </Text>
+                <Text
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "opacity": 0.65,
+                    }
+                  }
+                >
+                  Dec 13, 8:00 am
+                </Text>
+              </View>
+            </View>
+            <View
+              style={
+                {
+                  "alignSelf": "baseline",
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "justifyContent": "flex-end",
+                  "margin": 5,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <View
+                accessibilityState={
+                  {
+                    "disabled": true,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "flex-end",
+                      "flexDirection": "row",
+                      "margin": 0,
+                      "padding": 0,
+                    }
+                  }
+                >
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight="18"
+                    bbWidth="36"
+                    fill="rgb(28, 28, 30)"
+                    focusable={false}
+                    height={18}
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        {
+                          "marginBottom": 0.9,
+                        },
+                        {
+                          "flex": 0,
+                          "height": 18,
+                          "width": 36,
+                        },
+                      ]
+                    }
+                    vbHeight={147.85}
+                    vbWidth={282.84}
+                    width={36}
+                    xml="<?xml version="1.0" encoding="UTF-8"?>
+  <svg viewBox="0 0 282.84 147.85">
+    <polygon points="34.44 107.62 34.44 106.98 87.19 34.17 87.19 20.12 56.09 20.12 56.09 0 35.98 0 35.98 20.12 5.04 20.12 5.04 40.24 53.93 40.24 53.93 40.88 0 114.64 0 127.73 35.98 127.73 35.98 147.85 56.09 147.85 56.09 127.73 88.03 127.73 88.03 107.62 34.44 107.62"/>
+    <polygon points="180.89 39.03 180.89 19.35 124.56 19.35 110.48 19.35 102.52 19.35 102.52 127.75 110.48 127.75 124.56 127.75 180.89 127.75 180.89 108.07 124.56 108.07 124.56 83.77 172.04 83.77 172.04 64.09 124.56 64.09 124.56 39.03 180.89 39.03"/>
+    <path d="m240.92,128.87c-8.96,0-16.59-1.58-22.89-4.73-6.3-3.16-11.12-7.75-14.44-13.79-3.33-6.04-4.99-13.33-4.99-21.88v-29.75c0-8.6,1.66-15.9,4.99-21.92,3.33-6.01,8.14-10.61,14.44-13.79,6.3-3.18,13.93-4.77,22.89-4.77,7.4,0,13.99,1.47,19.75,4.4,5.77,2.93,10.54,7.18,14.32,12.75,3.78,5.57,6.4,12.33,7.85,20.28h-22.85c-.86-3.63-2.19-6.7-3.98-9.21-1.8-2.51-3.97-4.44-6.52-5.78-2.55-1.34-5.41-2.01-8.57-2.01-6.17,0-10.96,1.75-14.36,5.26-3.41,3.5-5.11,8.44-5.11,14.8v29.75c0,6.36,1.7,11.28,5.11,14.76,3.41,3.48,8.19,5.22,14.36,5.22,4.83,0,8.9-1.48,12.23-4.44,3.33-2.96,5.61-7.14,6.84-12.56h22.85c-1.5,7.9-4.14,14.65-7.93,20.24-3.78,5.59-8.54,9.85-14.28,12.79-5.74,2.93-12.31,4.4-19.71,4.4Z"/>
+  </svg>"
+                  >
+                    <RNSVGGroup
+                      fill={
+                        {
+                          "payload": 4280032286,
+                          "type": 0,
+                        }
+                      }
+                      propList={
+                        [
+                          "fill",
+                        ]
+                      }
+                    >
+                      <RNSVGPath
+                        d="M34.44 107.62 34.44 106.98 87.19 34.17 87.19 20.12 56.09 20.12 56.09 0 35.98 0 35.98 20.12 5.04 20.12 5.04 40.24 53.93 40.24 53.93 40.88 0 114.64 0 127.73 35.98 127.73 35.98 147.85 56.09 147.85 56.09 127.73 88.03 127.73 88.03 107.62 34.44 107.62z"
+                        fill={
+                          {
+                            "payload": 4278190080,
+                            "type": 0,
+                          }
+                        }
+                      />
+                      <RNSVGPath
+                        d="M180.89 39.03 180.89 19.35 124.56 19.35 110.48 19.35 102.52 19.35 102.52 127.75 110.48 127.75 124.56 127.75 180.89 127.75 180.89 108.07 124.56 108.07 124.56 83.77 172.04 83.77 172.04 64.09 124.56 64.09 124.56 39.03 180.89 39.03z"
+                        fill={
+                          {
+                            "payload": 4278190080,
+                            "type": 0,
+                          }
+                        }
+                      />
+                      <RNSVGPath
+                        d="m240.92,128.87c-8.96,0-16.59-1.58-22.89-4.73-6.3-3.16-11.12-7.75-14.44-13.79-3.33-6.04-4.99-13.33-4.99-21.88v-29.75c0-8.6,1.66-15.9,4.99-21.92,3.33-6.01,8.14-10.61,14.44-13.79,6.3-3.18,13.93-4.77,22.89-4.77,7.4,0,13.99,1.47,19.75,4.4,5.77,2.93,10.54,7.18,14.32,12.75,3.78,5.57,6.4,12.33,7.85,20.28h-22.85c-.86-3.63-2.19-6.7-3.98-9.21-1.8-2.51-3.97-4.44-6.52-5.78-2.55-1.34-5.41-2.01-8.57-2.01-6.17,0-10.96,1.75-14.36,5.26-3.41,3.5-5.11,8.44-5.11,14.8v29.75c0,6.36,1.7,11.28,5.11,14.76,3.41,3.48,8.19,5.22,14.36,5.22,4.83,0,8.9-1.48,12.23-4.44,3.33-2.96,5.61-7.14,6.84-12.56h22.85c-1.5,7.9-4.14,14.65-7.93,20.24-3.78,5.59-8.54,9.85-14.28,12.79-5.74,2.93-12.31,4.4-19.71,4.4Z"
+                        fill={
+                          {
+                            "payload": 4278190080,
+                            "type": 0,
+                          }
+                        }
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                  <Text
+                    style={
+                      {
+                        "color": "rgb(28, 28, 30)",
+                        "fontSize": 18,
+                        "fontWeight": "700",
+                        "margin": 0,
+                        "padding": 0,
+                      }
+                    }
+                  >
+                     0.0001
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "display": "flex",
+            "flexDirection": "column",
+          }
+        }
+        testID="transactionList.3"
       >
         <View
           onPress={[Function]}

--- a/__tests__/__snapshots__/History.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/History.snapshot.tsx.snap
@@ -687,19 +687,19 @@ exports[`Component History - test History currency USD, privacy high & mode adva
             }
           >
             <
-              color="rgb(0, 122, 255)"
+              color="rgb(28, 28, 30)"
               icon={
                 {
                   "icon": [
                     384,
                     512,
                     [
-                      8595,
+                      8593,
                     ],
-                    "f063",
-                    "M169.4 470.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 370.8 224 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 306.7L54.6 265.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z",
+                    "f062",
+                    "M214.6 41.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 141.2V448c0 17.7 14.3 32 32 32s32-14.3 32-32V141.2L329.4 246.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z",
                   ],
-                  "iconName": "arrow-down",
+                  "iconName": "arrow-up",
                   "prefix": "fas",
                 }
               }
@@ -728,7 +728,7 @@ exports[`Component History - test History currency USD, privacy high & mode adva
                   }
                 }
               >
-                Unknown
+                sent-ad...4567890
               </Text>
               <View
                 style={
@@ -808,7 +808,7 @@ exports[`Component History - test History currency USD, privacy high & mode adva
                     align="xMidYMid"
                     bbHeight="18"
                     bbWidth="36"
-                    fill="rgb(0, 122, 255)"
+                    fill="rgb(28, 28, 30)"
                     focusable={false}
                     height={18}
                     meetOrSlice={0}
@@ -843,7 +843,7 @@ exports[`Component History - test History currency USD, privacy high & mode adva
                     <RNSVGGroup
                       fill={
                         {
-                          "payload": 4278221567,
+                          "payload": 4280032286,
                           "type": 0,
                         }
                       }
@@ -885,7 +885,7 @@ exports[`Component History - test History currency USD, privacy high & mode adva
                   <Text
                     style={
                       {
-                        "color": "rgb(0, 122, 255)",
+                        "color": "rgb(28, 28, 30)",
                         "fontSize": 18,
                         "fontWeight": "700",
                         "margin": 0,
@@ -967,7 +967,7 @@ exports[`Component History - test History currency USD, privacy high & mode adva
                   }
                 }
               >
-                Unknown
+                receive...4567890
               </Text>
               <View
                 style={
@@ -1613,19 +1613,19 @@ exports[`Component History - test History no currency, privacy normal & mode bas
             }
           >
             <
-              color="rgb(0, 122, 255)"
+              color="rgb(28, 28, 30)"
               icon={
                 {
                   "icon": [
                     384,
                     512,
                     [
-                      8595,
+                      8593,
                     ],
-                    "f063",
-                    "M169.4 470.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 370.8 224 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 306.7L54.6 265.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z",
+                    "f062",
+                    "M214.6 41.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 141.2V448c0 17.7 14.3 32 32 32s32-14.3 32-32V141.2L329.4 246.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z",
                   ],
-                  "iconName": "arrow-down",
+                  "iconName": "arrow-up",
                   "prefix": "fas",
                 }
               }
@@ -1654,7 +1654,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                   }
                 }
               >
-                Unknown
+                sent-ad...4567890
               </Text>
               <View
                 style={
@@ -1734,7 +1734,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                     align="xMidYMid"
                     bbHeight="18"
                     bbWidth="36"
-                    fill="rgb(0, 122, 255)"
+                    fill="rgb(28, 28, 30)"
                     focusable={false}
                     height={18}
                     meetOrSlice={0}
@@ -1769,7 +1769,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                     <RNSVGGroup
                       fill={
                         {
-                          "payload": 4278221567,
+                          "payload": 4280032286,
                           "type": 0,
                         }
                       }
@@ -1811,7 +1811,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                   <Text
                     style={
                       {
-                        "color": "rgb(0, 122, 255)",
+                        "color": "rgb(28, 28, 30)",
                         "fontSize": 18,
                         "fontWeight": "700",
                         "margin": 0,
@@ -1824,7 +1824,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                   <Text
                     style={
                       {
-                        "color": "rgb(0, 122, 255)",
+                        "color": "rgb(28, 28, 30)",
                         "fontSize": 12.6,
                         "margin": 0,
                         "marginBottom": 1.2,
@@ -1906,7 +1906,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                   }
                 }
               >
-                Unknown
+                receive...4567890
               </Text>
               <View
                 style={

--- a/app/AppState/types/TransactionType.ts
+++ b/app/AppState/types/TransactionType.ts
@@ -1,14 +1,16 @@
 import TxDetailType from './TxDetailType';
 
 export default interface TransactionType {
-  type: 'sent' | 'receive';
+  type: 'Sent' | 'Received';
   address: string;
   amount: number;
-  position: string;
+  fee?: number;
+  memos: string[];
+  position?: string;
   confirmations: number;
   txid: string;
   time: number;
-  zec_price: number;
-  detailedTxns: TxDetailType[];
+  zec_price: number | null;
+  detailedTxns?: TxDetailType[];
   // eslint-disable-next-line semi
 }

--- a/app/AppState/types/TransactionType.ts
+++ b/app/AppState/types/TransactionType.ts
@@ -1,17 +1,12 @@
 import TxDetailType from './TxDetailType';
 
 export default interface TransactionType {
-  type: 'Sent' | 'Received'; // like kind
-  address?: string;
-  amount: number;
+  type: 'Sent' | 'Received' | 'SendToSelf'; // like kind
   fee?: number;
-  memos?: string[];
-  position?: string;
   confirmations: number;
   txid: string;
   time: number;
-  zec_price?: number | null;
-  detailedTxns?: TxDetailType[];
-  pool?: 'Orchard' | 'Sapling' | 'Transparent';
+  zec_price?: number;
+  txDetails: TxDetailType[];
   // eslint-disable-next-line semi
 }

--- a/app/AppState/types/TransactionType.ts
+++ b/app/AppState/types/TransactionType.ts
@@ -1,16 +1,17 @@
 import TxDetailType from './TxDetailType';
 
 export default interface TransactionType {
-  type: 'Sent' | 'Received';
-  address: string;
+  type: 'Sent' | 'Received'; // like kind
+  address?: string;
   amount: number;
   fee?: number;
-  memos: string[];
+  memos?: string[];
   position?: string;
   confirmations: number;
   txid: string;
   time: number;
-  zec_price: number | null;
+  zec_price?: number | null;
   detailedTxns?: TxDetailType[];
+  pool?: 'Orchard' | 'Sapling' | 'Transparent';
   // eslint-disable-next-line semi
 }

--- a/app/AppState/types/TxDetailType.ts
+++ b/app/AppState/types/TxDetailType.ts
@@ -1,6 +1,7 @@
 export default interface TxDetailType {
   address: string;
   amount: number;
-  memo?: string;
+  memos?: string[];
+  pool?: 'Orchard' | 'Sapling' | 'Transparent';
   // eslint-disable-next-line semi
 }

--- a/app/rpc/RPC.ts
+++ b/app/rpc/RPC.ts
@@ -30,6 +30,7 @@ import { RPCGetOptionType } from './types/RPCGetOptionType';
 import { RPCSendProgressType } from './types/RPCSendProgressType';
 import { RPCSyncRescan } from './types/RPCSyncRescanType';
 import { RPCUfvkType } from './types/RPCUfvkType';
+import { RPCSummariesType } from './types/RPCSummariesType';
 
 export default class RPC {
   fnSetInfo: (info: InfoType) => void;
@@ -1292,7 +1293,12 @@ export default class RPC {
   // Fetch all T and Z and O transactions
   async fetchTandZandOTransactions() {
     try {
+      const summariesStr: string = await RPCModule.execute('summaries', '');
+      console.log(summariesStr);
+      const summariesJSON: RPCSummariesType[] = await JSON.parse(summariesStr);
+      console.log(summariesJSON);
       const listStr: string = await RPCModule.execute('list', '');
+      console.log(listStr);
       if (listStr) {
         if (listStr.toLowerCase().startsWith('error')) {
           console.log(`Error txs list ${listStr}`);

--- a/app/rpc/RPC.ts
+++ b/app/rpc/RPC.ts
@@ -1439,7 +1439,7 @@ export default class RPC {
           }
           let resttxlist: TransactionType[] = txlist.filter(t => t.txid !== tx.txid);
 
-          const type = tx.kind === 'Received' ? tx.kind : 'Sent';
+          const type = tx.kind === 'Received' ? 'Received' : 'Sent';
 
           //if (tx.txid === '55d6efcb987e8c6b8842a4c78d4adc80d8ca4761e3ff670a730e4840d8659ead') {
           //console.log('tran: ', tx);
@@ -1459,7 +1459,7 @@ export default class RPC {
             currenttxlist[0].type = type;
           }
           if (!currenttxlist[0].address) {
-            currenttxlist[0].address = tx.to_address ? tx.to_address : '';
+            currenttxlist[0].address = tx.to_address === 'none' ? undefined : tx.to_address;
           }
           if (tx.kind === 'Fee') {
             currenttxlist[0].fee = (currenttxlist[0].fee ? currenttxlist[0].fee : 0) + tx.amount / 10 ** 8;
@@ -1484,14 +1484,22 @@ export default class RPC {
           if (!currenttxlist[0].txid) {
             currenttxlist[0].txid = tx.txid;
           }
-          if (!currenttxlist[0].zec_price) {
-            currenttxlist[0].zec_price = tx.price;
-          }
           if (!currenttxlist[0].time) {
             currenttxlist[0].time = tx.datetime;
           }
+          if (!currenttxlist[0].zec_price) {
+            currenttxlist[0].zec_price = tx.price === 'none' ? null : tx.price;
+          }
           //currenttxlist[0].detailedTxns = txdetail;
-
+          if (!currenttxlist[0].pool) {
+            currenttxlist[0].pool = tx.pool === 'none' ? undefined : tx.pool;
+          } else {
+            if (currenttxlist[0].pool !== tx.pool) {
+              // have more than one item for different pools
+              // I'm going to concat those values for now.
+              currenttxlist[0].pool += '/' + tx.pool;
+            }
+          }
           txlist = [...currenttxlist, ...resttxlist];
         });
 

--- a/app/rpc/types/RPCSummariesType.ts
+++ b/app/rpc/types/RPCSummariesType.ts
@@ -2,10 +2,10 @@ export type RPCSummariesType = {
   block_height: number; // not using.
   datetime: number;
   txid: string;
-  price?: number | null | 'none';
+  price?: number | null | 'None';
   amount: number;
   to_address?: string;
   memos?: string[];
   kind: 'Sent' | 'Received' | 'SendToSelf' | 'Fee';
-  pool?: 'Orchard' | 'Sapling' | 'Transparent' | 'none';
+  pool?: 'Orchard' | 'Sapling' | 'Transparent' | 'None';
 };

--- a/app/rpc/types/RPCSummariesType.ts
+++ b/app/rpc/types/RPCSummariesType.ts
@@ -1,0 +1,11 @@
+export type RPCSummariesType = {
+  block_height: number;
+  datetime: number;
+  txid: string;
+  price: number | null;
+  amount: number;
+  to_address?: string;
+  memos?: string[];
+  kind: 'Sent' | 'Received' | 'SendToSelf' | 'Fee';
+  pool?: 'Orchard' | 'Sapling' | 'Transparent';
+};

--- a/app/rpc/types/RPCSummariesType.ts
+++ b/app/rpc/types/RPCSummariesType.ts
@@ -1,11 +1,11 @@
 export type RPCSummariesType = {
-  block_height: number;
+  block_height: number; // not using.
   datetime: number;
   txid: string;
-  price: number | null;
+  price?: number | null | 'none';
   amount: number;
   to_address?: string;
   memos?: string[];
   kind: 'Sent' | 'Received' | 'SendToSelf' | 'Fee';
-  pool?: 'Orchard' | 'Sapling' | 'Transparent';
+  pool?: 'Orchard' | 'Sapling' | 'Transparent' | 'none';
 };

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -321,7 +321,6 @@
     "private": "Private",
     "amountrevealed" : "Amount Revealed",
     "deshielded": "Deshielded"
-
   },
   "receive": {
     "u-title": "Unified Address",
@@ -372,6 +371,7 @@
     "back": " Back",
     "sent": "Sent ",
     "receive": "Receive ",
+    "sendtoself": "Send-to-Self ",
     "time": "Time",
     "confirmations": "Confirmations",
     "txid": "Transaction ID",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -273,7 +273,8 @@
     "seed-acc": "Seed Phrase Field",
     "birthday-acc": "Birthday Field",
     "tapreveal": "Tap to reveal",
-    "showtransactions": "Show Transactions"
+    "showtransactions": "Show Transactions",
+    "youreceived": "You received"
   },
   "send": {
     "Broadcast": "Successfully Broadcast Tx:",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -389,7 +389,8 @@
     "history": "History",
     "sure": "Sure? ",
     "minago": " min.",
-    "details": "Transaction Details"
+    "details": "Transaction Details",
+    "pool": "Pool"
   },
   "report": {
     "title": "Sync / Rescan Report",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -371,6 +371,7 @@
     "back": " Atrás",
     "sent": "Enviado ",
     "receive": "Recibido ",
+    "sendtoself": "Auto-Enviado ",
     "time": "Hora",
     "confirmations": "Confirmaciones",
     "txid": "Transacción ID",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -273,7 +273,8 @@
     "seed-acc": "Campo Frase Semilla",
     "birthday-acc": "Campo Cumpleaños",
     "tapreveal": "Pulsar para revelar",
-    "showtransactions": "Ver Transacciones"
+    "showtransactions": "Ver Transacciones",
+    "youreceived": "Recibiste"
   },
   "send": {
     "Broadcast": "Transmitida con éxito Tx:",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -388,7 +388,8 @@
     "history": "Histórico",
     "sure": "¿Seguro? ",
     "minago": " min.",
-    "details": "Detalles de la Transacción"
+    "details": "Detalles de la Transacción",
+    "pool": "Grupo"
   },
   "report": {
     "title": "Informe de Sincronización",

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -535,7 +535,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
         </View>
       )}
 
-      {receivedLegend && (
+      {receivedLegend && totalBalance.total > 0 && (
         <View
           style={{
             flexDirection: 'row',
@@ -544,7 +544,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
             margin: 0,
             marginTop: readOnly ? 15 : 0,
           }}>
-          <RegText color={colors.primary}>You received</RegText>
+          <RegText color={colors.primary}>{translate('seed.youreceived') as string}</RegText>
           <ZecAmount
             currencyName={info.currencyName ? info.currencyName : ''}
             color={colors.primary}

--- a/components/History/components/TxDetail.tsx
+++ b/components/History/components/TxDetail.tsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 import 'moment/locale/es';
 import { useTheme } from '@react-navigation/native';
 
-import { TransactionType, TxDetailType } from '../../../app/AppState';
+import { TransactionType } from '../../../app/AppState';
 import Utils from '../../../app/utils';
 import RegText from '../../Components/RegText';
 import ZecAmount from '../../Components/ZecAmount';
@@ -16,6 +16,7 @@ import { ThemeType } from '../../../app/types';
 import { ContextAppLoaded } from '../../../app/context';
 import Header from '../../Header';
 import BoldText from '../../Components/BoldText';
+import CurrencyAmount from '../../Components/CurrencyAmount';
 
 type TxDetailProps = {
   tx: TransactionType;
@@ -25,11 +26,14 @@ type TxDetailProps = {
 
 const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_privacy_option }) => {
   const context = useContext(ContextAppLoaded);
-  const { info, translate, language, privacy, addLastSnackbar, server } = context;
+  const { info, translate, language, privacy, addLastSnackbar, server, currency } = context;
   const { colors } = useTheme() as unknown as ThemeType;
   const spendColor =
-    tx.confirmations === 0 ? colors.primaryDisabled : (tx.amount || 0) > 0 ? colors.primary : colors.text;
-
+    tx.confirmations === 0 ? colors.primaryDisabled : tx.type === 'Received' ? colors.primary : colors.text;
+  let numLines = 1;
+  if (tx.address) {
+    numLines = tx.address.length < 40 ? 2 : tx.address.length / 30;
+  }
   const [expandAddress, setExpandAddress] = useState(false);
   const [expandTxid, setExpandTxid] = useState(false);
   moment.locale(language);
@@ -109,6 +113,9 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
             privacy={privacy}
             smallPrefix={true}
           />
+          {!!tx.zec_price && (
+            <CurrencyAmount price={tx.zec_price} amtZec={tx.amount} currency={currency} privacy={privacy} />
+          )}
         </View>
 
         <View style={{ margin: 10 }}>
@@ -154,6 +161,56 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
             </TouchableOpacity>
           </View>
 
+          {!!tx.address && (
+            <View style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', marginTop: 10 }}>
+              <FadeText>{translate('history.address') as string}</FadeText>
+              <TouchableOpacity
+                onPress={() => {
+                  if (tx.address) {
+                    Clipboard.setString(tx.address);
+                    addLastSnackbar({
+                      message: translate('history.addresscopied') as string,
+                      type: 'Primary',
+                      duration: 'short',
+                    });
+                    setExpandAddress(true);
+                  }
+                }}>
+                <View style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
+                  {!tx.address && <RegText>{'Unknown'}</RegText>}
+                  {!expandAddress && !!tx.address && <RegText>{Utils.trimToSmall(tx.address, 10)}</RegText>}
+                  {expandAddress &&
+                    !!tx.address &&
+                    Utils.splitStringIntoChunks(tx.address, Number(numLines.toFixed(0))).map(
+                      (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
+                    )}
+                </View>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {!!tx.pool && (
+            <View style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', marginTop: 10 }}>
+              <FadeText>{translate('history.pool') as string}</FadeText>
+              <RegText>{tx.pool}</RegText>
+            </View>
+          )}
+
+          <View style={{ marginTop: 10 }}>
+            <FadeText>{translate('history.amount') as string}</FadeText>
+            <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
+              <ZecAmount
+                amtZec={tx.amount}
+                size={18}
+                currencyName={info.currencyName ? info.currencyName : ''}
+                privacy={privacy}
+              />
+              {!!tx.zec_price && (
+                <CurrencyAmount price={tx.zec_price} amtZec={tx.amount} currency={currency} privacy={privacy} />
+              )}
+            </View>
+          </View>
+
           {!!tx.fee && tx.fee > 0 && (
             <View style={{ display: 'flex', marginTop: 10 }}>
               <FadeText>{translate('history.txfee') as string}</FadeText>
@@ -197,84 +254,6 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
                           }
                         }}>
                         <RegText>{memo}</RegText>
-                      </TouchableOpacity>
-                    </View>
-                  )}
-                </View>
-              );
-            })}
-
-          {tx.detailedTxns &&
-            tx.detailedTxns.map((txd: TxDetailType) => {
-              // 30 characters per line
-              const numLines = txd.address.length < 40 ? 2 : txd.address.length / 30;
-
-              return (
-                <View
-                  key={txd.address}
-                  style={{
-                    display: 'flex',
-                    marginTop: 10,
-                    paddingBottom: 15,
-                    borderTopColor: colors.card,
-                    borderTopWidth: 1,
-                    borderBottomColor: colors.card,
-                    borderBottomWidth: 1,
-                  }}>
-                  <View style={{ marginTop: 10 }}>
-                    <FadeText>{translate('history.address') as string}</FadeText>
-
-                    <TouchableOpacity
-                      onPress={() => {
-                        if (txd.address) {
-                          Clipboard.setString(txd.address);
-                          addLastSnackbar({
-                            message: translate('history.addresscopied') as string,
-                            type: 'Primary',
-                            duration: 'short',
-                          });
-                          setExpandAddress(true);
-                        }
-                      }}>
-                      <View style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
-                        {!txd.address && <RegText>{'Unknown'}</RegText>}
-                        {!expandAddress && !!txd.address && <RegText>{Utils.trimToSmall(txd.address, 10)}</RegText>}
-                        {expandAddress &&
-                          !!txd.address &&
-                          Utils.splitStringIntoChunks(txd.address, Number(numLines.toFixed(0))).map(
-                            (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
-                          )}
-                      </View>
-                    </TouchableOpacity>
-                  </View>
-
-                  <View style={{ marginTop: 10 }}>
-                    <FadeText>{translate('history.amount') as string}</FadeText>
-                    <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
-                      <ZecAmount
-                        amtZec={txd.amount}
-                        size={18}
-                        currencyName={info.currencyName ? info.currencyName : ''}
-                        privacy={privacy}
-                      />
-                    </View>
-                  </View>
-
-                  {txd.memo && (
-                    <View style={{ marginTop: 10 }}>
-                      <FadeText>{translate('history.memo') as string}</FadeText>
-                      <TouchableOpacity
-                        onPress={() => {
-                          if (txd.memo) {
-                            Clipboard.setString(txd.memo);
-                            addLastSnackbar({
-                              message: translate('history.memocopied') as string,
-                              type: 'Primary',
-                              duration: 'short',
-                            });
-                          }
-                        }}>
-                        <RegText>{txd.memo}</RegText>
                       </TouchableOpacity>
                     </View>
                   )}

--- a/components/History/components/TxDetail.tsx
+++ b/components/History/components/TxDetail.tsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 import 'moment/locale/es';
 import { useTheme } from '@react-navigation/native';
 
-import { TransactionType } from '../../../app/AppState';
+import { TransactionType, TxDetailType } from '../../../app/AppState';
 import Utils from '../../../app/utils';
 import RegText from '../../Components/RegText';
 import ZecAmount from '../../Components/ZecAmount';
@@ -30,26 +30,9 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
   const { colors } = useTheme() as unknown as ThemeType;
   const spendColor =
     tx.confirmations === 0 ? colors.primaryDisabled : tx.type === 'Received' ? colors.primary : colors.text;
-  let numLines = 1;
-  if (tx.address) {
-    numLines = tx.address.length < 40 ? 2 : tx.address.length / 30;
-  }
   const [expandAddress, setExpandAddress] = useState(false);
   const [expandTxid, setExpandTxid] = useState(false);
   moment.locale(language);
-
-  //const sum =
-  //  (tx.detailedTxns && tx.detailedTxns.reduce((s: number, d: TxDetailType) => s + (d.amount ? d.amount : 0), 0)) || 0;
-  //let fee = 0;
-  // normal case: spend 1600 fee 1000 sent 600
-  //if (tx.type === 'Sent' && Math.abs(tx.amount) > Math.abs(sum)) {
-  //  fee = Math.abs(tx.amount) - Math.abs(sum);
-  //}
-  // self-send case: spend 1000 fee 1000 sent 0
-  // this is temporary until we have a new field in 'list' object, called: fee.
-  //if (tx.type === 'Sent' && Math.abs(tx.amount) <= Math.abs(sum)) {
-  //  fee = Math.abs(tx.amount);
-  //}
 
   const handleTxIDClick = (txid?: string) => {
     if (!txid) {
@@ -103,18 +86,26 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
             borderColor: colors.border,
           }}>
           <BoldText style={{ textAlign: 'center', textTransform: 'capitalize', color: spendColor }}>
-            {!!tx.type &&
-              (tx.type === 'Sent' ? (translate('history.sent') as string) : (translate('history.receive') as string))}
+            {tx.type === 'Sent'
+              ? (translate('history.sent') as string)
+              : tx.type === 'Received'
+              ? (translate('history.receive') as string)
+              : (translate('history.sendtoself') as string)}
           </BoldText>
           <ZecAmount
             currencyName={info.currencyName ? info.currencyName : ''}
             size={36}
-            amtZec={Math.abs(tx.amount)}
+            amtZec={tx.txDetails.reduce((s, d) => s + d.amount, 0)}
             privacy={privacy}
             smallPrefix={true}
           />
           {!!tx.zec_price && (
-            <CurrencyAmount price={tx.zec_price} amtZec={tx.amount} currency={currency} privacy={privacy} />
+            <CurrencyAmount
+              price={tx.zec_price}
+              amtZec={tx.txDetails.reduce((s, d) => s + d.amount, 0)}
+              currency={currency}
+              privacy={privacy}
+            />
           )}
         </View>
 
@@ -161,56 +152,6 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
             </TouchableOpacity>
           </View>
 
-          {!!tx.address && (
-            <View style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', marginTop: 10 }}>
-              <FadeText>{translate('history.address') as string}</FadeText>
-              <TouchableOpacity
-                onPress={() => {
-                  if (tx.address) {
-                    Clipboard.setString(tx.address);
-                    addLastSnackbar({
-                      message: translate('history.addresscopied') as string,
-                      type: 'Primary',
-                      duration: 'short',
-                    });
-                    setExpandAddress(true);
-                  }
-                }}>
-                <View style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
-                  {!tx.address && <RegText>{'Unknown'}</RegText>}
-                  {!expandAddress && !!tx.address && <RegText>{Utils.trimToSmall(tx.address, 10)}</RegText>}
-                  {expandAddress &&
-                    !!tx.address &&
-                    Utils.splitStringIntoChunks(tx.address, Number(numLines.toFixed(0))).map(
-                      (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
-                    )}
-                </View>
-              </TouchableOpacity>
-            </View>
-          )}
-
-          {!!tx.pool && (
-            <View style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', marginTop: 10 }}>
-              <FadeText>{translate('history.pool') as string}</FadeText>
-              <RegText>{tx.pool}</RegText>
-            </View>
-          )}
-
-          <View style={{ marginTop: 10 }}>
-            <FadeText>{translate('history.amount') as string}</FadeText>
-            <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
-              <ZecAmount
-                amtZec={tx.amount}
-                size={18}
-                currencyName={info.currencyName ? info.currencyName : ''}
-                privacy={privacy}
-              />
-              {!!tx.zec_price && (
-                <CurrencyAmount price={tx.zec_price} amtZec={tx.amount} currency={currency} privacy={privacy} />
-              )}
-            </View>
-          </View>
-
           {!!tx.fee && tx.fee > 0 && (
             <View style={{ display: 'flex', marginTop: 10 }}>
               <FadeText>{translate('history.txfee') as string}</FadeText>
@@ -225,41 +166,90 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
             </View>
           )}
 
-          {tx.memos &&
-            tx.memos.map((memo: string) => {
-              return (
-                <View
-                  key={memo}
-                  style={{
-                    display: 'flex',
-                    marginTop: 10,
-                    paddingBottom: 15,
-                    borderTopColor: colors.card,
-                    borderTopWidth: 1,
-                    borderBottomColor: colors.card,
-                    borderBottomWidth: 1,
-                  }}>
-                  {!!memo && (
-                    <View style={{ marginTop: 10 }}>
-                      <FadeText>{translate('history.memo') as string}</FadeText>
-                      <TouchableOpacity
-                        onPress={() => {
-                          if (memo) {
-                            Clipboard.setString(memo);
-                            addLastSnackbar({
-                              message: translate('history.memocopied') as string,
-                              type: 'Primary',
-                              duration: 'short',
-                            });
-                          }
-                        }}>
-                        <RegText>{memo}</RegText>
-                      </TouchableOpacity>
-                    </View>
-                  )}
+          {tx.txDetails.map((txd: TxDetailType) => {
+            // 30 characters per line
+            const numLines = txd.address ? (txd.address.length < 40 ? 2 : txd.address.length / 30) : 0;
+
+            return (
+              <View
+                key={txd.address + txd.pool}
+                style={{
+                  display: 'flex',
+                  paddingBottom: 15,
+                  borderTopColor: colors.text,
+                  borderTopWidth: tx.txDetails.length > 1 ? 1 : 0,
+                }}>
+                {!!txd.address && (
+                  <View style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', marginTop: 10 }}>
+                    <FadeText>{translate('history.address') as string}</FadeText>
+                    <TouchableOpacity
+                      onPress={() => {
+                        if (txd.address) {
+                          Clipboard.setString(txd.address);
+                          addLastSnackbar({
+                            message: translate('history.addresscopied') as string,
+                            type: 'Primary',
+                            duration: 'short',
+                          });
+                          setExpandAddress(true);
+                        }
+                      }}>
+                      <View style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
+                        {!txd.address && <RegText>{'Unknown'}</RegText>}
+                        {!expandAddress && !!txd.address && <RegText>{Utils.trimToSmall(txd.address, 10)}</RegText>}
+                        {expandAddress &&
+                          !!txd.address &&
+                          Utils.splitStringIntoChunks(txd.address, Number(numLines.toFixed(0))).map(
+                            (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
+                          )}
+                      </View>
+                    </TouchableOpacity>
+                  </View>
+                )}
+
+                {!!txd.pool && (
+                  <View style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', marginTop: 10 }}>
+                    <FadeText>{translate('history.pool') as string}</FadeText>
+                    <RegText>{txd.pool}</RegText>
+                  </View>
+                )}
+
+                <View style={{ marginTop: 10 }}>
+                  <FadeText>{translate('history.amount') as string}</FadeText>
+                  <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <ZecAmount
+                      amtZec={txd.amount}
+                      size={18}
+                      currencyName={info.currencyName ? info.currencyName : ''}
+                      privacy={privacy}
+                    />
+                    {!!tx.zec_price && (
+                      <CurrencyAmount price={tx.zec_price} amtZec={txd.amount} currency={currency} privacy={privacy} />
+                    )}
+                  </View>
                 </View>
-              );
-            })}
+
+                {txd.memos && (
+                  <View style={{ marginTop: 10 }}>
+                    <FadeText>{translate('history.memo') as string}</FadeText>
+                    <TouchableOpacity
+                      onPress={() => {
+                        if (txd.memos) {
+                          Clipboard.setString(txd.memos.join(''));
+                          addLastSnackbar({
+                            message: translate('history.memocopied') as string,
+                            type: 'Primary',
+                            duration: 'short',
+                          });
+                        }
+                      }}>
+                      <RegText>{txd.memos.join('')}</RegText>
+                    </TouchableOpacity>
+                  </View>
+                )}
+              </View>
+            );
+          })}
         </View>
       </ScrollView>
       <View style={{ flexGrow: 1, flexDirection: 'row', justifyContent: 'center', alignItems: 'center', margin: 10 }}>

--- a/components/History/components/TxDetail.tsx
+++ b/components/History/components/TxDetail.tsx
@@ -34,18 +34,18 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
   const [expandTxid, setExpandTxid] = useState(false);
   moment.locale(language);
 
-  const sum =
-    (tx.detailedTxns && tx.detailedTxns.reduce((s: number, d: TxDetailType) => s + (d.amount ? d.amount : 0), 0)) || 0;
-  let fee = 0;
+  //const sum =
+  //  (tx.detailedTxns && tx.detailedTxns.reduce((s: number, d: TxDetailType) => s + (d.amount ? d.amount : 0), 0)) || 0;
+  //let fee = 0;
   // normal case: spend 1600 fee 1000 sent 600
-  if (tx.type === 'sent' && Math.abs(tx.amount) > Math.abs(sum)) {
-    fee = Math.abs(tx.amount) - Math.abs(sum);
-  }
+  //if (tx.type === 'Sent' && Math.abs(tx.amount) > Math.abs(sum)) {
+  //  fee = Math.abs(tx.amount) - Math.abs(sum);
+  //}
   // self-send case: spend 1000 fee 1000 sent 0
   // this is temporary until we have a new field in 'list' object, called: fee.
-  if (tx.type === 'sent' && Math.abs(tx.amount) <= Math.abs(sum)) {
-    fee = Math.abs(tx.amount);
-  }
+  //if (tx.type === 'Sent' && Math.abs(tx.amount) <= Math.abs(sum)) {
+  //  fee = Math.abs(tx.amount);
+  //}
 
   const handleTxIDClick = (txid?: string) => {
     if (!txid) {
@@ -100,7 +100,7 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
           }}>
           <BoldText style={{ textAlign: 'center', textTransform: 'capitalize', color: spendColor }}>
             {!!tx.type &&
-              (tx.type === 'sent' ? (translate('history.sent') as string) : (translate('history.receive') as string))}
+              (tx.type === 'Sent' ? (translate('history.sent') as string) : (translate('history.receive') as string))}
           </BoldText>
           <ZecAmount
             currencyName={info.currencyName ? info.currencyName : ''}
@@ -154,12 +154,12 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
             </TouchableOpacity>
           </View>
 
-          {fee > 0 && (
+          {!!tx.fee && tx.fee > 0 && (
             <View style={{ display: 'flex', marginTop: 10 }}>
               <FadeText>{translate('history.txfee') as string}</FadeText>
               <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
                 <ZecAmount
-                  amtZec={fee}
+                  amtZec={tx.fee}
                   size={18}
                   currencyName={info.currencyName ? info.currencyName : ''}
                   privacy={privacy}
@@ -168,82 +168,119 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
             </View>
           )}
 
-          {tx.detailedTxns.map((txd: TxDetailType) => {
-            // 30 characters per line
-            const numLines = txd.address.length < 40 ? 2 : txd.address.length / 30;
-
-            return (
-              <View
-                key={txd.address}
-                style={{
-                  display: 'flex',
-                  marginTop: 10,
-                  paddingBottom: 15,
-                  borderTopColor: colors.card,
-                  borderTopWidth: 1,
-                  borderBottomColor: colors.card,
-                  borderBottomWidth: 1,
-                }}>
-                <View style={{ marginTop: 10 }}>
-                  <FadeText>{translate('history.address') as string}</FadeText>
-
-                  <TouchableOpacity
-                    onPress={() => {
-                      if (txd.address) {
-                        Clipboard.setString(txd.address);
-                        addLastSnackbar({
-                          message: translate('history.addresscopied') as string,
-                          type: 'Primary',
-                          duration: 'short',
-                        });
-                        setExpandAddress(true);
-                      }
-                    }}>
-                    <View style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
-                      {!txd.address && <RegText>{'Unknown'}</RegText>}
-                      {!expandAddress && !!txd.address && <RegText>{Utils.trimToSmall(txd.address, 10)}</RegText>}
-                      {expandAddress &&
-                        !!txd.address &&
-                        Utils.splitStringIntoChunks(txd.address, Number(numLines.toFixed(0))).map(
-                          (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
-                        )}
+          {tx.memos &&
+            tx.memos.map((memo: string) => {
+              return (
+                <View
+                  key={memo}
+                  style={{
+                    display: 'flex',
+                    marginTop: 10,
+                    paddingBottom: 15,
+                    borderTopColor: colors.card,
+                    borderTopWidth: 1,
+                    borderBottomColor: colors.card,
+                    borderBottomWidth: 1,
+                  }}>
+                  {!!memo && (
+                    <View style={{ marginTop: 10 }}>
+                      <FadeText>{translate('history.memo') as string}</FadeText>
+                      <TouchableOpacity
+                        onPress={() => {
+                          if (memo) {
+                            Clipboard.setString(memo);
+                            addLastSnackbar({
+                              message: translate('history.memocopied') as string,
+                              type: 'Primary',
+                              duration: 'short',
+                            });
+                          }
+                        }}>
+                        <RegText>{memo}</RegText>
+                      </TouchableOpacity>
                     </View>
-                  </TouchableOpacity>
+                  )}
                 </View>
+              );
+            })}
 
-                <View style={{ marginTop: 10 }}>
-                  <FadeText>{translate('history.amount') as string}</FadeText>
-                  <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <ZecAmount
-                      amtZec={txd.amount}
-                      size={18}
-                      currencyName={info.currencyName ? info.currencyName : ''}
-                      privacy={privacy}
-                    />
-                  </View>
-                </View>
+          {tx.detailedTxns &&
+            tx.detailedTxns.map((txd: TxDetailType) => {
+              // 30 characters per line
+              const numLines = txd.address.length < 40 ? 2 : txd.address.length / 30;
 
-                {txd.memo && (
+              return (
+                <View
+                  key={txd.address}
+                  style={{
+                    display: 'flex',
+                    marginTop: 10,
+                    paddingBottom: 15,
+                    borderTopColor: colors.card,
+                    borderTopWidth: 1,
+                    borderBottomColor: colors.card,
+                    borderBottomWidth: 1,
+                  }}>
                   <View style={{ marginTop: 10 }}>
-                    <FadeText>{translate('history.memo') as string}</FadeText>
+                    <FadeText>{translate('history.address') as string}</FadeText>
+
                     <TouchableOpacity
                       onPress={() => {
-                        if (txd.memo) {
-                          Clipboard.setString(txd.memo);
+                        if (txd.address) {
+                          Clipboard.setString(txd.address);
                           addLastSnackbar({
-                            message: translate('history.memocopied') as string,
+                            message: translate('history.addresscopied') as string,
                             type: 'Primary',
                             duration: 'short',
                           });
+                          setExpandAddress(true);
                         }
                       }}>
-                      <RegText>{txd.memo}</RegText>
+                      <View style={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
+                        {!txd.address && <RegText>{'Unknown'}</RegText>}
+                        {!expandAddress && !!txd.address && <RegText>{Utils.trimToSmall(txd.address, 10)}</RegText>}
+                        {expandAddress &&
+                          !!txd.address &&
+                          Utils.splitStringIntoChunks(txd.address, Number(numLines.toFixed(0))).map(
+                            (c: string, idx: number) => <RegText key={idx}>{c}</RegText>,
+                          )}
+                      </View>
                     </TouchableOpacity>
                   </View>
-                )}
-              </View>
-            );
-          })}
+
+                  <View style={{ marginTop: 10 }}>
+                    <FadeText>{translate('history.amount') as string}</FadeText>
+                    <View style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
+                      <ZecAmount
+                        amtZec={txd.amount}
+                        size={18}
+                        currencyName={info.currencyName ? info.currencyName : ''}
+                        privacy={privacy}
+                      />
+                    </View>
+                  </View>
+
+                  {txd.memo && (
+                    <View style={{ marginTop: 10 }}>
+                      <FadeText>{translate('history.memo') as string}</FadeText>
+                      <TouchableOpacity
+                        onPress={() => {
+                          if (txd.memo) {
+                            Clipboard.setString(txd.memo);
+                            addLastSnackbar({
+                              message: translate('history.memocopied') as string,
+                              type: 'Primary',
+                              duration: 'short',
+                            });
+                          }
+                        }}>
+                        <RegText>{txd.memo}</RegText>
+                      </TouchableOpacity>
+                    </View>
+                  )}
+                </View>
+              );
+            })}
         </View>
       </ScrollView>
       <View style={{ flexGrow: 1, flexDirection: 'row', justifyContent: 'center', alignItems: 'center', margin: 10 }}>

--- a/components/History/components/TxDetail.tsx
+++ b/components/History/components/TxDetail.tsx
@@ -175,6 +175,7 @@ const TxDetail: React.FunctionComponent<TxDetailProps> = ({ tx, closeModal, set_
                 key={txd.address + txd.pool}
                 style={{
                   display: 'flex',
+                  marginTop: tx.txDetails.length > 1 ? 10 : 0,
                   paddingBottom: 15,
                   borderTopColor: colors.text,
                   borderTopWidth: tx.txDetails.length > 1 ? 1 : 0,

--- a/components/History/components/TxSummaryLine.tsx
+++ b/components/History/components/TxSummaryLine.tsx
@@ -34,9 +34,9 @@ const TxSummaryLine: React.FunctionComponent<TxSummaryLineProps> = ({
   const { colors } = useTheme() as unknown as ThemeType;
 
   const amountColor =
-    tx.confirmations === 0 ? colors.primaryDisabled : (tx.amount || 0) > 0 ? colors.primary : colors.text;
+    tx.confirmations === 0 ? colors.primaryDisabled : tx.type === 'Received' ? colors.primary : colors.text;
 
-  const txIcon = tx.confirmations === 0 ? faRefresh : (tx.amount || 0) >= 0 ? faArrowDown : faArrowUp;
+  const txIcon = tx.confirmations === 0 ? faRefresh : tx.type === 'Received' ? faArrowDown : faArrowUp;
   moment.locale(language);
 
   const displayAddress =
@@ -86,7 +86,7 @@ const TxSummaryLine: React.FunctionComponent<TxSummaryLineProps> = ({
             <FadeText style={{ fontSize: 18 }}>{displayAddress}</FadeText>
             <View style={{ display: 'flex', flexDirection: 'row' }}>
               <FadeText>
-                {tx.type === 'sent' ? (translate('history.sent') as string) : (translate('history.receive') as string)}
+                {tx.type === 'Sent' ? (translate('history.sent') as string) : (translate('history.receive') as string)}
               </FadeText>
               <FadeText>{tx.time ? moment((tx.time || 0) * 1000).format('MMM D, h:mm a') : '--'}</FadeText>
             </View>

--- a/components/History/components/TxSummaryLine.tsx
+++ b/components/History/components/TxSummaryLine.tsx
@@ -39,10 +39,8 @@ const TxSummaryLine: React.FunctionComponent<TxSummaryLineProps> = ({
   const txIcon = tx.confirmations === 0 ? faRefresh : tx.type === 'Received' ? faArrowDown : faArrowUp;
   moment.locale(language);
 
-  const displayAddress =
-    tx.detailedTxns && tx.detailedTxns.length > 0 && tx.detailedTxns[0].address
-      ? Utils.trimToSmall(tx.detailedTxns[0].address, 7)
-      : 'Unknown';
+  // if no address I'm going to put txid here.
+  const displayAddress = tx.address ? Utils.trimToSmall(tx.address, 7) : Utils.trimToSmall(tx.txid, 7);
 
   //console.log('render TxSummaryLine - 5', index);
 

--- a/components/History/components/TxSummaryLine.tsx
+++ b/components/History/components/TxSummaryLine.tsx
@@ -40,7 +40,10 @@ const TxSummaryLine: React.FunctionComponent<TxSummaryLineProps> = ({
   moment.locale(language);
 
   // if no address I'm going to put txid here.
-  const displayAddress = tx.address ? Utils.trimToSmall(tx.address, 7) : Utils.trimToSmall(tx.txid, 7);
+  const displayAddress =
+    tx.txDetails.length === 1 && tx.txDetails[0].address
+      ? Utils.trimToSmall(tx.txDetails[0].address, 7)
+      : Utils.trimToSmall(tx.txid, 7);
 
   //console.log('render TxSummaryLine - 5', index);
 
@@ -84,7 +87,11 @@ const TxSummaryLine: React.FunctionComponent<TxSummaryLineProps> = ({
             <FadeText style={{ fontSize: 18 }}>{displayAddress}</FadeText>
             <View style={{ display: 'flex', flexDirection: 'row' }}>
               <FadeText>
-                {tx.type === 'Sent' ? (translate('history.sent') as string) : (translate('history.receive') as string)}
+                {tx.type === 'Sent'
+                  ? (translate('history.sent') as string)
+                  : tx.type === 'Received'
+                  ? (translate('history.receive') as string)
+                  : (translate('history.sendtoself') as string)}
               </FadeText>
               <FadeText>{tx.time ? moment((tx.time || 0) * 1000).format('MMM D, h:mm a') : '--'}</FadeText>
             </View>
@@ -94,7 +101,7 @@ const TxSummaryLine: React.FunctionComponent<TxSummaryLineProps> = ({
             size={18}
             currencyName={info.currencyName ? info.currencyName : ''}
             color={amountColor}
-            amtZec={tx.amount}
+            amtZec={tx.txDetails.reduce((s, d) => s + d.amount, 0) + (tx.fee ? tx.fee : 0)}
             privacy={privacy}
           />
         </View>

--- a/components/Seed/Seed.tsx
+++ b/components/Seed/Seed.tsx
@@ -254,7 +254,7 @@ const Seed: React.FunctionComponent<SeedProps> = ({ onClickOK, onClickCancel, ac
             netInfo={netInfo}
             mode={mode}
             addLastSnackbar={addLastSnackbar}
-            receivedLegend={!basicFirstViewSeed}
+            receivedLegend={action === 'view' ? !basicFirstViewSeed : false}
           />
         </View>
       </Animated.View>

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -953,7 +953,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2061,8 +2061,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
- "bytes 1.4.0",
- "prost-derive 0.11.9",
+ "bytes 1.5.0",
+ "prost-derive 0.12.1",
 ]
 
 [[package]]
@@ -2390,7 +2390,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes 1.5.0",
  "encoding_rs",
  "futures-core",
@@ -2457,21 +2457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
-dependencies = [
- "bitflags 2.4.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
- "time 0.3.28",
-]
-
-[[package]]
 name = "rust"
 version = "1.0.1"
 dependencies = [
@@ -2507,7 +2492,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.31",
+ "syn 2.0.37",
  "walkdir",
 ]
 
@@ -2546,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.11"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2737,14 +2722,14 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -2939,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2985,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -3009,7 +2994,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3113,7 +3098,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3314,7 +3299,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3531,7 +3516,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -3565,7 +3550,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3799,6 +3784,8 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "group 0.13.0",
+ "hdwallet",
+ "hex 0.4.3",
  "incrementalmerkletree",
  "memuse",
  "nom",
@@ -3913,7 +3900,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -953,7 +953,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2061,8 +2061,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
- "bytes 1.5.0",
- "prost-derive 0.12.1",
+ "bytes 1.4.0",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -2390,8 +2390,8 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.4",
- "bytes 1.5.0",
+ "base64 0.21.3",
+ "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2457,6 +2457,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+dependencies = [
+ "bitflags 2.4.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "time 0.3.28",
+]
+
+[[package]]
 name = "rust"
 version = "1.0.1"
 dependencies = [
@@ -2492,7 +2507,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.37",
+ "syn 2.0.29",
  "walkdir",
 ]
 
@@ -2722,7 +2737,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2924,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2994,7 +3009,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3098,7 +3113,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3299,7 +3314,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3516,7 +3531,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -3550,7 +3565,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3784,8 +3799,6 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "group 0.13.0",
- "hdwallet",
- "hex 0.4.3",
  "incrementalmerkletree",
  "memuse",
  "nom",
@@ -3900,7 +3913,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -953,7 +953,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -2391,7 +2391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64 0.21.3",
- "bytes 1.4.0",
+ "bytes 1.5.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2507,7 +2507,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.29",
+ "syn 2.0.31",
  "walkdir",
 ]
 
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2737,14 +2737,14 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -2939,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3009,7 +3009,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3113,7 +3113,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3314,7 +3314,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3531,7 +3531,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
  "wasm-bindgen-shared",
 ]
 
@@ -3565,7 +3565,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3913,7 +3913,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]


### PR DESCRIPTION
I'm migrating from `list` to `summaries` (both commands).

Comments:
- I can see more than 1 items for the same `txid`, in these cases I sum the amount, sum the fees and sum the memos arrays in only one tx with the `txid`.
- I can see some `txid` only with one item with `Fee` kind, I guess the amount is 0.
- BUG: In the `SendToSelf` kind txs I can see a second item with the same `txid` with a fee with an astronomic value... something happen here.
- in `SendToSelf` txs I can see the value `None` in `pool`, `price` & `to_address`, I don't think `None` is the best value for those fields in this case... maybe remove those fields, or use `null` like price when in other cases have no value.
- I see the field `to_address` always empty. I'm using old wallets.
- I assume that all of this tx are automatically `confirmmed`... or I have to use some new confirmation rule for this?
- I assume the kinds `SendToSelf` & `Sent` are the same in zingo-mobile -> `Sent`.
- I'm going to put the `address` in the summary line as always and if no `address`, then I'm going to put the `txid`
- If the tx is of `Received` kind... I'm going to put the `pool` as well.
- I can see the orchard balance wrong, I t seems like the old shieldings were no effect... (this is from other command `balance` and it is related with the new sync feature shardtree...)

@AloeareV @zancas 