### PR TITLE
Downgrade openssl to 3.3.2

### DIFF
--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -150,7 +150,7 @@ jobs:
           LD: ld
           RANLIB: llvm-ranlib
           CC: ${{ env.CC }}24-clang
-          OPENSSL_DIR: /opt/openssl-3.4.1/${{ env.OPENSSL_PATH }}
+          OPENSSL_DIR: /opt/openssl-3.3.2/${{ env.OPENSSL_PATH }}
           CARGO_FEATURE_STD: true
 
       - name: LLVM Strip

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -21,27 +21,27 @@ RUN cargo run --release --features=uniffi/cli --bin uniffi-bindgen \
 RUN cargo install --version ^3 cargo-ndk
 
 #RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=aarch64-linux-android24-clang \
-#    OPENSSL_DIR=/opt/openssl-3.4.1/aarch64 cargo +nightly build -Z build-std \
+#    OPENSSL_DIR=/opt/openssl-3.3.2/aarch64 cargo +nightly build -Z build-std \
 #    --target aarch64-linux-android --release
 # this is for indexmap 1.9.3 -> forcing `features = ["std"]`
 ENV CARGO_FEATURE_STD=true
-RUN OPENSSL_DIR=/opt/openssl-3.4.1/aarch64 cargo ndk --target arm64-v8a build --release -Z build-std
+RUN OPENSSL_DIR=/opt/openssl-3.3.2/aarch64 cargo ndk --target arm64-v8a build --release -Z build-std
 RUN llvm-strip ../target/aarch64-linux-android/release/libzingo.so
 
 #RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=x86_64-linux-android24-clang \
-#    OPENSSL_DIR=/opt/openssl-3.4.1/x86_64 cargo +nightly build -Z build-std \
+#    OPENSSL_DIR=/opt/openssl-3.3.2/x86_64 cargo +nightly build -Z build-std \
 #    --target x86_64-linux-android --release
-RUN OPENSSL_DIR=/opt/openssl-3.4.1/x86_64 cargo ndk --target x86_64 build --release -Z build-std
+RUN OPENSSL_DIR=/opt/openssl-3.3.2/x86_64 cargo ndk --target x86_64 build --release -Z build-std
 RUN llvm-strip ../target/x86_64-linux-android/release/libzingo.so
 
 #RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=armv7a-linux-androideabi24-clang \
-#    OPENSSL_DIR=/opt/openssl-3.4.1/armv7 cargo +nightly build -Z build-std \
+#    OPENSSL_DIR=/opt/openssl-3.3.2/armv7 cargo +nightly build -Z build-std \
 #    --target armv7-linux-androideabi --release
-RUN OPENSSL_DIR=/opt/openssl-3.4.1/armv7 cargo ndk --target armeabi-v7a build --release -Z build-std
+RUN OPENSSL_DIR=/opt/openssl-3.3.2/armv7 cargo ndk --target armeabi-v7a build --release -Z build-std
 RUN llvm-strip ../target/armv7-linux-androideabi/release/libzingo.so
 
 #RUN AR=llvm-ar LD=ld RANLIB=llvm-ranlib CC=i686-linux-android24-clang \
-#    OPENSSL_DIR=/opt/openssl-3.4.1/x86 cargo +nightly build -Z build-std \
+#    OPENSSL_DIR=/opt/openssl-3.3.2/x86 cargo +nightly build -Z build-std \
 #    --target i686-linux-android --release
-RUN OPENSSL_DIR=/opt/openssl-3.4.1/x86 cargo ndk --target x86 build --release -Z build-std
+RUN OPENSSL_DIR=/opt/openssl-3.3.2/x86 cargo ndk --target x86 build --release -Z build-std
 RUN llvm-strip ../target/i686-linux-android/release/libzingo.so

--- a/rust/android/builder/Dockerfile
+++ b/rust/android/builder/Dockerfile
@@ -15,6 +15,7 @@ RUN apt update \
     libclang1 \
     llvm-dev \
     libclang-dev \
+    libatomic1 \
     clang \
     make \
     curl \
@@ -71,17 +72,17 @@ RUN echo "[target.x86_64-linux-android]" >> $CARGO_HOME/config.toml \
 
 # Install and setup OpenSSL
 WORKDIR /opt
-RUN curl -LO https://www.openssl.org/source/openssl-3.4.1.tar.gz -o openssl-3.4.1.tar.gz \
-    && tar xvf openssl-3.4.1.tar.gz \
-    && rm -rf openssl-3.4.1.tar.gz
+RUN curl -LO https://www.openssl.org/source/openssl-3.3.2.tar.gz -o openssl-3.3.2.tar.gz \
+    && tar xvf openssl-3.3.2.tar.gz \
+    && rm -rf openssl-3.3.2.tar.gz
 ENV OPENSSL_STATIC=yes
-WORKDIR /opt/openssl-3.4.1 
+WORKDIR /opt/openssl-3.3.2 
 RUN mkdir x86 \
     && mkdir aarch64 \
     && mkdir armv7 \
     && mkdir x86_64
 
-RUN ./Configure --prefix=/opt/openssl-3.4.1/aarch64 android-arm64 \
+RUN ./Configure --prefix=/opt/openssl-3.3.2/aarch64 android-arm64 \
     -mno-outline-atomics \
     -U__ANDROID_API__ \
     -D__ANDROID_API__=24 \
@@ -89,23 +90,23 @@ RUN ./Configure --prefix=/opt/openssl-3.4.1/aarch64 android-arm64 \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
-RUN ./Configure --prefix=/opt/openssl-3.4.1/armv7 android-arm \
+RUN ./Configure --prefix=/opt/openssl-3.3.2/armv7 android-arm \
     -U__ANDROID_API__ \
     -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
-# openssl-3.4.1 -> remove: -DBROKEN_CLANG_ATOMICS \
-RUN ./Configure --prefix=/opt/openssl-3.4.1/x86 android-x86 \
-    -latomic \
+RUN ./Configure --prefix=/opt/openssl-3.3.2/x86 android-x86 \
+    -DBROKEN_CLANG_ATOMICS \
+    #-latomic \
     -U__ANDROID_API__ \
     -D__ANDROID_API__=24 \
     && make -j$(nproc) \
     && make -j$(nproc) install \
     && make clean \
     && make distclean
-RUN ./Configure --prefix=/opt/openssl-3.4.1/x86_64 android-x86_64 \
+RUN ./Configure --prefix=/opt/openssl-3.3.2/x86_64 android-x86_64 \
     -U__ANDROID_API__ \
     -D__ANDROID_API__=24 \
     && make -j$(nproc) \


### PR DESCRIPTION
Detected some errors in i868-linux-android (x86) in CI nightly.

`dlopen failed: cannot locate symbol "__atomic_fetch_add_8" referenced by "/data/app/org.ZingoLabs.Zingo-reJnQKpu-uHyQUOU5UzxiQ==/base.apk!/lib/x86/libuniffi_zingo.so"...`