### PR TITLE
E2E: Add parse for invalid address

### DIFF
--- a/.github/workflows/android-ubuntu-e2e-test-ci.yaml
+++ b/.github/workflows/android-ubuntu-e2e-test-ci.yaml
@@ -113,6 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         test: [
+          "parse_invalid_address",
           "tex_send_address", 
           "reload_while_tx_pending", 
           "change_custom_server", 

--- a/.github/workflows/ios-e2e-test.yaml
+++ b/.github/workflows/ios-e2e-test.yaml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         test: [
+          "parse_invalid_address",
           "tex_send_address", 
           "reload_while_tx_pending", 
           "change_custom_server", 

--- a/components/Components/ErrorText.tsx
+++ b/components/Components/ErrorText.tsx
@@ -6,12 +6,17 @@ import { ThemeType } from '../../app/types/ThemeType';
 type ErrorTextProps = {
   style?: TextStyle;
   children: string;
+  testID?: string;
 };
 
-const ErrorText: React.FunctionComponent<ErrorTextProps> = ({ style, children }) => {
+const ErrorText: React.FunctionComponent<ErrorTextProps> = ({ style, children, testID }) => {
   const { colors } = useTheme() as unknown as ThemeType;
 
-  return <Text style={{ color: colors.primary, ...style }}>{children}</Text>;
+  return (
+    <Text testID={testID} style={{ color: colors.primary, ...style }}>
+      {children}
+    </Text>
+  );
 };
 
 export default ErrorText;

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -1001,7 +1001,9 @@ const Send: React.FunctionComponent<SendProps> = ({
                       <FontAwesomeIcon icon={faCheck} color={colors.primary} />
                     </View>
                   )}
-                  {validAddress === -1 && <ErrorText>{translate('send.invalidaddress') as string}</ErrorText>}
+                  {validAddress === -1 && (
+                    <ErrorText testID="send.address.error">{translate('send.invalidaddress') as string}</ErrorText>
+                  )}
                 </View>
                 <View
                   style={{

--- a/e2e/parse_invalid_address.test.js
+++ b/e2e/parse_invalid_address.test.js
@@ -5,15 +5,15 @@ import { loadRecipientWallet } from './e2e-utils/loadRecipientWallet.js';
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 describe('Renders wallet data correctly.', () => {
-  beforeEach(async () => {
-    await device.launchApp({
-      newInstance: true,
-    });
-  });
   it('loads a wallet', async () => await loadRecipientWallet());
   it('does not parse an incorrect address', async () => {
+    await waitFor(element(by.id('vt-1')))
+    .toExist()
+    .withTimeout(30000);
     await element(by.text('SEND')).tap();
+
     await element(by.id('send.addressplaceholder')).replaceText('thisisaninvalidaddress');
+
     await waitFor(element(by.id('send.address.error')))
       .toExist()
       .withTimeout(5000);

--- a/e2e/parse_invalid_address.test.js
+++ b/e2e/parse_invalid_address.test.js
@@ -1,0 +1,21 @@
+const { log, device, by, element, expect } = require('detox');
+
+import { loadRecipientWallet } from './e2e-utils/loadRecipientWallet.js';
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+describe('Renders wallet data correctly.', () => {
+  beforeEach(async () => {
+    await device.launchApp({
+      newInstance: true,
+    });
+  });
+  it('loads a wallet', async () => await loadRecipientWallet());
+  it('does not parse an incorrect address', async () => {
+    await element(by.text('SEND')).tap();
+    await element(by.id('send.addressplaceholder')).replaceText('thisisaninvalidaddress');
+    await waitFor(element(by.id('send.address.error')))
+      .toExist()
+      .withTimeout(5000);
+  });
+});

--- a/e2e/send.test.js
+++ b/e2e/send.test.js
@@ -6,11 +6,6 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 describe('Renders wallet data correctly.', () => {
   // i just pulled this seed out of thin air
-  beforeEach(async () => {
-    await device.launchApp({
-      newInstance: true,
-    });
-  });
   it('loads a wallet', async () => await loadRecipientWallet());
   it('adds return address to the memo if that option is selected, and correctly renders confirm screen', async () => {
     await element(by.text('SEND')).tap();
@@ -46,12 +41,5 @@ describe('Renders wallet data correctly.', () => {
     //  '1\n2\n3\n4\n5\n6\n7\n8\nReply to: \nuregtest1zkuzfv5m3yhv2j4fmvq5rjurkxenxyq8r7h4daun2zkznrjaa8ra8asgdm8wwgwjvlwwrxx7347r8w0ee6dqyw4rufw4wg9djwcr6frzkezmdw6dud3wsm99eany5r8wgsctlxquu009nzd6hsme2tcsk0v3sgjvxa70er7h27z5epr67p5q767s2z5gt88paru56mxpm6pwz0cu35m',
     //);
     await expect(memo).toHaveText('1\n2\n3\n4\n5\n6\n7\n8');
-  });
-  it('does not parse an incorrect address', async () => {
-    await element(by.text('SEND')).tap();
-    await element(by.id('send.addressplaceholder')).replaceText('thisisaninvalidaddress');
-    await waitFor(element(by.id('send.address.error')))
-      .toExist()
-      .withTimeout(5000);
   });
 });

--- a/e2e/send.test.js
+++ b/e2e/send.test.js
@@ -6,6 +6,11 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 describe('Renders wallet data correctly.', () => {
   // i just pulled this seed out of thin air
+  beforeEach(async () => {
+    await device.launchApp({
+      newInstance: true,
+    });
+  });
   it('loads a wallet', async () => await loadRecipientWallet());
   it('adds return address to the memo if that option is selected, and correctly renders confirm screen', async () => {
     await element(by.text('SEND')).tap();
@@ -25,7 +30,9 @@ describe('Renders wallet data correctly.', () => {
     await element(by.id('send.memo-field')).replaceText('1\n2\n3\n4\n5\n6\n7\n8');
     await element(by.id('send.scroll-view')).scrollTo('bottom');
 
-    await waitFor(element(by.id('send.button'))).toBeVisible().withTimeout(sync_timeout);
+    await waitFor(element(by.id('send.button')))
+      .toBeVisible()
+      .withTimeout(sync_timeout);
     await element(by.id('send.button')).tap();
 
     await expect(element(by.id('send.confirm.scroll-view'))).toExist();
@@ -38,8 +45,13 @@ describe('Renders wallet data correctly.', () => {
     //await expect(memo).toHaveText(
     //  '1\n2\n3\n4\n5\n6\n7\n8\nReply to: \nuregtest1zkuzfv5m3yhv2j4fmvq5rjurkxenxyq8r7h4daun2zkznrjaa8ra8asgdm8wwgwjvlwwrxx7347r8w0ee6dqyw4rufw4wg9djwcr6frzkezmdw6dud3wsm99eany5r8wgsctlxquu009nzd6hsme2tcsk0v3sgjvxa70er7h27z5epr67p5q767s2z5gt88paru56mxpm6pwz0cu35m',
     //);
-    await expect(memo).toHaveText(
-      '1\n2\n3\n4\n5\n6\n7\n8',
-    );
+    await expect(memo).toHaveText('1\n2\n3\n4\n5\n6\n7\n8');
+  });
+  it('does not parse an incorrect address', async () => {
+    await element(by.text('SEND')).tap();
+    await element(by.id('send.addressplaceholder')).replaceText('thisisaninvalidaddress');
+    await waitFor(element(by.id('send.address.error')))
+      .toExist()
+      .withTimeout(5000);
   });
 });

--- a/rust/android/tests/e2e_tests.rs
+++ b/rust/android/tests/e2e_tests.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "regchest"))]
-use zingolib::testutils::{scenarios};
+use zingolib::testutils::scenarios;
 
 use darkside_tests::utils::{prepare_darksidewalletd, DarksideHandler};
 
@@ -24,12 +24,42 @@ async fn tex_send_address(abi: &str) {
         };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test(abi, "tex_send_address");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test(abi, "tex_send_address");
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_e2e_test_ci(abi, "tex_send_address");
-    
+
+    #[cfg(feature = "regchest")]
+    match regchest_utils::close(&docker).await {
+        Ok(_) => (),
+        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
+    }
+
+    println!("Exit Code: {}", exit_code);
+    println!("Output: {}", output);
+    println!("Error: {}", error);
+
+    assert_eq!(exit_code, 0);
+}
+
+async fn parse_invalid_address(abi: &str) {
+    #[cfg(not(feature = "regchest"))]
+    let (_regtest_manager, _child_process_handler) =
+        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    #[cfg(feature = "regchest")]
+    let docker =
+        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
+            Ok(d) => d,
+            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
+        };
+
+    #[cfg(not(feature = "ci"))]
+    let (exit_code, output, error) =
+        zingomobile_utils::android_e2e_test(abi, "parse_invalid_address");
+    #[cfg(feature = "ci")]
+    let (exit_code, output, error) =
+        zingomobile_utils::android_e2e_test_ci(abi, "parse_invalid_address");
+
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
         Ok(_) => (),
@@ -60,7 +90,7 @@ async fn reload_while_tx_pending(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_e2e_test_ci(abi, "reload_while_tx_pending");
-    
+
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
         Ok(_) => (),
@@ -106,13 +136,13 @@ async fn change_custom_regtest_server(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_e2e_test_ci(abi, "change_custom_regtest_server");
-    
+
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
         Ok(_) => (),
         Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
     }
-    
+
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
     println!("Error: {}", error);
@@ -152,11 +182,9 @@ async fn change_server_from_list(abi: &str) {
 
 async fn new_wallet(abi: &str) {
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test(abi, "new_wallet");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test(abi, "new_wallet");
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test_ci(abi, "new_wallet");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test_ci(abi, "new_wallet");
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -167,11 +195,9 @@ async fn new_wallet(abi: &str) {
 
 async fn screen_awake(abi: &str) {
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test(abi, "screen_awake");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test(abi, "screen_awake");
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test_ci(abi, "screen_awake");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test_ci(abi, "screen_awake");
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -192,11 +218,9 @@ async fn send(abi: &str) {
         };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test(abi, "send");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test(abi, "send");
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test_ci(abi, "send");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test_ci(abi, "send");
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
@@ -213,11 +237,9 @@ async fn send(abi: &str) {
 
 async fn sync_report(abi: &str) {
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test(abi, "sync_report");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test(abi, "sync_report");
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_e2e_test_ci(abi, "sync_report");
+    let (exit_code, output, error) = zingomobile_utils::android_e2e_test_ci(abi, "sync_report");
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -259,7 +281,7 @@ async fn darkside_simple_sync(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_e2e_test_ci(abi, "darkside_simple_sync");
-    
+
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
     println!("Error: {}", error);
@@ -274,6 +296,11 @@ mod e2e {
         #[tokio::test]
         async fn tex_send_address() {
             crate::tex_send_address(ABI).await;
+        }
+
+        #[tokio::test]
+        async fn parse_invalid_address() {
+            crate::parse_invalid_address(ABI).await;
         }
 
         #[tokio::test]
@@ -343,6 +370,11 @@ mod e2e {
         }
 
         #[tokio::test]
+        async fn parse_invalid_address() {
+            crate::parse_invalid_address(ABI).await;
+        }
+
+        #[tokio::test]
         async fn reload_while_tx_pending() {
             crate::reload_while_tx_pending(ABI).await;
         }
@@ -409,6 +441,11 @@ mod e2e {
         }
 
         #[tokio::test]
+        async fn parse_invalid_address() {
+            crate::parse_invalid_address(ABI).await;
+        }
+
+        #[tokio::test]
         async fn reload_while_tx_pending() {
             crate::reload_while_tx_pending(ABI).await;
         }
@@ -472,6 +509,11 @@ mod e2e {
         #[tokio::test]
         async fn tex_send_address() {
             crate::tex_send_address(ABI).await;
+        }
+
+        #[tokio::test]
+        async fn parse_invalid_address() {
+            crate::parse_invalid_address(ABI).await;
         }
 
         #[tokio::test]


### PR DESCRIPTION
This PR adds an E2E detox test inside `e2e/send.test.js` that validates an invalid address.