### PR TITLE
Finsight address book contact - send icon removed

### DIFF
--- a/__tests__/Insight.snapshot.tsx
+++ b/__tests__/Insight.snapshot.tsx
@@ -48,7 +48,7 @@ describe('Component Insight - test', () => {
     const onClose = jest.fn();
     const insight = render(
       <ContextAppLoadedProvider value={state}>
-        <Insight closeModal={onClose} openModal={onClose} setPrivacyOption={onClose} setSendPageState={onClose} />
+        <Insight closeModal={onClose} setPrivacyOption={onClose} />
       </ContextAppLoadedProvider>,
     );
     expect(insight.toJSON()).toMatchSnapshot();

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -1632,9 +1632,7 @@ export class LoadedAppClass extends Component<LoadedAppClassProps, LoadedAppClas
               }>
               <Insight
                 closeModal={() => this.setState({ insightModalVisible: false })}
-                openModal={() => this.setState({ insightModalVisible: true })}
                 setPrivacyOption={this.setPrivacyOption}
-                setSendPageState={this.setSendPageState}
               />
             </Suspense>
           </Modal>

--- a/components/Insight/Insight.tsx
+++ b/components/Insight/Insight.tsx
@@ -18,7 +18,7 @@ import FadeText from '../Components/FadeText';
 import Header from '../Header';
 import RPCModule from '../../app/RPCModule';
 import AddressItem from '../Components/AddressItem';
-import { ButtonTypeEnum, CommandEnum, SendPageStateClass, SnackbarDurationEnum } from '../../app/AppState';
+import { ButtonTypeEnum, CommandEnum, SnackbarDurationEnum } from '../../app/AppState';
 import moment from 'moment';
 import 'moment/locale/es';
 import 'moment/locale/pt';
@@ -81,17 +81,10 @@ const getPercent = (percent: number) => {
 
 type InsightProps = {
   closeModal: () => void;
-  openModal: () => void;
   setPrivacyOption: (value: boolean) => Promise<void>;
-  setSendPageState: (s: SendPageStateClass) => void;
 };
 
-const Insight: React.FunctionComponent<InsightProps> = ({
-  closeModal,
-  setPrivacyOption,
-  openModal,
-  setSendPageState,
-}) => {
+const Insight: React.FunctionComponent<InsightProps> = ({ closeModal, setPrivacyOption }) => {
   const context = useContext(ContextAppLoaded);
   const { info, translate, privacy, addLastSnackbar, language } = context;
   const { colors } = useTheme() as unknown as ThemeType;
@@ -217,10 +210,8 @@ const Insight: React.FunctionComponent<InsightProps> = ({
                     oneLine={true}
                     onlyContact={true}
                     withIcon={true}
-                    withSendIcon={true}
-                    setSendPageState={setSendPageState}
-                    closeModal={closeModal}
-                    openModal={openModal}
+                    closeModal={() => {}}
+                    openModal={() => {}}
                   />
                 )}
                 {!expandAddress[index] && !!item.address && (


### PR DESCRIPTION
When the contact is fairly long, even when is short, the send Icon there is ugly and useless. Now the contact is like in the send screen, only the text. The user don't need to send to a contact when is reviewing the financial charts.

Looks good this way:
![image](https://github.com/user-attachments/assets/cf8627c8-47d0-4875-b253-15ab1c781126)
