### PR TITLE
New zingolib version & openssl 3.1.3 updated & create build_andoid 007 docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,6 @@ jobs:
         if: ${{ env.ARCH == 'x86_64' }}
         run: |
           echo "TARGET=x86_64-linux-android" >> $GITHUB_ENV
-          echo "RUSTFLAGS=" >> $GITHUB_ENV
           echo "CC=x86_64-linux-android" >> $GITHUB_ENV
           echo "OPENSSL_PATH=x86_64" >> $GITHUB_ENV
       
@@ -82,7 +81,6 @@ jobs:
         if: ${{ env.ARCH == 'x86' }}
         run: |
           echo "TARGET=i686-linux-android" >> $GITHUB_ENV
-          echo "RUSTFLAGS=-Clink-arg=-latomic" >> $GITHUB_ENV
           echo "CC=i686-linux-android" >> $GITHUB_ENV
           echo "OPENSSL_PATH=x86" >> $GITHUB_ENV
       
@@ -90,7 +88,6 @@ jobs:
         if: ${{ env.ARCH == 'arm64-v8a' }}
         run: |
           echo "TARGET=aarch64-linux-android" >> $GITHUB_ENV
-          echo "RUSTFLAGS=" >> $GITHUB_ENV
           echo "CC=aarch64-linux-android" >> $GITHUB_ENV
           echo "OPENSSL_PATH=aarch64" >> $GITHUB_ENV
       
@@ -98,7 +95,6 @@ jobs:
         if: ${{ env.ARCH == 'armeabi-v7a' }}
         run: |
           echo "TARGET=armv7-linux-androideabi" >> $GITHUB_ENV
-          echo "RUSTFLAGS=" >> $GITHUB_ENV
           echo "CC=armv7a-linux-androideabi" >> $GITHUB_ENV
           echo "OPENSSL_PATH=armv7" >> $GITHUB_ENV
       
@@ -109,7 +105,6 @@ jobs:
         working-directory: ./rust/android
         run: cargo +nightly build -Z build-std --target ${{ env.TARGET }} --release
         env:
-          RUSTFLAGS: ${{ env.RUSTFLAGS }}
           AR: llvm-ar
           LD: ld
           RANLIB: llvm-ranlib

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
     if: ${{ needs.check-build-cache.outputs.cache-found != 'true' }}
     runs-on: ubuntu-22.04
     container:
-      image: zingodevops/android_builder:006
+      image: zingodevops/android_builder:007
     env:
       RUSTUP_HOME: /root/.rustup
     steps:
@@ -114,7 +114,7 @@ jobs:
           LD: ld
           RANLIB: llvm-ranlib
           CC: ${{ env.CC }}24-clang
-          OPENSSL_DIR: /opt/openssl-3.1.2/${{ env.OPENSSL_PATH }}
+          OPENSSL_DIR: /opt/openssl-3.1.3/${{ env.OPENSSL_PATH }}
       
       - name: LLVM Strip
         working-directory: ./rust/target

--- a/.github/workflows/create-cache-key.yaml
+++ b/.github/workflows/create-cache-key.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Create cache key
     runs-on: ubuntu-22.04
     container:
-      image: zingodevops/android_builder:006
+      image: zingodevops/android_builder:007
     env:
       RUSTUP_HOME: /root/.rustup
     outputs:

--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
@@ -154,7 +154,7 @@ class ExecuteAddressesFromUfvk {
         System.out.println("\nExport Ufvk:")
         System.out.println(exportUfvkJson)
         val exportUfvk: ExportUfvk = mapper.readValue(exportUfvkJson)
-        assertThat(exportUfvk.ufvk).isEqualTo(ufvk.ABANDON)
+        assertThat(exportUfvk.ufvk).isEqualTo(Ufvk.ABANDON)
         assertThat(exportUfvk.birthday).isEqualTo(1)
 
         var addressesJson = RustFFI.execute("addresses", "")

--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
@@ -26,6 +26,11 @@ data class InitFromUfvk (
     val error : String
 )
 
+data class ExportUfvk (
+    val ufvk : String,
+    val birthday : Long
+)
+
 data class Addresses (
 	val address : String,
 	val receivers : Receivers
@@ -144,6 +149,13 @@ class ExecuteAddressesFromUfvk {
         System.out.println(initFromUfvkJson)
         val initFromUfvk: InitFromUfvk = mapper.readValue(initFromUfvkJson)
         assertThat(initFromUfvk.error).startsWith("This wallet is watch-only")
+
+        var exportUfvkJson = RustFFI.execute("exportufvk", "")
+        System.out.println("\nExport Ufvk:")
+        System.out.println(exportUfvkJson)
+        val exportUfvk: ExportUfvk = mapper.readValue(exportUfvkJson)
+        assertThat(exportUfvk.ufvk).isEqualTo(ufvk.ABANDON)
+        assertThat(exportUfvk.birthday).isEqualTo(1)
 
         var addressesJson = RustFFI.execute("addresses", "")
         System.out.println("\nAddresses:")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 33
         targetSdkVersion = 33
-        ndkVersion = "21.4.7075529" //"25.2.9519653"
+        ndkVersion = "26.1.10909125" //"21.4.7075529" //"25.2.9519653"
         kotlinVersion = '1.6.21'
     }
     repositories {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#53cffa3bab1c98e15b67c724b9a19981b7611a42"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
 
 [[package]]
 name = "bumpalo"
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "serde",
 ]
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=zingo_rc_branch#8f1ce801780e88c8961435d615d45e76f1de51dd"
+source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc.2#29c676ff125406e4b9f20fd046d103f42aa85e31"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=zingo_rc_branch#8f1ce801780e88c8961435d615d45e76f1de51dd"
+source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc.2#29c676ff125406e4b9f20fd046d103f42aa85e31"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2535,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.18"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2701,9 +2701,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -2720,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3324,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3335,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.3.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=zingo_rc_branch#8f1ce801780e88c8961435d615d45e76f1de51dd"
+source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc.2#29c676ff125406e4b9f20fd046d103f42aa85e31"
 dependencies = [
  "bech32",
  "bs58",
@@ -3811,8 +3811,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.10.0-rc.4"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=zingo_rc_branch#8f1ce801780e88c8961435d615d45e76f1de51dd"
+version = "0.10.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc.2#29c676ff125406e4b9f20fd046d103f42aa85e31"
 dependencies = [
  "base64 0.21.4",
  "bech32",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=zingo_rc_branch#8f1ce801780e88c8961435d615d45e76f1de51dd"
+source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc.2#29c676ff125406e4b9f20fd046d103f42aa85e31"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -3867,10 +3867,11 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.13.0-rc.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=zingo_rc_branch#8f1ce801780e88c8961435d615d45e76f1de51dd"
+version = "0.13.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc.2#29c676ff125406e4b9f20fd046d103f42aa85e31"
 dependencies = [
  "aes",
+ "bellman",
  "bip0039",
  "bitvec",
  "blake2b_simd",
@@ -3902,8 +3903,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.13.0-rc.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=zingo_rc_branch#8f1ce801780e88c8961435d615d45e76f1de51dd"
+version = "0.13.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc.2#29c676ff125406e4b9f20fd046d103f42aa85e31"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3943,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "zingo-memo"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#53cffa3bab1c98e15b67c724b9a19981b7611a42"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
 dependencies = [
  "zcash_address",
  "zcash_client_backend",
@@ -3955,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "zingo-testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#53cffa3bab1c98e15b67c724b9a19981b7611a42"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
 dependencies = [
  "http",
  "incrementalmerkletree",
@@ -3977,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "zingoconfig"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#53cffa3bab1c98e15b67c724b9a19981b7611a42"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
 dependencies = [
  "dirs",
  "http",
@@ -3990,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#53cffa3bab1c98e15b67c724b9a19981b7611a42"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
 dependencies = [
  "append-only-vec",
  "base58",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -302,9 +302,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#fbf4aeed29fbbcd3ac0848d716088805f39e2a68"
 
 [[package]]
 name = "bumpalo"
@@ -654,6 +654,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -1747,7 +1748,7 @@ version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1980,6 +1981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,7 +2029,7 @@ checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -2331,25 +2338,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.1",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.1",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2360,9 +2367,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "remove_dir_all"
@@ -2428,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+checksum = "fce3045ffa7c981a6ee93f640b538952e155f1ae3a1a02b84547fc7a56b7059a"
 dependencies = [
  "cc",
  "getrandom",
@@ -2539,7 +2546,7 @@ version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2829,7 +2836,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19f96dde3a8693874f7e7c53d95616569b4009379a903789efbd448f4ea9cc7"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -3030,12 +3037,11 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79474f573561cdc4871a0de34a51c92f7f5a56039113fbb5b9c9f96bdb756669"
+checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
 dependencies = [
  "libc",
- "redox_syscall 0.2.16",
  "winapi",
 ]
 
@@ -3051,12 +3057,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -3311,11 +3318,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3624,7 +3630,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.3",
+ "ring 0.17.4",
  "untrusted 0.9.0",
 ]
 
@@ -3944,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "zingo-memo"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#fbf4aeed29fbbcd3ac0848d716088805f39e2a68"
 dependencies = [
  "zcash_address",
  "zcash_client_backend",
@@ -3956,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "zingo-testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#fbf4aeed29fbbcd3ac0848d716088805f39e2a68"
 dependencies = [
  "http",
  "incrementalmerkletree",
@@ -3978,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "zingoconfig"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#fbf4aeed29fbbcd3ac0848d716088805f39e2a68"
 dependencies = [
  "dirs",
  "http",
@@ -3991,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#4107d65a34c5fec6bba1dfdc10801024f171ab18"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#fbf4aeed29fbbcd3ac0848d716088805f39e2a68"
 dependencies = [
  "append-only-vec",
  "base58",
@@ -4025,7 +4031,7 @@ dependencies = [
  "prost 0.10.4",
  "rand 0.8.5",
  "reqwest",
- "ring 0.17.3",
+ "ring 0.17.4",
  "ripemd160",
  "rust-embed",
  "rustls-pemfile",

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM zingodevops/android_builder:006 as build_android
+FROM zingodevops/android_builder:007 as build_android
 
 WORKDIR /opt/zingo/rust/android/
 
@@ -11,21 +11,21 @@ COPY ios/ /opt/zingo/rust/ios/
 COPY zingomobile_utils/ /opt/zingo/rust/zingomobile_utils/
 
 RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=aarch64-linux-android24-clang \
-    OPENSSL_DIR=/opt/openssl-3.1.2/aarch64 cargo +nightly build -Z build-std \
+    OPENSSL_DIR=/opt/openssl-3.1.3/aarch64 cargo +nightly build -Z build-std \
     --target aarch64-linux-android --release
 RUN llvm-strip ../target/aarch64-linux-android/release/librust.so
 
 RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=x86_64-linux-android24-clang \
-    OPENSSL_DIR=/opt/openssl-3.1.2/x86_64 cargo +nightly build -Z build-std \
+    OPENSSL_DIR=/opt/openssl-3.1.3/x86_64 cargo +nightly build -Z build-std \
     --target x86_64-linux-android --release
 RUN llvm-strip ../target/x86_64-linux-android/release/librust.so
 
 RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=armv7a-linux-androideabi24-clang \
-    OPENSSL_DIR=/opt/openssl-3.1.2/armv7 cargo +nightly build -Z build-std \
+    OPENSSL_DIR=/opt/openssl-3.1.3/armv7 cargo +nightly build -Z build-std \
     --target armv7-linux-androideabi --release
 RUN llvm-strip ../target/armv7-linux-androideabi/release/librust.so
 
 RUN RUSTFLAGS="-C link-arg=-latomic" AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=i686-linux-android24-clang \
-    OPENSSL_DIR=/opt/openssl-3.1.2/x86 cargo +nightly build -Z build-std \
+    OPENSSL_DIR=/opt/openssl-3.1.3/x86 cargo +nightly build -Z build-std \
     --target i686-linux-android --release
 RUN llvm-strip ../target/i686-linux-android/release/librust.so

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -25,7 +25,7 @@ RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=armv7a-linux-androideabi24-clang \
     --target armv7-linux-androideabi --release
 RUN llvm-strip ../target/armv7-linux-androideabi/release/librust.so
 
-RUN RUSTFLAGS="-C link-arg=-latomic" AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=i686-linux-android24-clang \
+RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=i686-linux-android24-clang \
     OPENSSL_DIR=/opt/openssl-3.1.3/x86 cargo +nightly build -Z build-std \
     --target i686-linux-android --release
 RUN llvm-strip ../target/i686-linux-android/release/librust.so

--- a/rust/android/builder/Dockerfile
+++ b/rust/android/builder/Dockerfile
@@ -66,33 +66,33 @@ RUN echo "[target.x86_64-linux-android]" >> $CARGO_HOME/config.toml \
 
 # Install and setup OpenSSL
 WORKDIR /opt
-RUN curl --proto '=https' --tlsv1.2 https://www.openssl.org/source/openssl-3.1.2.tar.gz -o openssl-3.1.2.tar.gz \
-    && tar xvf openssl-3.1.2.tar.gz \
-    && rm -rf openssl-3.1.2.tar.gz
+RUN curl --proto '=https' --tlsv1.2 https://www.openssl.org/source/openssl-3.1.3.tar.gz -o openssl-3.1.3.tar.gz \
+    && tar xvf openssl-3.1.3.tar.gz \
+    && rm -rf openssl-3.1.3.tar.gz
 ENV OPENSSL_STATIC=yes
-WORKDIR /opt/openssl-3.1.2 
+WORKDIR /opt/openssl-3.1.3 
 RUN mkdir x86 \
     && mkdir aarch64 \
     && mkdir armv7 \
     && mkdir x86_64
 # -mno-outline-atomics removed
-RUN ./Configure --prefix=/opt/openssl-3.1.2/aarch64  android-arm64 -U__ANDROID_API__ -D__ANDROID_API__=24 \
+RUN ./Configure --prefix=/opt/openssl-3.1.3/aarch64  android-arm64 -U__ANDROID_API__ -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
-RUN ./Configure --prefix=/opt/openssl-3.1.2/armv7  android-arm -U__ANDROID_API__ -D__ANDROID_API__=24 \
+RUN ./Configure --prefix=/opt/openssl-3.1.3/armv7  android-arm -U__ANDROID_API__ -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
 # -DBROKEN_CLANG_ATOMICS removed
-RUN ./Configure --prefix=/opt/openssl-3.1.2/x86  android-x86 -U__ANDROID_API__ -D__ANDROID_API__=24 \
+RUN ./Configure --prefix=/opt/openssl-3.1.3/x86  android-x86 -U__ANDROID_API__ -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
-RUN ./Configure --prefix=/opt/openssl-3.1.2/x86_64 -U__ANDROID_API__  android-x86_64 -D__ANDROID_API__=24 \
+RUN ./Configure --prefix=/opt/openssl-3.1.3/x86_64 -U__ANDROID_API__  android-x86_64 -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \

--- a/rust/android/builder/Dockerfile
+++ b/rust/android/builder/Dockerfile
@@ -46,7 +46,6 @@ RUN rustup target add \
     armv7-linux-androideabi \
     i686-linux-android \
     x86_64-linux-android
-# RUN cargo install cargo-ndk
 RUN echo "[target.aarch64-linux-android]" >> $CARGO_HOME/config.toml \
     && echo "ar = \"llvm-ar\"" >> $CARGO_HOME/config.toml \
     && echo "linker = \"aarch64-linux-android24-clang\"" >> $CARGO_HOME/config.toml \

--- a/rust/android/builder/Dockerfile
+++ b/rust/android/builder/Dockerfile
@@ -46,7 +46,7 @@ RUN rustup target add \
     armv7-linux-androideabi \
     i686-linux-android \
     x86_64-linux-android
-RUN cargo install cargo-ndk
+# RUN cargo install cargo-ndk
 RUN echo "[target.aarch64-linux-android]" >> $CARGO_HOME/config.toml \
     && echo "ar = \"llvm-ar\"" >> $CARGO_HOME/config.toml \
     && echo "linker = \"aarch64-linux-android24-clang\"" >> $CARGO_HOME/config.toml \

--- a/rust/android/builder/Dockerfile
+++ b/rust/android/builder/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:bullseye-slim
-ARG android_ndk_ver=r21e
+ARG android_ndk_ver=r26b
 # 21.4.7075529
 
 # Install dependencies
@@ -23,7 +23,7 @@ RUN apt update \
     && update-ca-certificates
 
 # Install Android NDK
-RUN curl -vfL -o /tmp/android-ndk.zip https://dl.google.com/android/repository/android-ndk-${android_ndk_ver}-linux-x86_64.zip \
+RUN curl -vfL -o /tmp/android-ndk.zip https://dl.google.com/android/repository/android-ndk-${android_ndk_ver}-linux.zip \
     && unzip /tmp/android-ndk.zip -d /usr/local/ \
     && rm -rf /tmp/android-ndk.zip
 ENV ANDROID_NDK_HOME=/usr/local/android-ndk-${android_ndk_ver}
@@ -76,23 +76,26 @@ RUN mkdir x86 \
     && mkdir armv7 \
     && mkdir x86_64
 # -mno-outline-atomics removed
-RUN ./Configure --prefix=/opt/openssl-3.1.3/aarch64  android-arm64 -U__ANDROID_API__ -D__ANDROID_API__=24 \
+RUN ./Configure --prefix=/opt/openssl-3.1.3/aarch64 android-arm64 -march=armv9.4-a \
+    -U__ANDROID_API__ -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
-RUN ./Configure --prefix=/opt/openssl-3.1.3/armv7  android-arm -U__ANDROID_API__ -D__ANDROID_API__=24 \
+RUN ./Configure --prefix=/opt/openssl-3.1.3/armv7 android-arm -march=armv9.4-a \
+    -U__ANDROID_API__ -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
-# -DBROKEN_CLANG_ATOMICS removed
-RUN ./Configure --prefix=/opt/openssl-3.1.3/x86  android-x86 -U__ANDROID_API__ -D__ANDROID_API__=24 \
+RUN ./Configure --prefix=/opt/openssl-3.1.3/x86 android-x86 -latomic -DBROKEN_CLANG_ATOMICS \
+    -U__ANDROID_API__ -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
-RUN ./Configure --prefix=/opt/openssl-3.1.3/x86_64 -U__ANDROID_API__  android-x86_64 -D__ANDROID_API__=24 \
+RUN ./Configure --prefix=/opt/openssl-3.1.3/x86_64 android-x86_64 \
+    -U__ANDROID_API__  -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -150,7 +150,7 @@ fi
 
 case "$abi" in
     x86_64)
-        api_level_default="31"
+        api_level_default="30"
         api_target_default="google_apis_playstore"
         if [ $intel_host_os == true ]; then       
             arch="x86_64"
@@ -159,7 +159,7 @@ case "$abi" in
         fi
         ;;
     x86) 
-        api_level_default="31"
+        api_level_default="30"
         api_target_default="google_apis_playstore"
         if [ $intel_host_os == true ]; then       
             arch="x86"
@@ -168,7 +168,7 @@ case "$abi" in
         fi
         ;;
     arm64-v8a)
-        api_level_default="31"
+        api_level_default="30"
         api_target_default="google_apis_playstore"
         if [ $intel_host_os == true ]; then       
             arch="x86_64"
@@ -177,7 +177,7 @@ case "$abi" in
         fi
         ;;
     armeabi-v7a)
-        api_level_default="31"
+        api_level_default="30"
         api_target_default="google_apis_playstore"
         if [ $intel_host_os == true ]; then       
             arch="x86"

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -150,7 +150,7 @@ fi
 
 case "$abi" in
     x86_64)
-        api_level_default="30"
+        api_level_default="31"
         api_target_default="google_apis_playstore"
         if [ $intel_host_os == true ]; then       
             arch="x86_64"
@@ -159,7 +159,7 @@ case "$abi" in
         fi
         ;;
     x86) 
-        api_level_default="30"
+        api_level_default="31"
         api_target_default="google_apis_playstore"
         if [ $intel_host_os == true ]; then       
             arch="x86"
@@ -168,7 +168,7 @@ case "$abi" in
         fi
         ;;
     arm64-v8a)
-        api_level_default="30"
+        api_level_default="31"
         api_target_default="google_apis_playstore"
         if [ $intel_host_os == true ]; then       
             arch="x86_64"
@@ -177,7 +177,7 @@ case "$abi" in
         fi
         ;;
     armeabi-v7a)
-        api_level_default="30"
+        api_level_default="31"
         api_target_default="google_apis_playstore"
         if [ $intel_host_os == true ]; then       
             arch="x86"


### PR DESCRIPTION
- android ndk r26b Latest.
- cargo-ndk removed because we are not using it.
- openssl updated to the Latest version 3.1.3.
- new build_android docker image 007.
- new zingolib version.
- new test for `exportufvk`.