### PR TITLE
Detox is failing in macos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,9 +67,11 @@ jobs:
       timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
 
-  ios-e2e-test:
-    uses: ./.github/workflows/ios-e2e-test.yaml
-    needs: [create-timestamp, ios-build]
-    with:
-      timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
-      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
+  # deactivating these for now, until we fix how
+  # detox run in MACOS.
+  #ios-e2e-test:
+  #  uses: ./.github/workflows/ios-e2e-test.yaml
+  #  needs: [create-timestamp, ios-build]
+  #  with:
+  #    timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
+  #    cache-key: ${{ needs.create-cache-key.outputs.cache-key }}


### PR DESCRIPTION
It's annoying to see those fails. Deactivating them until we can figure out how to fix detox in macos.