### PR TITLE
A couple of UI issues fixed in send screen

### DIFF
--- a/__tests__/__snapshots__/About.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/About.snapshot.tsx.snap
@@ -63,6 +63,7 @@ exports[`Component About - test About - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/__tests__/__snapshots__/Header.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Header.snapshot.tsx.snap
@@ -252,6 +252,7 @@ exports[`Component Header - test Header Complex - snapshot 1`] = `
           "color": "rgb(28, 28, 30)",
           "fontSize": 18,
           "fontWeight": "600",
+          "marginBottom": 3,
           "opacity": 1,
           "paddingHorizontal": 5,
         }
@@ -411,6 +412,7 @@ exports[`Component Header - test Header Simple - snapshot 1`] = `
           "color": "rgb(28, 28, 30)",
           "fontSize": 18,
           "fontWeight": "600",
+          "marginBottom": 3,
           "opacity": 1,
           "paddingHorizontal": 5,
         }

--- a/__tests__/__snapshots__/History.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/History.snapshot.tsx.snap
@@ -511,6 +511,7 @@ exports[`Component History - test History currency USD, privacy high & mode adva
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }
@@ -1676,6 +1677,7 @@ exports[`Component History - test History no currency, privacy normal & mode bas
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/__tests__/__snapshots__/Info.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Info.snapshot.tsx.snap
@@ -63,6 +63,7 @@ exports[`Component Info - test Info - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/__tests__/__snapshots__/Insight.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Insight.snapshot.tsx.snap
@@ -63,6 +63,7 @@ exports[`Component Insight - test Insight - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/__tests__/__snapshots__/Pools.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Pools.snapshot.tsx.snap
@@ -63,6 +63,7 @@ exports[`Component Pools - test Pools - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/__tests__/__snapshots__/PrivKey.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/PrivKey.snapshot.tsx.snap
@@ -63,6 +63,7 @@ exports[`Component PrivKey - test PrivKey Private - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }
@@ -415,6 +416,7 @@ exports[`Component PrivKey - test PrivKey View - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/__tests__/__snapshots__/Rescan.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Rescan.snapshot.tsx.snap
@@ -63,6 +63,7 @@ exports[`Component Rescan - test Rescan - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/__tests__/__snapshots__/ShowUfvk.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/ShowUfvk.snapshot.tsx.snap
@@ -63,6 +63,7 @@ exports[`Component ShowUfvk - test ShowUfvk - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/__tests__/__snapshots__/SyncReport.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/SyncReport.snapshot.tsx.snap
@@ -63,6 +63,7 @@ exports[`Component SyncReport - test SyncReport - snapshot 1`] = `
             "color": "rgb(28, 28, 30)",
             "fontSize": 18,
             "fontWeight": "600",
+            "marginBottom": 3,
             "opacity": 1,
             "paddingHorizontal": 5,
           }

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -923,6 +923,8 @@ export class LoadedAppClass extends Component<LoadedAppClassProps, AppStateLoade
     await SettingsFileImpl.writeSettings(name, value);
     this.setState({
       mode: value as 'basic' | 'advanced',
+      poolsToShieldSelectSapling: true,
+      poolsToShieldSelectTransparent: true,
     });
 
     // Refetch the settings to update

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -748,7 +748,7 @@ const Header: React.FunctionComponent<HeaderProps> = ({
           justifyContent: 'center',
           flexWrap: 'wrap',
         }}>
-        <RegText testID={testID} color={colors.money} style={{ paddingHorizontal: 5 }}>
+        <RegText testID={testID} color={colors.money} style={{ paddingHorizontal: 5, marginBottom: 3 }}>
           {title}
         </RegText>
       </View>

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-native/no-inline-styles */
 import React, { useState, useEffect, useRef, useCallback, useContext } from 'react';
-import { View, ScrollView, Modal, Keyboard, TextInput, TouchableOpacity, Platform } from 'react-native';
+import { View, ScrollView, Modal, Keyboard, TextInput, TouchableOpacity, Platform, Alert } from 'react-native';
 import { faQrcode, faCheck, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { useTheme, useIsFocused } from '@react-navigation/native';
@@ -82,6 +82,8 @@ const Send: React.FunctionComponent<SendProps> = ({
   const [validAddress, setValidAddress] = useState(0); // 1 - OK, 0 - Empty, -1 - KO
   const [validAmount, setValidAmount] = useState(0); // 1 - OK, 0 - Empty, -1 - KO
   const [sendButtonEnabled, setSendButtonEnabled] = useState(false);
+  const [basicModeStep, setBasicModeStep] = useState(0);
+  const [withTip, setWithTip] = useState(false);
   const isFocused = useIsFocused();
 
   const slideAnim = useRef(new Animated.Value(0)).current;
@@ -436,12 +438,37 @@ const Send: React.FunctionComponent<SendProps> = ({
   useEffect(() => {
     (async () => {
       if (isFocused) {
+        // basic mode & step 0
+        if (mode === 'basic' && basicModeStep === 0) {
+          Alert.alert(
+            translate('send.xxxx') as string,
+            translate('send.yyyyyy') as string,
+            [
+              {
+                text: translate('send.sendpay') as string,
+                onPress: () => {
+                  setWithTip(false);
+                  setBasicModeStep(1);
+                },
+              },
+              {
+                text: translate('send.sendpaywithtip') as string,
+                onPress: () => {
+                  setWithTip(true);
+                  setBasicModeStep(1);
+                },
+              },
+              { text: translate('cancel') as string, style: 'cancel' },
+            ],
+            { cancelable: true, userInterfaceStyle: 'light' },
+          );
+        }
         await RPC.rpc_setInterruptSyncAfterBatch('true');
       } else {
         await RPC.rpc_setInterruptSyncAfterBatch('false');
       }
     })();
-  }, [isFocused]);
+  }, [basicModeStep, isFocused, mode, translate]);
 
   //console.log('render Send - 4');
 

--- a/components/Send/components/ScannerAddress.tsx
+++ b/components/Send/components/ScannerAddress.tsx
@@ -14,10 +14,15 @@ type ScannerAddressProps = {
     memo: string | null,
     includeUAMemo: boolean | null,
   ) => void;
-  closeModal: () => void;
+  closeModalOK: () => void;
+  closeModalCancel: () => void;
 };
 
-const ScannerAddress: React.FunctionComponent<ScannerAddressProps> = ({ updateToField, closeModal }) => {
+const ScannerAddress: React.FunctionComponent<ScannerAddressProps> = ({
+  updateToField,
+  closeModalOK,
+  closeModalCancel,
+}) => {
   const context = useContext(ContextAppLoaded);
   const { translate, netInfo, server, addLastSnackbar } = context;
   const validateAddress = async (scannedAddress: string) => {
@@ -27,7 +32,7 @@ const ScannerAddress: React.FunctionComponent<ScannerAddressProps> = ({ updateTo
     }
     if (scannedAddress.startsWith('zcash:')) {
       updateToField(scannedAddress, null, null, null, null);
-      closeModal();
+      closeModalOK();
       return;
     }
 
@@ -55,7 +60,7 @@ const ScannerAddress: React.FunctionComponent<ScannerAddressProps> = ({ updateTo
 
     if (valid) {
       updateToField(scannedAddress, null, null, null, null);
-      closeModal();
+      closeModalOK();
     }
   };
 
@@ -66,7 +71,7 @@ const ScannerAddress: React.FunctionComponent<ScannerAddressProps> = ({ updateTo
   };
 
   const doCancel = () => {
-    closeModal();
+    closeModalCancel();
   };
 
   return (


### PR DESCRIPTION
Two enhancements:
- Adding another text `spendable` for dollars, same as ZEC. The users usually get confused about this dollar amount.
- Make everything clickable when the Keyboard is open. (send, seed, ufvk & settings) 

Working on a new send flow for basic users, because that screen is really hard to understand.