### PR TITLE
Using node 16 with actions-rust-lang/setup-rust-toolchain@v1

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,10 +28,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          override: true
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -141,11 +140,9 @@ jobs:
       - name: Pull regchest docker image
         run: docker pull zingodevops/regchest:003
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
Avoiding this warning: `The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/`