### PR TITLE
Pin `cargo-ndk` version 

### DIFF
--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -77,7 +77,7 @@ jobs:
             clang-18 \
             libclang-18-dev \
             gcc \
-            g++ 
+            g++
 
       - name: Set envs for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}
@@ -120,7 +120,7 @@ jobs:
         with:
           name: kotlin-android-uniffi-${{ env.ARCH }}-${{ env.CACHE-KEY }}
           path: android/app/build/generated/source/uniffi/release/java/uniffi/zingo/zingo.kt
-          
+
       - name: Set envs for x86_64
         if: ${{ env.ARCH == 'x86_64' }}
         run: |
@@ -167,7 +167,7 @@ jobs:
           LD: ld
           RANLIB: llvm-ranlib
           CC: ${{ env.CC }}24-clang
-          OPENSSL_DIR: /opt/openssl-3.3.2/${{ env.OPENSSL_PATH }}
+          # OPENSSL_DIR: /opt/openssl-3.3.2/${{ env.OPENSSL_PATH }}
           CARGO_FEATURE_STD: ${{ env.CARGO_FEATURE_STD }}
           LIBCLANG_PATH: /usr/lib/llvm-18/lib
 

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -108,17 +108,6 @@ jobs:
       - name: AWS libcrypto rust building
         run: cargo install --force --locked bindgen-cli
 
-      - name: Run dummy Gradle task to install NDK
-        run: |
-          cd android
-          ./gradlew tasks
-
-      - name: Locate Android NDK path
-        id: locate-ndk
-        run: |
-          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/$(ls $ANDROID_SDK_ROOT/ndk | sort -V | tail -n1)" >> $GITHUB_ENV
-          echo "BINDGEN_EXTRA_CLANG_ARGS=--sysroot=$ANDROID_SDK_ROOT/ndk/$(ls $ANDROID_SDK_ROOT/ndk | sort -V | tail -n1)/toolchains/llvm/prebuilt/linux-x86_64/sysroot" >> $GITHUB_ENV
-
       - name: Cargo uniffi kotlin
         working-directory: ./rust/lib
         run: |
@@ -178,7 +167,7 @@ jobs:
           LD: ld
           RANLIB: llvm-ranlib
           CC: ${{ env.CC }}24-clang
-          # OPENSSL_DIR: /opt/openssl-3.3.2/${{ env.OPENSSL_PATH }}
+          OPENSSL_DIR: /opt/openssl-3.3.2/${{ env.OPENSSL_PATH }}
           CARGO_FEATURE_STD: ${{ env.CARGO_FEATURE_STD }}
           LIBCLANG_PATH: /usr/lib/llvm-18/lib
 

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -83,10 +83,6 @@ jobs:
         if: ${{ contains(github.repository, 'zingolib') }}
         run: echo "REPO-OWNER=zingolabs" >> $GITHUB_ENV
 
-      - name: Set envs for NDK
-        run: |
-          echo $ANDROID_HOME
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -108,6 +108,15 @@ jobs:
       - name: AWS libcrypto rust building
         run: cargo install --force --locked bindgen-cli
 
+      - name: Run dummy Gradle task to install NDK
+        run: ./gradlew tasks
+
+      - name: Locate Android NDK path
+        id: locate-ndk
+        run: |
+          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/$(ls $ANDROID_SDK_ROOT/ndk | sort -V | tail -n1)" >> $GITHUB_ENV
+          echo "BINDGEN_EXTRA_CLANG_ARGS=--sysroot=$ANDROID_SDK_ROOT/ndk/$(ls $ANDROID_SDK_ROOT/ndk | sort -V | tail -n1)/toolchains/llvm/prebuilt/linux-x86_64/sysroot" >> $GITHUB_ENV
+
       - name: Cargo uniffi kotlin
         working-directory: ./rust/lib
         run: |

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -109,7 +109,9 @@ jobs:
         run: cargo install --force --locked bindgen-cli
 
       - name: Run dummy Gradle task to install NDK
-        run: ./gradlew tasks
+        run: |
+          cd android
+          ./gradlew tasks
 
       - name: Locate Android NDK path
         id: locate-ndk

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Set envs for NDK
         run: |
-          echo $ANDROID_HOME >> $GITHUB_ENV
+          echo $ANDROID_HOME
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -85,12 +85,7 @@ jobs:
 
       - name: Set envs for NDK
         run: |
-          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
-          ndk_path=$(ls -d ${ANDROID_SDK_ROOT}/ndk/* | sort -V | tail -n1)
-          echo "ANDROID_NDK${ndk_path}" >> $GITHUB_ENV
-          echo "ANDROID_NDK_HOME=${ANDROID_NDK}" >> $GITHUB_ENV
-          echo "ANDROID_NDK_ROOT=${ANDROID_NDK}" >> $GITHUB_ENV
-          echo "BINDGEN_EXTRA_CLANG_ARGS="--sysroot=${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"" >> $GITHUB_ENV
+          echo $ANDROID_HOME >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -83,6 +83,15 @@ jobs:
         if: ${{ contains(github.repository, 'zingolib') }}
         run: echo "REPO-OWNER=zingolabs" >> $GITHUB_ENV
 
+      - name: Set envs for NDK
+        run: |
+          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
+          ndk_path=$(ls -d ${ANDROID_SDK_ROOT}/ndk/* | sort -V | tail -n1)
+          echo "ANDROID_NDK${ndk_path}" >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=${ANDROID_NDK}" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=${ANDROID_NDK}" >> $GITHUB_ENV
+          echo "BINDGEN_EXTRA_CLANG_ARGS="--sysroot=${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2301,15 +2301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.4.2+3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,7 +2308,6 @@ checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5062,8 +5052,6 @@ dependencies = [
  "http",
  "lazy_static",
  "log",
- "openssl-src",
- "openssl-sys",
  "rustls",
  "tokio",
  "uniffi",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2301,6 +2301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.2+3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2317,7 @@ checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5052,6 +5062,8 @@ dependencies = [
  "http",
  "lazy_static",
  "log",
+ "openssl-src",
+ "openssl-sys",
  "rustls",
  "tokio",
  "uniffi",

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo run --release --features=uniffi/cli --bin uniffi-bindgen \
     generate ./src/zingo.udl --language kotlin \ 
     --out-dir ./src
 
-RUN cargo install --version ^3 cargo-ndk
+RUN cargo install --version 3.5.4 cargo-ndk
 
 ENV SOURCE_DATE_EPOCH=1710000000
 ENV ZERO_AR_DATE=1
@@ -54,7 +54,6 @@ ENV LIBCLANG_PATH=/usr/lib/llvm-18/lib
 
 # this is for indexmap 1.9.3 -> forcing `features = ["std"]`
 ENV CARGO_FEATURE_STD=true
-ENV OPENSSL_DIR=/opt/openssl-3.3.2/aarch64
 RUN cargo ndk --target arm64-v8a build --release -Z build-std
 RUN llvm-strip --strip-all ../target/aarch64-linux-android/release/libzingo.so
 RUN llvm-objcopy \
@@ -63,7 +62,6 @@ RUN llvm-objcopy \
 RUN sha256sum ../target/aarch64-linux-android/release/libzingo.so
 ENV CARGO_FEATURE_STD=false
 
-ENV OPENSSL_DIR=/opt/openssl-3.3.2/armv7
 RUN cargo ndk --target armeabi-v7a build --release -Z build-std
 RUN llvm-strip --strip-all ../target/armv7-linux-androideabi/release/libzingo.so
 RUN llvm-objcopy \
@@ -71,7 +69,6 @@ RUN llvm-objcopy \
     ../target/armv7-linux-androideabi/release/libzingo.so
 RUN sha256sum ../target/armv7-linux-androideabi/release/libzingo.so
 
-ENV OPENSSL_DIR=/opt/openssl-3.3.2/x86
 RUN cargo ndk --target x86 build --release -Z build-std
 RUN llvm-strip --strip-all ../target/i686-linux-android/release/libzingo.so
 RUN llvm-objcopy \
@@ -79,7 +76,6 @@ RUN llvm-objcopy \
     ../target/i686-linux-android/release/libzingo.so
 RUN sha256sum ../target/i686-linux-android/release/libzingo.so
 
-ENV OPENSSL_DIR=/opt/openssl-3.3.2/x86_64
 RUN cargo ndk --target x86_64 build --release -Z build-std
 RUN llvm-strip --strip-all ../target/x86_64-linux-android/release/libzingo.so
 RUN llvm-objcopy \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -54,6 +54,7 @@ ENV LIBCLANG_PATH=/usr/lib/llvm-18/lib
 
 # this is for indexmap 1.9.3 -> forcing `features = ["std"]`
 ENV CARGO_FEATURE_STD=true
+ENV OPENSSL_DIR=/opt/openssl-3.3.2/aarch64
 RUN cargo ndk --target arm64-v8a build --release -Z build-std
 RUN llvm-strip --strip-all ../target/aarch64-linux-android/release/libzingo.so
 RUN llvm-objcopy \
@@ -62,6 +63,7 @@ RUN llvm-objcopy \
 RUN sha256sum ../target/aarch64-linux-android/release/libzingo.so
 ENV CARGO_FEATURE_STD=false
 
+ENV OPENSSL_DIR=/opt/openssl-3.3.2/armv7
 RUN cargo ndk --target armeabi-v7a build --release -Z build-std
 RUN llvm-strip --strip-all ../target/armv7-linux-androideabi/release/libzingo.so
 RUN llvm-objcopy \
@@ -69,6 +71,7 @@ RUN llvm-objcopy \
     ../target/armv7-linux-androideabi/release/libzingo.so
 RUN sha256sum ../target/armv7-linux-androideabi/release/libzingo.so
 
+ENV OPENSSL_DIR=/opt/openssl-3.3.2/x86
 RUN cargo ndk --target x86 build --release -Z build-std
 RUN llvm-strip --strip-all ../target/i686-linux-android/release/libzingo.so
 RUN llvm-objcopy \
@@ -76,6 +79,7 @@ RUN llvm-objcopy \
     ../target/i686-linux-android/release/libzingo.so
 RUN sha256sum ../target/i686-linux-android/release/libzingo.so
 
+ENV OPENSSL_DIR=/opt/openssl-3.3.2/x86_64
 RUN cargo ndk --target x86_64 build --release -Z build-std
 RUN llvm-strip --strip-all ../target/x86_64-linux-android/release/libzingo.so
 RUN llvm-objcopy \

--- a/rust/build_fdroid.sh
+++ b/rust/build_fdroid.sh
@@ -138,7 +138,7 @@ cargo run --release --features=uniffi/cli --bin uniffi-bindgen \
     generate ./src/zingo.udl --language kotlin \
     --out-dir ./src
 
-cargo install --version ^3 cargo-ndk
+cargo install --version 3.5.4 cargo-ndk
 
 export LIBCLANG_PATH=/usr/lib/llvm-16/lib
 

--- a/rust/lib/Cargo.toml
+++ b/rust/lib/Cargo.toml
@@ -11,12 +11,19 @@ lazy_static = "1.4.0"
 base64 = "0.22"
 android_logger = "0.11"
 log = "0.4"
-uniffi = { workspace = true, features = [ "cli" ] }
+uniffi = { workspace = true, features = ["cli"] }
 tokio = { workspace = true }
 rustls = { workspace = true }
 
+[dependencies.openssl-sys]
+version = "0.9.107"
+features = ["vendored"]
+
+[dependencies.openssl-src]
+version = "300.3.2+3.3.2" # Equals to openssl=3.3.2
+
 [build-dependencies]
-uniffi_build = { version = "0.27", features = [ "builtin-bindgen" ] }
+uniffi_build = { version = "0.27", features = ["builtin-bindgen"] }
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/rust/lib/Cargo.toml
+++ b/rust/lib/Cargo.toml
@@ -15,12 +15,6 @@ uniffi = { workspace = true, features = ["cli"] }
 tokio = { workspace = true }
 rustls = { workspace = true }
 
-[dependencies.openssl-sys]
-version = "0.9.107"
-features = ["vendored"]
-
-[dependencies.openssl-src]
-version = "300.3.2+3.3.2" # Equals to openssl=3.3.2
 
 [build-dependencies]
 uniffi_build = { version = "0.27", features = ["builtin-bindgen"] }


### PR DESCRIPTION
<s>This PR also switches to `openssl-src` for version management.

Note: Zingolib 2.0 does not depend on `openssl` anymore, so this is change will need to be reapplied there, once it lands.
</s>

Edit: Usage of `openssl-src` does not make sense to be included in this PR.