### PR TITLE
Nextest partitioning ci - integration Tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   build-test-artifacts:
     name: Build test artifacts
-    runs-on: ubuntu-22.04
+    runs-on: macos-12
     env:
       RUSTFLAGS: -D warnings
     steps:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: nextest-archive
-          path: nextest-archive.tar.zst
+          path: ./rust/nextest-archive.tar.zst
 
   prep-integration-test:
     name: Preparing integration test
@@ -161,7 +161,6 @@ jobs:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Download archive
-        working-directory: ./rust
         uses: actions/download-artifact@v3
         with:
           name: nextest-archive

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -167,6 +167,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Docker
+        uses: actions/setup-docker@v3
+        with:
+          docker-version: 'latest'
+
       - name: Symlink lightwalletd and zcash binaries
         run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./zingocli/regtest/bin/
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -55,7 +55,7 @@ jobs:
     needs: build-test-artifacts
     strategy:
       matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8]
+        partition: [1, 2, 3]
     steps:
       - name: Set envs for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
+        runs:
+          using: "node16"
         with:
           toolchain: stable
           override: true
@@ -142,6 +144,8 @@ jobs:
         run: docker pull zingodevops/regchest:003
 
       - uses: actions-rs/toolchain@v1
+        runs:
+          using: "node16"
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -20,6 +20,9 @@ env:
   REPO-OWNER: ${{ github.repository_owner }}
   RUSTFLAGS: -D warnings
 
+runs:
+  using: "node16"
+
 jobs:
   build-test-artifacts:
     name: Build test artifacts
@@ -29,8 +32,6 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
-        runs:
-          using: "node16"
         with:
           toolchain: stable
           override: true
@@ -144,8 +145,6 @@ jobs:
         run: docker pull zingodevops/regchest:003
 
       - uses: actions-rs/toolchain@v1
-        runs:
-          using: "node16"
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -45,6 +45,7 @@ jobs:
         run: cargo nextest archive --verbose --workspace --all-features --archive-file nextest-archive.tar.zst
 
       - name: Upload archive
+        working-directory: ./rust
         uses: actions/upload-artifact@v3
         with:
           name: nextest-archive
@@ -160,6 +161,7 @@ jobs:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Download archive
+        working-directory: ./rust
         uses: actions/download-artifact@v3
         with:
           name: nextest-archive

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -23,6 +23,9 @@ jobs:
   integration-test:
     name: Integration test
     runs-on: macos-12
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Set envs for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}
@@ -120,9 +123,17 @@ jobs:
           max_attempts: 3
           command: ./scripts/integration_tests.sh -a ${{ env.AVD-ARCH }} -s
 
+      - name: Build and archive tests
+        run: cargo nextest archive --verbose --workspace --features "ci regchest" \
+          --archive-file nextest-archive.tar.zst
+
       - name: Run integration tests
         working-directory: ./rust
         run: cargo nextest run ${{ env.NEXTEST-ABI }} --profile ci --features "ci regchest"
+        run: |
+          cargo nextest run ${{ env.NEXTEST-ABI }} --verbose --profile ci \
+            --archive-file nextest-archive.tar.zst --features "ci regchest" \
+            --workspace-remap ./ --partition count:${{ matrix.partition}}/8
 
       - name: Upload test reports
         if: ${{ ! cancelled() }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -163,7 +163,7 @@ jobs:
         run: |
           cargo nextest run ${{ env.NEXTEST-ABI }} --verbose --profile ci \
             --archive-file ./../nextest-archive.tar.zst \
-            --workspace-remap ./ --partition count:${{ matrix.partition}}/8
+            --workspace-remap ./ --partition count:${{ matrix.partition}}/3
 
       - name: Upload test reports
         if: ${{ ! cancelled() }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v3
         with:
-          name: nextest-archive
+          name: nextest-archive-${{ env.ABI }}
           path: ./rust/nextest-archive.tar.zst
 
   integration-test:
@@ -156,7 +156,7 @@ jobs:
       - name: Download archive
         uses: actions/download-artifact@v3
         with:
-          name: nextest-archive
+          name: nextest-archive-${{ env.ABI }}
 
       - name: Run integration tests
         working-directory: ./rust

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -88,26 +88,6 @@ jobs:
           echo "AVD-ARCH=x86" >> $GITHUB_ENV
           echo "NEXTEST-ABI=arm32" >> $GITHUB_ENV
 
-      - name: Install docker
-        run: |
-          brew install docker
-          colima start
-
-      - name: Pull regchest docker image
-        run: docker pull zingodevops/regchest:003
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Cargo cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Native rust cache
         uses: actions/cache@v3
         with:
@@ -157,9 +137,6 @@ jobs:
     needs: prep-integration-test
     env:
       RUSTFLAGS: -D warnings
-    container:
-      image: zingodevops/ci-build:002
-      options: --security-opt seccomp=unconfined
     strategy:
       matrix:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
@@ -167,10 +144,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Docker
-        uses: actions/setup-docker@v3
+      - name: Install docker
+        run: |
+          brew install docker
+          colima start
+
+      - name: Pull regchest docker image
+        run: docker pull zingodevops/regchest:003
+
+      - uses: actions-rs/toolchain@v1
         with:
-          docker-version: 'latest'
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Symlink lightwalletd and zcash binaries
         run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./zingocli/regtest/bin/

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -45,7 +45,6 @@ jobs:
         run: cargo nextest archive --verbose --workspace --all-features --archive-file nextest-archive.tar.zst
 
       - name: Upload archive
-        working-directory: ./rust
         uses: actions/upload-artifact@v3
         with:
           name: nextest-archive

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -173,7 +173,7 @@ jobs:
         working-directory: ./rust
         run: |
           cargo nextest run ${{ env.NEXTEST-ABI }} --verbose --profile ci \
-            --archive-file ./../nextest-archive.tar.zst --features "ci regchest" \
+            --archive-file ./../nextest-archive.tar.zst \
             --workspace-remap ./ --partition count:${{ matrix.partition}}/8
 
       - name: Upload test reports

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -20,13 +20,12 @@ env:
   REPO-OWNER: ${{ github.repository_owner }}
   RUSTFLAGS: -D warnings
 
-runs:
-  using: "node16"
-
 jobs:
   build-test-artifacts:
     name: Build test artifacts
     runs-on: macos-12
+    runs:
+      using: "node16"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -59,6 +58,8 @@ jobs:
     strategy:
       matrix:
         partition: [1, 2, 3]
+    runs:
+      using: "node16"
     steps:
       - name: Set envs for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -18,13 +18,12 @@ env:
   TIMESTAMP: ${{ inputs.timestamp }}
   ABI: ${{ inputs.abi }}
   REPO-OWNER: ${{ github.repository_owner }}
+  RUSTFLAGS: -D warnings
 
 jobs:
   build-test-artifacts:
     name: Build test artifacts
     runs-on: macos-12
-    env:
-      RUSTFLAGS: -D warnings
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -50,10 +49,13 @@ jobs:
           name: nextest-archive
           path: ./rust/nextest-archive.tar.zst
 
-  prep-integration-test:
-    name: Preparing integration test
+  integration-test:
+    name: Integration test
     runs-on: macos-12
     needs: build-test-artifacts
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Set envs for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}
@@ -130,19 +132,6 @@ jobs:
           timeout_minutes: 60
           max_attempts: 3
           command: ./scripts/integration_tests.sh -a ${{ env.AVD-ARCH }} -s
-
-  integration-test:
-    name: Integration test
-    runs-on: macos-12
-    needs: prep-integration-test
-    env:
-      RUSTFLAGS: -D warnings
-    strategy:
-      matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
 
       - name: Install docker
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -155,17 +155,30 @@ jobs:
     name: Integration test
     runs-on: macos-12
     needs: prep-integration-test
+    env:
+      RUSTFLAGS: -D warnings
+    container:
+      image: zingodevops/ci-build:002
+      options: --security-opt seccomp=unconfined
     strategy:
       matrix:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Symlink lightwalletd and zcash binaries
+        run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./zingocli/regtest/bin/
+
+      - name: Symlink zcash parameters
+        run: ln -s /root/.zcash-params /github/home
+
       - name: Download archive
         uses: actions/download-artifact@v3
         with:
           name: nextest-archive
 
       - name: Run integration tests
-        working-directory: ./rust
         run: |
           cargo nextest run ${{ env.NEXTEST-ABI }} --verbose --profile ci \
             --archive-file nextest-archive.tar.zst --features "ci regchest" \

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -41,8 +41,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build and archive tests
-        run: cargo nextest archive --verbose --workspace --features "ci regchest" \
-          --archive-file nextest-archive.tar.zst
+        run: cargo nextest archive --verbose --workspace --all-features --archive-file nextest-archive.tar.zst
 
       - name: Upload archive
         uses: actions/upload-artifact@v3
@@ -50,18 +49,10 @@ jobs:
           name: nextest-archive
           path: nextest-archive.tar.zst
 
-  integration-test:
-    name: Integration test
+  prep-integration-test:
+    name: Preparing integration test
     runs-on: macos-12
     needs: build-test-artifacts
-    env:
-      RUSTFLAGS: -D warnings
-    container:
-      image: zingodevops/ci-build:002
-      options: --security-opt seccomp=unconfined
-    strategy:
-      matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Set envs for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}
@@ -159,6 +150,14 @@ jobs:
           max_attempts: 3
           command: ./scripts/integration_tests.sh -a ${{ env.AVD-ARCH }} -s
 
+  integration-test:
+    name: Integration test
+    runs-on: macos-12
+    needs: prep-integration-test
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
       - name: Download archive
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -184,9 +184,10 @@ jobs:
           name: nextest-archive
 
       - name: Run integration tests
+        working-directory: ./rust
         run: |
           cargo nextest run ${{ env.NEXTEST-ABI }} --verbose --profile ci \
-            --archive-file nextest-archive.tar.zst --features "ci regchest" \
+            --archive-file ./../nextest-archive.tar.zst --features "ci regchest" \
             --workspace-remap ./ --partition count:${{ matrix.partition}}/8
 
       - name: Upload test reports

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -129,7 +129,6 @@ jobs:
 
       - name: Run integration tests
         working-directory: ./rust
-        run: cargo nextest run ${{ env.NEXTEST-ABI }} --profile ci --features "ci regchest"
         run: |
           cargo nextest run ${{ env.NEXTEST-ABI }} --verbose --profile ci \
             --archive-file nextest-archive.tar.zst --features "ci regchest" \

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build and archive tests
+        working-directory: ./rust
         run: cargo nextest archive --verbose --workspace --all-features --archive-file nextest-archive.tar.zst
 
       - name: Upload archive

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -164,12 +164,6 @@ jobs:
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Symlink lightwalletd and zcash binaries
-        run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./zingocli/regtest/bin/
-
-      - name: Symlink zcash parameters
-        run: ln -s /root/.zcash-params /github/home
-
       - name: Download archive
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,8 +24,6 @@ jobs:
   build-test-artifacts:
     name: Build test artifacts
     runs-on: macos-12
-    runs:
-      using: "node16"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -58,8 +56,6 @@ jobs:
     strategy:
       matrix:
         partition: [1, 2, 3]
-    runs:
-      using: "node16"
     steps:
       - name: Set envs for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -20,9 +20,45 @@ env:
   REPO-OWNER: ${{ github.repository_owner }}
 
 jobs:
+  build-test-artifacts:
+    name: Build test artifacts
+    runs-on: ubuntu-22.04
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build and archive tests
+        run: cargo nextest archive --verbose --workspace --features "ci regchest" \
+          --archive-file nextest-archive.tar.zst
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: nextest-archive
+          path: nextest-archive.tar.zst
+
   integration-test:
     name: Integration test
     runs-on: macos-12
+    needs: build-test-artifacts
+    env:
+      RUSTFLAGS: -D warnings
+    container:
+      image: zingodevops/ci-build:002
+      options: --security-opt seccomp=unconfined
     strategy:
       matrix:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
@@ -123,9 +159,10 @@ jobs:
           max_attempts: 3
           command: ./scripts/integration_tests.sh -a ${{ env.AVD-ARCH }} -s
 
-      - name: Build and archive tests
-        run: cargo nextest archive --verbose --workspace --features "ci regchest" \
-          --archive-file nextest-archive.tar.zst
+      - name: Download archive
+        uses: actions/download-artifact@v3
+        with:
+          name: nextest-archive
 
       - name: Run integration tests
         working-directory: ./rust


### PR DESCRIPTION
I'm using only three partitions since there are only three Tests:
- OfflineTest suite (with three tests)
- ExecuteSyncFromSeed
- ExecuteSendFromOrchard

You can see the result here: https://github.com/juanky201271/zingo-mobile/actions/runs/6291915543

I don't know why the OfflineTest is a group of 3 tests... I'm thinking maybe it's better if I change a little bit the `integration_test.rc` and run the 5 test, and this way I can actually use 5 partitions and could be faster.

@Oscar-Pepper Please take a look at this and tell what do you think...