### PR TITLE
Cargo patch lib sodiumoxide for IOS simulator buildings

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1487,9 +1487,8 @@ dependencies = [
 
 [[package]]
 name = "libsodium-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
+version = "0.2.8"
+source = "git+https://github.com/juanky201271/sodiumoxide?rev=2f1b91e031199412ec631a3afd571a7df2450981#2f1b91e031199412ec631a3afd571a7df2450981"
 dependencies = [
  "cc",
  "libc",
@@ -2842,9 +2841,8 @@ dependencies = [
 
 [[package]]
 name = "sodiumoxide"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
+version = "0.2.8"
+source = "git+https://github.com/juanky201271/sodiumoxide?rev=2f1b91e031199412ec631a3afd571a7df2450981#2f1b91e031199412ec631a3afd571a7df2450981"
 dependencies = [
  "ed25519",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,3 +18,7 @@ debug = false
 [profile.test]
 opt-level = 3
 debug = false
+
+# this is needed to build for IOS simulator
+[patch.crates-io]
+sodiumoxide = { git = "https://github.com/juanky201271/sodiumoxide", rev = "2f1b91e031199412ec631a3afd571a7df2450981"}


### PR DESCRIPTION
We need this patch to build the rust library with `cargo-lipo` to test the App with IOS simulator. There is no problem for Android or IOS with physical device because the original crate `sodiumoxide` was archived long time ago.