### PR TITLE
Add production zec.rocks servers

### DIFF
--- a/__tests__/__snapshots__/Settings.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/Settings.snapshot.tsx.snap
@@ -915,8 +915,24 @@ exports[`Component Settings - test Settings - snapshot 1`] = `
                   "value": "https://lwd1.zcash-infra.com:9067",
                 },
                 {
-                  "label": "text translated https://test.zec.rocks:443",
-                  "value": "https://test.zec.rocks:443",
+                  "label": "text translated https://zec.rocks:443",
+                  "value": "https://zec.rocks:443",
+                },
+                {
+                  "label": "text translated https://na.zec.rocks:443",
+                  "value": "https://na.zec.rocks:443",
+                },
+                {
+                  "label": "text translated https://sa.zec.rocks:443",
+                  "value": "https://sa.zec.rocks:443",
+                },
+                {
+                  "label": "text translated https://eu.zec.rocks:443",
+                  "value": "https://eu.zec.rocks:443",
+                },
+                {
+                  "label": "text translated https://ap.zec.rocks:443",
+                  "value": "https://ap.zec.rocks:443",
                 },
                 {
                   "label": "text translated https://na.lightwalletd.com:443",

--- a/app/uris/serverUris.ts
+++ b/app/uris/serverUris.ts
@@ -19,10 +19,38 @@ const serverUris = (translate: (key: string) => TranslateType | void): ServerUri
     },
     // new servers (not default)
     {
-      uri: 'https://test.zec.rocks:443',
+      uri: 'https://zec.rocks:443',
       region: translate('settings.usa') as string,
       chain_name: 'main',
       default: true,
+      latency: null,
+    },
+    {
+      uri: 'https://na.zec.rocks:443',
+      region: translate('settings.na') as string,
+      chain_name: 'main',
+      default: false,
+      latency: null,
+    },
+    {
+      uri: 'https://sa.zec.rocks:443',
+      region: translate('settings.sa') as string,
+      chain_name: 'main',
+      default: false,
+      latency: null,
+    },
+    {
+      uri: 'https://eu.zec.rocks:443',
+      region: translate('settings.ea') as string,
+      chain_name: 'main',
+      default: false,
+      latency: null,
+    },
+    {
+      uri: 'https://ap.zec.rocks:443',
+      region: translate('settings.ao') as string,
+      chain_name: 'main',
+      default: false,
       latency: null,
     },
     {


### PR DESCRIPTION
I updated the server list to switch zec.rocks' test endpoint over to our production endpoint which will be online long term.

Zec.rocks is new lightwalletd infrastructure [funded by a ZCG award](https://forum.zcashcommunity.com/t/rfp-zcash-lightwalletd-infrastructure-development-and-maintenance/47080). It is globally load-balanced, currently across four regions, with an emphasis on using dedicated hardware and infrastructure-as-code. We are in the process of open-sourcing the Kubernetes helm charts used to maintain this new infrastructure to make it easier for people to host their own light wallet servers.

The "zec.rocks:443" endpoint is globally load-balanced using anycast, automatically routing users to their closest region.