### PR TITLE
History screen filter with funds estrictly > 0

### DIFF
--- a/components/History/History.tsx
+++ b/components/History/History.tsx
@@ -116,12 +116,9 @@ const History: React.FunctionComponent<HistoryProps> = ({
     if (!valueTransfers) {
       return [] as ValueTransferType[];
     }
+    // strictly show VT's with some amount on it.
     return valueTransfers
-      .filter((vt: ValueTransferType) =>
-        filter === FilterEnum.withFunds
-          ? vt.amount > Utils.parseStringLocaleToNumberFloat(Utils.getZenniesDonationAmount())
-          : true,
-      )
+      .filter((vt: ValueTransferType) => (filter === FilterEnum.withFunds ? vt.amount > 0 : true))
       .slice(0, numVt);
   }, [valueTransfers, numVt, filter]);
 


### PR DESCRIPTION
The filter in history by default will be `with funds` selecting the vt's with amount > 0, hopefully exclude all the messages created by the other screen. If the user want to see all the VT's in the wallet always can click on `All`.