### PR TITLE
upgraded b64 representer. 

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -305,12 +305,6 @@ checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -320,6 +314,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64ct"
@@ -2689,7 +2689,7 @@ name = "rustlib"
 version = "1.0.1"
 dependencies = [
  "android_logger",
- "base64 0.11.0",
+ "base64 0.22.0",
  "http",
  "lazy_static",
  "log",

--- a/rust/lib/Cargo.toml
+++ b/rust/lib/Cargo.toml
@@ -9,7 +9,7 @@ zingolib = { workspace = true }
 zingoconfig = { workspace = true }
 http = "0.2.4"
 lazy_static = "1.4.0"
-base64 = "0.11.0"
+base64 = "0.22.0"
 android_logger = "0.11"
 log = "0.4"
 uniffi = { workspace = true, features = [ "cli" ] }

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -6,7 +6,7 @@ extern crate android_logger;
 
 #[cfg(target_os = "android")]
 use android_logger::{Config, FilterBuilder};
-use base64::engine::general_purpose::STANDARD;
+use base64::{engine::general_purpose::STANDARD, DecodeError};
 #[cfg(target_os = "android")]
 use log::Level;
 
@@ -171,12 +171,13 @@ pub fn init_from_b64(
     }
     let decoded_bytes = match STANDARD_NO_PAD.decode(&base64_data) {
         Ok(b) => b,
-        Err(e) => match STANDARD.decode(&base64_data) {
+        Err(base64::DecodeError::InvalidPadding) => match STANDARD.decode(&base64_data) {
             Ok(b) => b,
             Err(e) => {
                 return format!("Error: Decoding Base64: {}", e);
             }
         },
+        _ => todo!(),
     };
 
     let lightclient =

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -9,7 +9,7 @@ use android_logger::{Config, FilterBuilder};
 #[cfg(target_os = "android")]
 use log::Level;
 
-use base64::{decode, encode};
+use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 use zingoconfig::{construct_lightwalletd_uri, ChainType, RegtestNetwork, ZingoConfig};
@@ -66,15 +66,15 @@ pub fn init_logging() -> String {
     // this is only for Android
     #[cfg(target_os = "android")]
     android_logger::init_once(
-      Config::default().with_min_level(Level::Trace).with_filter(
-          FilterBuilder::new()
-              .parse("debug,hello::crate=zingolib")
-              .build(),
-      ),
+        Config::default().with_min_level(Level::Trace).with_filter(
+            FilterBuilder::new()
+                .parse("debug,hello::crate=zingolib")
+                .build(),
+        ),
     );
-  
+
     "OK".to_string()
-}  
+}
 
 pub fn init_new(
     server_uri: String,
@@ -168,7 +168,7 @@ pub fn init_from_b64(
         Ok((c, h)) => (config, _lightwalletd_uri) = (c, h),
         Err(s) => return s,
     }
-    let decoded_bytes = match decode(&base64_data) {
+    let decoded_bytes = match STANDARD_NO_PAD.decode(&base64_data) {
         Ok(b) => b,
         Err(e) => {
             return format!("Error: Decoding Base64: {}", e);
@@ -199,7 +199,7 @@ pub fn save_to_b64() -> String {
     };
 
     match lightclient.export_save_buffer_runtime() {
-        Ok(buf) => encode(&buf),
+        Ok(buf) => STANDARD_NO_PAD.encode(&buf),
         Err(e) => {
             format!("Error: {}", e)
         }
@@ -238,4 +238,3 @@ pub fn get_latest_block_server(server_uri: String) -> String {
         Err(e) => e,
     }
 }
-

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -6,6 +6,7 @@ extern crate android_logger;
 
 #[cfg(target_os = "android")]
 use android_logger::{Config, FilterBuilder};
+use base64::engine::general_purpose::STANDARD;
 #[cfg(target_os = "android")]
 use log::Level;
 
@@ -170,9 +171,12 @@ pub fn init_from_b64(
     }
     let decoded_bytes = match STANDARD_NO_PAD.decode(&base64_data) {
         Ok(b) => b,
-        Err(e) => {
-            return format!("Error: Decoding Base64: {}", e);
-        }
+        Err(e) => match STANDARD.decode(&base64_data) {
+            Ok(b) => b,
+            Err(e) => {
+                return format!("Error: Decoding Base64: {}", e);
+            }
+        },
     };
 
     let lightclient =


### PR DESCRIPTION
likely fixes https://github.com/zingolabs/zingo-mobile/issues/634

because the deprecated engine is unclear about whether it uses PADDING. the new engine explicitly uses no PADDING.