### PR TITLE
For host x86_64 do not use arm64 android AVD in ci

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -28,7 +28,7 @@ jobs:
   android-ubuntu-integration-test-ci:
     strategy:
       matrix:
-        abi: [ x86_64, x86, arm64-v8a, armeabi-v7a ]
+        abi: [ x86_64, x86 ]
     uses: ./.github/workflows/android-ubuntu-integration-test-ci.yaml
     needs: [create-timestamp, android-build]
     with:


### PR DESCRIPTION
logs:
```
INFO    | Found systemPath /usr/local/lib/android/sdk/system-images/android-29/default/arm64-v8a/
PANIC: Avd's CPU Architecture 'arm64' is not supported by the QEMU2 emulator on x86_64 host.
```