### PR TITLE
New version zingo 1.3.0 128

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -144,9 +144,9 @@ android {
         //applicationId 'com.ZingoMobile' // @Test
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 126 // Real
+        versionCode 128 // Real
         //versionCode 117 // @Test
-        versionName "zingo-1.2.5" // Real
+        versionName "zingo-1.3.0" // Real
         missingDimensionStrategy 'react-native-camera', 'general'
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/rpc/RPC.ts
+++ b/app/rpc/RPC.ts
@@ -1091,22 +1091,6 @@ export default class RPC {
               await RPCModule.doSave();
               this.batches = 0;
 
-              // store SyncStatus object for a new screen
-              this.fnSetSyncingStatus({
-                syncID: this.sync_id,
-                totalBatches: batch_total,
-                currentBatch: ss.in_progress ? batch_num + 1 : 0,
-                lastBlockWallet: this.lastWalletBlockHeight,
-                currentBlock: current_block,
-                inProgress: ss.in_progress,
-                lastError: ss.last_error,
-                blocksPerBatch: this.blocksPerBatch,
-                secondsPerBatch: this.seconds_batch,
-                process_end_block: process_end_block,
-                lastBlockServer: this.lastServerBlockHeight,
-                syncProcessStalled: false,
-              } as SyncingStatusClass);
-
               //console.log('sync status', ss);
               //console.log(
               //  `@@@@@@@@@@@ Saving because batch num changed ${this.prevBatchNum} - ${batch_num}. seconds: ${this.seconds_batch}`,

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -430,9 +430,9 @@
   },
   "about": {
     "copyright": [
-      "Copyright (c) 2023, ZingoLabs.",
+      "Copyright (c) 2024, ZingoLabs.",
       "Built with React Native.",
-      "The MIT License (MIT) Copyright (c) 2023 Zingo!",
+      "The MIT License (MIT) Copyright (c) 2024 Zingo!",
       "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:",
       "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.",
       "THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1,6 +1,6 @@
 {
   "zingo": "Zingo!",
-  "version": "zingo-1.2.5 (126)",
+  "version": "zingo-1.3.0 (128)",
   "loading": "loading...",
   "connectingserver": "Connecting to the server...",
   "wait": "Please wait...",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -1,6 +1,6 @@
 {
   "zingo": "Zingo!",
-  "version": "zingo-1.2.5 (126)",
+  "version": "zingo-1.3.0 (128)",
   "loading": "cargando...",
   "connectingserver": "Conectando con el servidor...",
   "wait": "Por favor espere...",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -430,9 +430,9 @@
   },
   "about": {
     "copyright": [
-      "Copyright (c) 2023, ZingoLabs.",
+      "Copyright (c) 2024, ZingoLabs.",
       "Construida con React Native.",
-      "La Licencia MIT (MIT) Copyright (c) 2023 Zingo!",
+      "La Licencia MIT (MIT) Copyright (c) 2024 Zingo!",
       "Por la presente se otorga permiso, sin cargo, a cualquier persona que obtenga una copia de este software y los archivos de documentación asociados (el 'Software'), para operar con el Software sin restricciones, incluidos, entre otros, los derechos de uso, copia, modificación, fusión , publicar, distribuir, otorgar sublicencias y/o vender copias del Software, y permitir que las personas a las que se les proporcione el Software lo hagan, sujeto a las siguientes condiciones:",
       "El aviso de derechos de autor anterior y este aviso de permiso se incluirán en todas las copias o partes sustanciales del Software.",
       "EL SOFTWARE SE PROPORCIONA 'TAL CUAL', SIN GARANTÍA DE NINGÚN TIPO, EXPRESA O IMPLÍCITA, INCLUYENDO, ENTRE OTRAS, LAS GARANTÍAS DE COMERCIABILIDAD, IDONEIDAD PARA UN FIN DETERMINADO Y NO VIOLACIÓN. EN NINGÚN CASO LOS AUTORES O LOS TITULARES DE LOS DERECHOS DE AUTOR SERÁN RESPONSABLES DE CUALQUIER RECLAMACIÓN, DAÑOS U OTRA RESPONSABILIDAD, YA SEA EN UNA ACCIÓN DE CONTRATO, AGRAVIO O DE CUALQUIER OTRO TIPO, QUE SURJA DE, FUERA DE O EN RELACIÓN CON EL SOFTWARE O EL USO U OTROS TRATOS EN EL SOFTWARE."

--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -1,1 +1,1 @@
-NODE_BINARY=~/.nvm/versions/node/v16.20.2/bin/node
+NODE_BINARY=~/.nvm/versions/node/v20.9.0/bin/node

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -77,7 +77,7 @@ PODS:
   - hermes-engine (0.70.7)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - Permission-Camera (3.6.1):
+  - Permission-Camera (3.10.1):
     - RNPermissions
   - RCT-Folly (2021.07.22.00):
     - boost
@@ -313,18 +313,14 @@ PODS:
     - React-Core
   - react-native-camera/RN (4.2.1):
     - React-Core
-  - react-native-keep-awake (1.1.0):
+  - react-native-keep-awake (1.2.2):
     - React-Core
-  - react-native-netinfo (9.3.9):
+  - react-native-netinfo (9.5.0):
     - React-Core
-  - react-native-pager-view (6.1.2):
+  - react-native-pager-view (6.2.2):
     - React-Core
-  - react-native-safe-area-context (4.4.1):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
+  - react-native-safe-area-context (4.7.4):
     - React-Core
-    - ReactCommon/turbomodule/core
   - React-perflogger (0.70.7)
   - React-RCTActionSheet (0.70.7):
     - React-Core/RCTActionSheetHeaders (= 0.70.7)
@@ -393,22 +389,22 @@ PODS:
     - React-perflogger (= 0.70.7)
   - ReactNativeART (1.2.0):
     - React
-  - RNCAsyncStorage (1.17.11):
+  - RNCAsyncStorage (1.19.4):
     - React-Core
-  - RNCCheckbox (0.5.14):
+  - RNCCheckbox (0.5.16):
     - BEMCheckBox (~> 1.4)
     - React-Core
   - RNCClipboard (1.5.1):
     - React-Core
   - RNFS (2.20.0):
     - React-Core
-  - RNGestureHandler (2.9.0):
+  - RNGestureHandler (2.13.4):
     - React-Core
-  - RNLocalize (2.2.4):
+  - RNLocalize (2.2.6):
     - React-Core
-  - RNPermissions (3.6.1):
+  - RNPermissions (3.10.1):
     - React-Core
-  - RNReanimated (2.14.4):
+  - RNReanimated (2.17.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -435,12 +431,12 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.18.2):
+  - RNScreens (3.27.0):
     - React-Core
     - React-RCTImage
   - RNSnackbar (2.6.2):
     - React-Core
-  - RNSVG (13.7.0):
+  - RNSVG (13.14.0):
     - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -671,7 +667,7 @@ SPEC CHECKSUMS:
   hermes-engine: 566e656aa95456a3f3f739fd76ea9a9656f2633f
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  Permission-Camera: bf6791b17c7f614b6826019fcfdcc286d3a107f6
+  Permission-Camera: 9b70902f34a83c10e198d2d01f0e453e58842776
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: 837880d26ec119e105317dc28a456f3016bf16d1
   RCTTypeSafety: 5c854c04c3383cab04f404e25d408ed52124b300
@@ -688,10 +684,10 @@ SPEC CHECKSUMS:
   React-jsinspector: 1c34fea1868136ecde647bc11fae9266d4143693
   React-logger: e9f407f9fdf3f3ce7749ae6f88affe63e8446019
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
-  react-native-keep-awake: acbee258db16483744910f0da3ace39eb9ab47fd
-  react-native-netinfo: 22c082970cbd99071a4e5aa7a612ac20d66b08f0
-  react-native-pager-view: 54bed894cecebe28cede54c01038d9d1e122de43
-  react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
+  react-native-keep-awake: ad1d67f617756b139536977a0bf06b27cec0714a
+  react-native-netinfo: 48c5f79a84fbc3ba1d28a8b0d04adeda72885fa8
+  react-native-pager-view: 02a5c4962530f7efc10dd51ee9cdabeff5e6c631
+  react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-perflogger: 52a94f38c19a518d05726624b49bfc192639374d
   React-RCTActionSheet: 7b89fe64a852bc3ae39b91dbd142ef09931ef3f7
   React-RCTAnimation: ad84bfbf8c5f6f77e65092d0c2b0506b80b5cf99
@@ -705,17 +701,17 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7cec9ed92ebde8309902530bb566819645c84ee5
   ReactCommon: 0253d197eaa7f6689dcd3e7d5360449ab93e10df
   ReactNativeART: 78edc68dd4a1e675338cd0cd113319cf3a65f2ab
-  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
-  RNCCheckbox: 38989bbd3d7d536adf24ba26c6b3e6cefe0bea6f
+  RNCAsyncStorage: 3a8f7145d17cdd9f88e7b77666c94a09e4f759c8
+  RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
-  RNLocalize: 0df7970cfc60389f00eb62fd7c097dc75af3fb4f
-  RNPermissions: dcdb7b99796bbeda6975a6e79ad519c41b251b1c
-  RNReanimated: 6668b0587bebd4b15dd849b99e5a9c70fc12ed95
-  RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
+  RNGestureHandler: 360f9c7e91ec49ac76f03e73fb394d92e2a88e55
+  RNLocalize: d4b8af4e442d4bcca54e68fc687a2129b4d71a81
+  RNPermissions: 4e3714e18afe7141d000beae3755e5b5fb2f5e05
+  RNReanimated: bec7736122a268883bdede07f1bf9cf4b40158db
+  RNScreens: 2b19e2471db8a581c83f381f4ea5d43071c9a3bf
   RNSnackbar: 3727b42bf6c4314a53c18185b5203e915a4ab020
-  RNSVG: d787d64ca06b9158e763ad2638a8c4edce00782a
+  RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 92d086bb705a41cc588599b51db726ba7b1d341c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/ios/ZingoMobile.xcodeproj/project.pbxproj
+++ b/ios/ZingoMobile.xcodeproj/project.pbxproj
@@ -521,7 +521,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ZingoMobile/ZingoMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 126;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 788KRST4S8;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
@@ -538,7 +538,7 @@
 					"$(PROJECT_DIR)",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -561,7 +561,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = ZingoMobile/ZingoMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 126;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 788KRST4S8;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
@@ -578,7 +578,7 @@
 					"$(PROJECT_DIR)",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/ZingoMobile.xcodeproj/project.pbxproj
+++ b/ios/ZingoMobile.xcodeproj/project.pbxproj
@@ -283,7 +283,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nexport NODE_BINARY=~/.nvm/versions/node/v16.20.2/bin/node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
+			shellScript = "set -e\n\nexport NODE_BINARY=~/.nvm/versions/node/v20.9.0/bin/node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		0D3D17FAF0DEFCD154030675 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#c008e3f5b12a90608a279745d8b9b3d240539401"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#f8c914a5894fd448d1b77556ad239c1f4f0ddad2"
 
 [[package]]
 name = "bumpalo"
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "darkside-tests"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#c008e3f5b12a90608a279745d8b9b3d240539401"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#f8c914a5894fd448d1b77556ad239c1f4f0ddad2"
 dependencies = [
  "bech32",
  "bip0039",
@@ -2675,9 +2675,9 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -2694,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2705,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "4d1bd37ce2324cf3bf85e5a25f96eb4baf0d5aa6eba43e7ae8958870c4ec48ed"
 dependencies = [
  "itoa",
  "ryu",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "zingo-memo"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#c008e3f5b12a90608a279745d8b9b3d240539401"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#f8c914a5894fd448d1b77556ad239c1f4f0ddad2"
 dependencies = [
  "zcash_address",
  "zcash_client_backend",
@@ -3985,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "zingo-status"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#c008e3f5b12a90608a279745d8b9b3d240539401"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#f8c914a5894fd448d1b77556ad239c1f4f0ddad2"
 dependencies = [
  "serde_json",
  "zcash_primitives",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "zingo-testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#c008e3f5b12a90608a279745d8b9b3d240539401"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#f8c914a5894fd448d1b77556ad239c1f4f0ddad2"
 dependencies = [
  "futures",
  "http",
@@ -4020,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "zingo-testvectors"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#c008e3f5b12a90608a279745d8b9b3d240539401"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#f8c914a5894fd448d1b77556ad239c1f4f0ddad2"
 dependencies = [
  "zcash_primitives",
  "zingoconfig",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "zingoconfig"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#c008e3f5b12a90608a279745d8b9b3d240539401"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#f8c914a5894fd448d1b77556ad239c1f4f0ddad2"
 dependencies = [
  "dirs",
  "http",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#c008e3f5b12a90608a279745d8b9b3d240539401"
+source = "git+https://github.com/zingolabs/zingolib?branch=dev#f8c914a5894fd448d1b77556ad239c1f4f0ddad2"
 dependencies = [
  "append-only-vec",
  "base58",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itertools 0.10.5",
+ "itertools",
  "json",
  "log",
  "orchard",
@@ -1390,15 +1390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,7 +2042,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes 1.5.0",
  "heck",
- "itertools 0.11.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -2072,7 +2063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.48",

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -236,6 +236,7 @@ mod tests {
             Err(_) => panic!(),
         }
         let test_client = LightClient::create_unconnected(&config, wallet_base, 1)
+            .await
             .expect("To create a lightclient.");
         dbg!(test_client.do_info().await);
     }


### PR DESCRIPTION
New production version of Zingo.

I used to build the App:
* zingolib -> commit: https://github.com/zingolabs/zingolib/commit/f8c914a5894fd448d1b77556ad239c1f4f0ddad2
* zingo-mobile -> commit: https://github.com/zingolabs/zingo-mobile/pull/478/commits/3c5758f513056f56e63d0a48ac88c67d869398a2

What's new:
* Faster Syncing with the ShardTree witness update.
* Significant increase in test coverage
* New transaction explorer.
* New server on the list.
* Privacy Level Info Added.
* Bugs fixed and minor improvements.

@fluidvanadium @zancas @AloeareV @Oscar-Pepper @idky137 

Everything was tested by @edicksonjga.