### PR TITLE
Summaries -> only fee assume sendtoself

### DIFF
--- a/app/rpc/RPC.ts
+++ b/app/rpc/RPC.ts
@@ -1411,7 +1411,8 @@ export default class RPC {
           if (tx.kind === 'Fee') {
             currentTxList[0].fee = (currentTxList[0].fee ? currentTxList[0].fee : 0) + tx.amount / 10 ** 8;
             if (currentTxList[0].txDetails.length === 0) {
-              // when only have 1 item with `Fee`, we assume this tx is `Sent`.
+              // when only have 1 item with `Fee`, we assume this tx is `SendToSelf`.
+              currentTxList[0].type = 'SendToSelf';
               currenttxdetails.address = '';
               currenttxdetails.amount = 0;
               currentTxList[0].txDetails.push(currenttxdetails);


### PR DESCRIPTION
Really simple change.

In summaries if we got only one item for a txid, and this item is fee, we can assume this is a `sendToSelf` transaction...