### PR TITLE
Claude code improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ buck-out/
 # Keystore
 /android/app/Zingo.jks
 /android/local.zingo.jks.properties
+
+# Claude Code
+.claude/

--- a/__tests__/About.snapshot.tsx
+++ b/__tests__/About.snapshot.tsx
@@ -36,7 +36,7 @@ function makeDrawerProps(): DrawerScreenProps<
 describe('Component About - test', () => {
   //snapshot test
   test('About - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.translate = mockTranslate;
     state.info = mockInfo;
     state.totalBalance = mockTotalBalance;

--- a/__tests__/AddressBook.AbDetail.snapshot.tsx
+++ b/__tests__/AddressBook.AbDetail.snapshot.tsx
@@ -23,7 +23,7 @@ import { mockAddressBook } from '../__mocks__/dataMocks/mockAddressBook';
 // test suite
 describe('Component Address Book Details - test', () => {
   //snapshot test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.addressBook = mockAddressBook;
   state.translate = mockTranslate;
   const onCancel = jest.fn();

--- a/__tests__/AddressBook.snapshot.tsx
+++ b/__tests__/AddressBook.snapshot.tsx
@@ -35,7 +35,7 @@ function makeDrawerProps(): DrawerScreenProps<
 describe('Component Address Book - test', () => {
   //snapshot test
   test('Address Book - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.addressBook = mockAddressBook;
     state.translate = mockTranslate;
     const onSet = jest.fn();

--- a/__tests__/AddressList.snapshot.tsx
+++ b/__tests__/AddressList.snapshot.tsx
@@ -37,7 +37,7 @@ function makeDrawerProps(
 describe('Component Unified Address List - test', () => {
   //snapshot test
   test('Address Unified List - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.addresses = mockAddresses;
     state.translate = mockTranslate;
     const props = makeDrawerProps(AddressKindEnum.u);
@@ -50,7 +50,7 @@ describe('Component Unified Address List - test', () => {
   });
 
   test('Address Transparent List - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.addresses = mockAddresses;
     state.translate = mockTranslate;
     const props = makeDrawerProps(AddressKindEnum.t);

--- a/__tests__/Header.snapshot.tsx
+++ b/__tests__/Header.snapshot.tsx
@@ -20,7 +20,7 @@ import { ScreenEnum } from '../app/AppState';
 describe('Component Header - test', () => {
   //snapshot test
   test('Header Simple - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.translate = mockTranslate;
     const close = jest.fn();
     const about = render(
@@ -40,7 +40,7 @@ describe('Component Header - test', () => {
     expect(about.toJSON()).toMatchSnapshot();
   });
   test('Header Complex - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.translate = mockTranslate;
     state.info = mockInfo;
     state.totalBalance = mockTotalBalance;

--- a/__tests__/History.ValueTransferDetail.unit.tsx
+++ b/__tests__/History.ValueTransferDetail.unit.tsx
@@ -40,7 +40,7 @@ function makeDrawerProps(
 // test suite
 describe('Component History ValueTransferDetail - test', () => {
   //unit test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.translate = mockTranslate;
   state.info = mockInfo;
   state.totalBalance = mockTotalBalance;

--- a/__tests__/History.snapshot.tsx
+++ b/__tests__/History.snapshot.tsx
@@ -37,7 +37,7 @@ function makeDrawerProps(): DrawerScreenProps<
 // test suite
 describe('Component History - test', () => {
   //snapshot test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.valueTransfers = mockValueTransfers;
   state.addresses = mockAddresses;
   state.translate = mockTranslate;

--- a/__tests__/ImportUfvk.snapshot.tsx
+++ b/__tests__/ImportUfvk.snapshot.tsx
@@ -19,7 +19,7 @@ import { mockTotalBalance } from '../__mocks__/dataMocks/mockTotalBalance';
 describe('Component ImportUfvk - test', () => {
   //snapshot test
   test('ImportUfvk - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.translate = mockTranslate;
     state.info = mockInfo;
     state.totalBalance = mockTotalBalance;

--- a/__tests__/Info.es.unit.tsx
+++ b/__tests__/Info.es.unit.tsx
@@ -45,7 +45,7 @@ function makeDrawerProps(): DrawerScreenProps<
 describe('Component Info - test', () => {
   //unit test
   test('Info - price with es (,) decimal point', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.info = mockInfo;
     state.zecPrice = mockZecPrice;
     state.currency = CurrencyEnum.USDCurrency;

--- a/__tests__/Info.snapshot.tsx
+++ b/__tests__/Info.snapshot.tsx
@@ -37,7 +37,7 @@ function makeDrawerProps(): DrawerScreenProps<
 describe('Component Info - test', () => {
   //snapshot test
   test('Info - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.info = mockInfo;
     state.zecPrice = mockZecPrice;
     state.translate = mockTranslate;

--- a/__tests__/Info.us.unit.tsx
+++ b/__tests__/Info.us.unit.tsx
@@ -35,7 +35,7 @@ function makeDrawerProps(): DrawerScreenProps<
 describe('Component Info - test', () => {
   //unit test
   test('Info - price with us (.) decimal point', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.info = mockInfo;
     state.zecPrice = mockZecPrice;
     state.currency = CurrencyEnum.USDCurrency;

--- a/__tests__/Insight.snapshot.tsx
+++ b/__tests__/Insight.snapshot.tsx
@@ -36,7 +36,7 @@ function makeDrawerProps(): DrawerScreenProps<
 describe('Component Insight - test', () => {
   //snapshot test
   test('Insight - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.translate = mockTranslate;
     state.info = mockInfo;
     state.totalBalance = mockTotalBalance;

--- a/__tests__/Memo.snapshot.tsx
+++ b/__tests__/Memo.snapshot.tsx
@@ -38,7 +38,7 @@ function makeDrawerProps(): DrawerScreenProps<
 describe('Component Memo - test', () => {
   //snapshot test
   test('Memo - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.translate = mockTranslate;
     const props = makeDrawerProps();
     const memo = render(

--- a/__tests__/Pools.snapshot.tsx
+++ b/__tests__/Pools.snapshot.tsx
@@ -35,7 +35,7 @@ function makeDrawerProps(): DrawerScreenProps<
 // test suite
 describe('Component Pools - test', () => {
   //snapshot test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.translate = mockTranslate;
   state.info = mockInfo;
   state.totalBalance = mockTotalBalance;

--- a/__tests__/Receive.snapshot.tsx
+++ b/__tests__/Receive.snapshot.tsx
@@ -37,7 +37,7 @@ function makeDrawerProps(): DrawerScreenProps<
 describe('Component Receive - test', () => {
   //snapshot test
   test('Receive - snapshot', () => {
-    const state = defaultAppContextLoaded;
+    const state = { ...defaultAppContextLoaded };
     state.addresses = mockAddresses;
     state.translate = mockTranslate;
     state.info = mockInfo;

--- a/__tests__/Rescan.snapshot.tsx
+++ b/__tests__/Rescan.snapshot.tsx
@@ -36,7 +36,7 @@ function makeDrawerProps(): DrawerScreenProps<
 // test suite
 describe('Component Rescan - test', () => {
   //snapshot test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.translate = mockTranslate;
   state.info = mockInfo;
   state.totalBalance = mockTotalBalance;

--- a/__tests__/Seed.snapshot.tsx
+++ b/__tests__/Seed.snapshot.tsx
@@ -40,7 +40,7 @@ function makeDrawerProps(
 // test suite
 describe('Component Seed - test', () => {
   //snapshot test
-  const stateLoaded = defaultAppContextLoaded;
+  const stateLoaded = { ...defaultAppContextLoaded };
   stateLoaded.translate = mockTranslate;
   stateLoaded.birthday = mockWallet.birthday || 0;
   stateLoaded.info = mockInfo;

--- a/__tests__/Send.snapshot.tsx
+++ b/__tests__/Send.snapshot.tsx
@@ -39,7 +39,7 @@ function makeDrawerProps(): DrawerScreenProps<
 // test suite
 describe('Component Send - test', () => {
   //snapshot test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.valueTransfers = mockValueTransfers;
   state.addresses = mockAddresses;
   state.translate = mockTranslate;

--- a/__tests__/Settings.snapshot.tsx
+++ b/__tests__/Settings.snapshot.tsx
@@ -41,7 +41,7 @@ function makeDrawerProps(): DrawerScreenProps<
 // test suite
 describe('Component Settings - test', () => {
   //snapshot test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.translate = mockTranslate;
   state.info = mockInfo;
   state.totalBalance = mockTotalBalance;

--- a/__tests__/ShowUfvk.snapshot.tsx
+++ b/__tests__/ShowUfvk.snapshot.tsx
@@ -37,7 +37,7 @@ function makeDrawerProps(
 // test suite
 describe('Component ShowUfvk - test', () => {
   //snapshot test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.translate = mockTranslate;
   state.info = mockInfo;
   state.totalBalance = mockTotalBalance;

--- a/__tests__/SyncReport.snapshot.tsx
+++ b/__tests__/SyncReport.snapshot.tsx
@@ -38,7 +38,7 @@ function makeDrawerProps(): DrawerScreenProps<
 // test suite
 describe('Component SyncReport - test', () => {
   //snapshot test
-  const state = defaultAppContextLoaded;
+  const state = { ...defaultAppContextLoaded };
   state.translate = mockTranslate;
   state.info = mockInfo;
   state.totalBalance = mockTotalBalance;

--- a/app/AppState/const/GlobalConst.ts
+++ b/app/AppState/const/GlobalConst.ts
@@ -1,5 +1,5 @@
 export const GlobalConst = {
-  error: 'error',
+  error: 'error:',
   zcash: 'zcash:',
   port80: '80',
   port443: '443',

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -69,7 +69,6 @@ import {
   EventListenerEnum,
   AppContextLoaded,
   NetInfoType,
-  WalletType,
   BackgroundErrorType,
   ValueTransferType,
   ValueTransferKindEnum,
@@ -276,7 +275,6 @@ export default function LoadedApp(props: LoadedAppProps) {
 
       //I have to check what language is in the settings
       const settings = await SettingsFileImpl.readSettings();
-      //console.log('LoadedApp', settings);
 
       // for testing
       //await delay(5000);
@@ -290,7 +288,6 @@ export default function LoadedApp(props: LoadedAppProps) {
       ) {
         setLanguage(settings.language);
         i18n.locale = settings.language;
-        //console.log('apploaded settings', settings.language, settings.currency);
       } else {
         const lang =
           languageTag === LanguageEnum.en ||
@@ -303,7 +300,6 @@ export default function LoadedApp(props: LoadedAppProps) {
         setLanguage(lang);
         i18n.locale = lang;
         await SettingsFileImpl.writeSettings(SettingsNameEnum.language, lang);
-        //console.log('apploaded NO settings', languageTag);
       }
       if (
         settings.currency === CurrencyEnum.noCurrency ||
@@ -460,7 +456,6 @@ export default function LoadedApp(props: LoadedAppProps) {
           if (!a.hasOwnProperty('own')) {
             // verify this address as own or not
             const checkStr = await RPCModule.checkMyAddressInfo(a.address);
-            //console.log(checkStr);
             if (
               checkStr &&
               !checkStr.toLowerCase().startsWith(GlobalConst.error)
@@ -510,7 +505,6 @@ export default function LoadedApp(props: LoadedAppProps) {
             let own: boolean;
             // verify this address as own or not
             const checkStr = await RPCModule.checkMyAddressInfo(a.address);
-            //console.log(checkStr);
             if (
               checkStr &&
               !checkStr.toLowerCase().startsWith(GlobalConst.error)
@@ -546,12 +540,9 @@ export default function LoadedApp(props: LoadedAppProps) {
       setAddressBook(abSorted);
       await AddressBookFileImpl.writeAddressBook(abSorted);
       setLoading(false);
-      //console.log('LoadedApp functional component - finished');
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  //console.log('render LoadedApp - 2');
 
   if (loading) {
     return (
@@ -793,8 +784,6 @@ export class LoadedAppClass extends Component<
       }
     }
 
-    //console.log('DID MOUNT APPLOADED...');
-
     // Configure the RPC to start doing refreshes
     await this.rpc.clearTimers();
     await this.rpc.configure();
@@ -804,7 +793,6 @@ export class LoadedAppClass extends Component<
     this.appstate = AppState.addEventListener(
       EventListenerEnum.change,
       async nextAppState => {
-        //console.log('LOADED', 'prior', this.state.appStateStatus, 'next', nextAppState);
         // let's catch the prior value
         const priorAppState = this.state.appStateStatus;
         if (Platform.OS === GlobalConst.platformOSios) {
@@ -814,7 +802,6 @@ export class LoadedAppClass extends Component<
             (priorAppState === AppStateStatusEnum.active &&
               nextAppState === AppStateStatusEnum.inactive)
           ) {
-            //console.log('LOADED SAVED IOS do nothing', nextAppState);
             this.setState({ appStateStatus: nextAppState });
             return;
           }
@@ -826,12 +813,8 @@ export class LoadedAppClass extends Component<
             this.setState({ appStateStatus: nextAppState });
             // setting value for background task Android
             await AsyncStorage.setItem(GlobalConst.background, GlobalConst.yes);
-            //console.log('&&&&& background yes in storage &&&&&');
             await this.rpc.clearTimers();
-            //console.log('clear timers IOS');
             this.setSyncingStatus({} as RPCSyncStatusType);
-            //console.log('clear sync status state');
-            //console.log('LOADED SAVED IOS background', nextAppState);
             // We need to save the wallet file here because
             // sometimes the App can lose the last synced chunk
             await RPCModule.doSave();
@@ -840,7 +823,6 @@ export class LoadedAppClass extends Component<
         }
         if (Platform.OS === GlobalConst.platformOSandroid) {
           if (priorAppState !== nextAppState) {
-            //console.log('LOADED SAVED Android', nextAppState);
             this.setState({ appStateStatus: nextAppState });
           }
         }
@@ -849,9 +831,7 @@ export class LoadedAppClass extends Component<
             priorAppState === AppStateStatusEnum.background) &&
           nextAppState === AppStateStatusEnum.active
         ) {
-          //console.log('App LOADED Android & IOS has come to the foreground!');
           if (Platform.OS === GlobalConst.platformOSios) {
-            //console.log('LOADED SAVED IOS foreground', nextAppState);
             this.setState({ appStateStatus: nextAppState });
           }
           // (PIN or TouchID or FaceID)
@@ -862,7 +842,6 @@ export class LoadedAppClass extends Component<
           // - true      -> the user do pass the authentication
           // - false     -> the user do NOT pass the authentication
           // - undefined -> no biometric authentication available -> Passcode -> Nothing.
-          //console.log('BIOMETRIC FOREGROUND --------> ', resultBio);
           if (resultBio === false) {
             this.navigateToLoadingApp({
               startingApp: true,
@@ -873,12 +852,10 @@ export class LoadedAppClass extends Component<
             await this.fetchBackgroundSyncInfo();
             // setting value for background task Android
             await AsyncStorage.setItem(GlobalConst.background, GlobalConst.no);
-            //console.log('&&&&& background no in storage &&&&&');
             // needs this because when the App go from back to fore
             // it have to re-launch all the tasks.
             await this.rpc.clearTimers();
             await this.rpc.configure();
-            //console.log('configure start timers Android & IOS');
             if (
               this.state.backgroundError &&
               (this.state.backgroundError.title ||
@@ -899,22 +876,17 @@ export class LoadedAppClass extends Component<
           console.log('App LOADED is gone to the background!');
           // setting value for background task Android
           await AsyncStorage.setItem(GlobalConst.background, GlobalConst.yes);
-          //console.log('&&&&& background yes in storage &&&&&');
           await this.rpc.clearTimers();
-          //console.log('clear timers');
           this.setSyncingStatus({} as RPCSyncStatusType);
-          //console.log('clear sync status state');
           // We need to save the wallet file here because
           // sometimes the App can lose the last synced chunk
           await RPCModule.doSave();
           if (Platform.OS === GlobalConst.platformOSios) {
-            //console.log('LOADED SAVED IOS background', nextAppState);
             this.setState({ appStateStatus: nextAppState });
           }
         } else {
           if (Platform.OS === GlobalConst.platformOSios) {
             if (priorAppState !== nextAppState) {
-              //console.log('LOADED SAVED IOS', nextAppState);
               this.setState({ appStateStatus: nextAppState });
             }
           }
@@ -954,7 +926,6 @@ export class LoadedAppClass extends Component<
           type !== state.type ||
           isConnectionExpensive !== state.details?.isConnectionExpensive
         ) {
-          //console.log('fetch net info');
           this.setState({
             netInfo: {
               isConnected: state.isConnected,
@@ -965,9 +936,7 @@ export class LoadedAppClass extends Component<
           });
           if (isConnected !== state.isConnected) {
             if (!state.isConnected) {
-              //console.log('EVENT Loaded: No internet connection.');
             } else {
-              //console.log('EVENT Loaded: YES internet connection.');
               // restart the interval process again...
               await this.rpc.clearTimers();
               await this.rpc.configure();
@@ -998,7 +967,6 @@ export class LoadedAppClass extends Component<
   };
 
   readUrl = async (url: string) => {
-    //console.log(url);
     // Attempt to parse as URI if it starts with zcash
     // only if it is a spendable wallet
     if (url && url.startsWith(GlobalConst.zcash) && !this.state.readOnly) {
@@ -1007,7 +975,6 @@ export class LoadedAppClass extends Component<
         this.state.translate,
         this.state.server,
       );
-      //console.log(targets);
 
       if (target) {
         let update = false;
@@ -1021,7 +988,7 @@ export class LoadedAppClass extends Component<
               // fill the fields in the screen with the donation data
               update = true;
             })
-            .catch(() => {});
+            .catch(() => {}); // user cancelled the alert — expected
         } else if (target.address) {
           // fill the fields in the screen with the donation data
           update = true;
@@ -1058,7 +1025,6 @@ export class LoadedAppClass extends Component<
     const backgroundSyncInfoJson: BackgroundType =
       await BackgroundFileImpl.readBackground();
     if (!isEqual(this.state.backgroundSyncInfo, backgroundSyncInfoJson)) {
-      //console.log('fetch background sync info');
       this.setState({ backgroundSyncInfo: backgroundSyncInfoJson });
     }
   };
@@ -1073,7 +1039,6 @@ export class LoadedAppClass extends Component<
   setShieldingAmount = (value: number) => {
     //const start = Date.now();
     this.setState({ shieldingAmount: value });
-    //console.log('=========================================== > SH AMOUNT STORED SETSTATE - ', Date.now() - start);
   };
 
   setShowSwipeableIcons = (value: boolean) => {
@@ -1082,10 +1047,8 @@ export class LoadedAppClass extends Component<
 
   setTotalBalance = (totalBalance: TotalBalanceClass) => {
     if (!isEqual(this.state.totalBalance, totalBalance)) {
-      //console.log('fetch total balance');
       //const start = Date.now();
       this.setState({ totalBalance });
-      //console.log('=========================================== > BALANCE STORED SETSTATE - ', Date.now() - start);
     }
   };
 
@@ -1093,10 +1056,8 @@ export class LoadedAppClass extends Component<
     // here is a good place to fetch the background task info
     this.fetchBackgroundSyncInfo();
     if (!isEqual(this.state.syncingStatus, syncingStatus)) {
-      //console.log('fetch syncing status report');
       //const start = Date.now();
       this.setState({ syncingStatus });
-      //console.log('=========================================== > SYNC STATUS STORED SETSTATE - ', Date.now() - start);
     }
   };
 
@@ -1164,8 +1125,6 @@ export class LoadedAppClass extends Component<
                 vt.address === vtOld.address &&
                 vt.poolType === vtOld.poolType,
             );
-            //console.log('old', vtOld);
-            //console.log('new', vtNew);
             // the ValueTransfer is confirmed when the confirmations are > 0
             if (vtNew.length > 0 && vtNew[0].confirmations > 0) {
               let message: string = '';
@@ -1289,7 +1248,6 @@ export class LoadedAppClass extends Component<
         },
         pending === 0 ? 250 : 0,
       );
-      //console.log(
       //  '=========================================== > VALUE TRANSFERS STORED SETSTATE - ',
       //  Date.now() - start,
       //);
@@ -1301,10 +1259,8 @@ export class LoadedAppClass extends Component<
       !isEqual(this.state.messages, messages) ||
       this.state.messagesTotal !== messagesTotal
     ) {
-      //console.log('fetch messages');
       //const start = Date.now();
       this.setState({ messages, messagesTotal });
-      //console.log('=========================================== > MESSAGES STORED SETSTATE - ', Date.now() - start);
     }
   };
 
@@ -1312,10 +1268,8 @@ export class LoadedAppClass extends Component<
     addresses: (UnifiedAddressClass | TransparentAddressClass)[],
   ) => {
     if (!isEqual(this.state.addresses, addresses)) {
-      //console.log('fetch addresses');
       //const start = Date.now();
       this.setState({ addresses });
-      //console.log('=========================================== > ADDRESSES STORED SETSTATE - ', Date.now() - start);
     }
     if (addresses.length > 0) {
       // the last Unified Address created.
@@ -1334,10 +1288,8 @@ export class LoadedAppClass extends Component<
   };
 
   setSendPageState = (sendPageState: SendPageStateClass) => {
-    //console.log('fetch send page state');
     //const start = Date.now();
     this.setState({ sendPageState });
-    //console.log('=========================================== > SEND PAGE STORED SETSTATE - ', Date.now() - start);
   };
 
   clearToAddr = () => {
@@ -1351,13 +1303,11 @@ export class LoadedAppClass extends Component<
   };
 
   setZecPrice = (newZecPrice: number, newDate: number) => {
-    //console.log(this.state.zecPrice, newZecPrice);
     const zecPrice = {
       zecPrice: newZecPrice,
       date: newDate,
     } as ZecPriceType;
     if (!isEqual(this.state.zecPrice, zecPrice)) {
-      //console.log('fetch zec price');
       this.setState({ zecPrice });
     }
   };
@@ -1385,8 +1335,6 @@ export class LoadedAppClass extends Component<
       }
       //const start = Date.now();
       this.setState({ info: newInfo });
-      //console.log('=========================================== > INFO STORED SETSTATE - ', Date.now() - start);
-      //console.log('SET', newInfo);
     }
   };
 
@@ -1394,8 +1342,6 @@ export class LoadedAppClass extends Component<
     if (!this.state.zingolibVersion) {
       //const start = Date.now();
       this.setState({ zingolibVersion: newZingolibVersion });
-      //console.log('=========================================== > ZINGOLIB STORED SETSTATE - ', Date.now() - start);
-      //console.log('SET', newZingolibVersion);
     }
   };
 
@@ -1413,17 +1359,14 @@ export class LoadedAppClass extends Component<
       );
       //const start = Date.now();
       const txid = await this.rpc.sendTransaction(sendJson);
-      //console.log('&&&&&&&&&&&&&& send tx', Date.now() - start);
 
       return txid;
     } catch (err) {
-      //console.log('route sendtx error', err);
       throw err;
     }
   };
 
   doRefresh = (screen: ScreenEnum) => {
-    //console.log('================== MANUAL REFRESH ================== ', screen);
     if (screen === ScreenEnum.History || screen === ScreenEnum.ContactList) {
       // Value Transfers
       this.rpc.fetchTandZandOValueTransfers();
@@ -1444,7 +1387,6 @@ export class LoadedAppClass extends Component<
     if (!isEqual(this.state.birthday, birthday)) {
       //const start = Date.now();
       this.setState({ birthday });
-      //console.log('=========================================== > WALLET STORED SETSTATE - ', Date.now() - start);
     }
   };
 
@@ -1612,7 +1554,6 @@ export class LoadedAppClass extends Component<
         this.state.performanceLevel,
         GlobalConst.minConfirmations.toString(),
       );
-      //console.log('load existing wallet', result);
       if (result && !result.toLowerCase().startsWith(GlobalConst.error)) {
         try {
           // here result can have an `error` field for watch-only which is actually OK.
@@ -1620,7 +1561,6 @@ export class LoadedAppClass extends Component<
             await JSON.parse(result);
           if (!resultJson.error) {
             // Load the wallet and navigate to the ValueTransfers screen
-            //console.log(`wallet loaded ok ${value.uri}`);
             if (toast && selectServer !== SelectServerEnum.offline) {
               this.addLastSnackbar({
                 message: `${this.state.translate('loadedapp.readingwallet')} ${value.uri}`,
@@ -1677,7 +1617,6 @@ export class LoadedAppClass extends Component<
           action: SeedActionEnum.server,
         });
       }
-      //console.log(`Error Reading Wallet ${value} - ${error}`);
       if (toast) {
         this.addLastSnackbar({
           message: `${this.state.translate('loadedapp.readingwallet-error')} ${value.uri}`,
@@ -1711,16 +1650,12 @@ export class LoadedAppClass extends Component<
     ) {
       // when the user select USD
       // the App have to create a Tor Client
-      //console.log('before CREATE ------------------- TOR CLIENT');
       const result = await RPCModule.createTorClientProcess();
-      //console.log('after CREATE ------------------- TOR CLIENT', result);
       if (result && result.toLowerCase().startsWith(GlobalConst.error)) {
         this.setLastError(`Create tor client error: ${result}`);
       }
     } else {
-      //console.log('before REMOVE ------------------- TOR CLIENT');
       const result = await RPCModule.removeTorClientProcess();
-      //console.log('after REMOVE ------------------- TOR CLIENT', result);
       if (result && result.toLowerCase().startsWith(GlobalConst.error)) {
         this.setLastError(`Remove tor client error: ${result}`);
       }
@@ -1802,8 +1737,10 @@ export class LoadedAppClass extends Component<
     if (!value) {
       await removeRecoveryWalletInfo();
     } else {
-      const wallet: WalletType = await RPC.rpcFetchWallet(this.state.readOnly);
-      await createUpdateRecoveryWalletInfo(wallet);
+      const wallet = await RPC.rpcFetchWallet(this.state.readOnly);
+      if (wallet) {
+        await createUpdateRecoveryWalletInfo(wallet);
+      }
     }
   };
 
@@ -1872,9 +1809,7 @@ export class LoadedAppClass extends Component<
       resultStr = (await this.rpc.changeWalletNoBackup()) as string;
     }
 
-    //console.log("jc change", resultStr);
     if (resultStr && resultStr.toLowerCase().startsWith(GlobalConst.error)) {
-      //console.log(`Error change wallet. ${resultStr}`);
       createAlert(
         this.setBackgroundError,
         this.addLastSnackbar,
@@ -1896,9 +1831,7 @@ export class LoadedAppClass extends Component<
   onClickOKRestoreBackup = async () => {
     const resultStr = (await this.rpc.restoreBackup()) as string;
 
-    //console.log("jc restore", resultStr);
     if (resultStr && resultStr.toLowerCase().startsWith(GlobalConst.error)) {
-      //console.log(`Error restore backup wallet. ${resultStr}`);
       createAlert(
         this.setBackgroundError,
         this.addLastSnackbar,
@@ -1934,20 +1867,17 @@ export class LoadedAppClass extends Component<
         resultStrServerPromise,
         timeoutServerPromise,
       ]);
-      //console.log(resultStrServer);
 
       if (
         resultStrServer &&
         resultStrServer.toLowerCase().startsWith(GlobalConst.error)
       ) {
-        //console.log(`Error change server ${value} - ${resultStr}`);
         this.addLastSnackbar({
           message: `${this.state.translate('loadedapp.changeservernew-error')} ${resultStrServer}`,
           screenName: [this.screenName],
         });
         return;
       } else {
-        //console.log(`change server ok ${value}`);
       }
 
       await SettingsFileImpl.writeSettings(
@@ -1977,12 +1907,10 @@ export class LoadedAppClass extends Component<
         resultStr2 = (await this.rpc.changeWalletNoBackup()) as string;
       }
 
-      //console.log("jc change", resultStr);
       if (
         resultStr2 &&
         resultStr2.toLowerCase().startsWith(GlobalConst.error)
       ) {
-        //console.log(`Error change wallet. ${resultStr}`);
         createAlert(
           this.setBackgroundError,
           this.addLastSnackbar,
@@ -2225,11 +2153,6 @@ export class LoadedAppClass extends Component<
         </View>
       );
     };
-
-    //console.log('render LoadedAppClass - 3');
-    //console.log('vt', valueTransfers);
-    //console.log('ad', addresses);
-    //console.log('ba', totalBalance);
 
     return (
       <ToastProvider>

--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -184,10 +184,8 @@ export default function LoadingApp(props: LoadingAppProps) {
 
       //I have to check what language and other things are in the settings
       const settings = await SettingsFileImpl.readSettings();
-      //console.log('LoadingApp', settings);
 
       // checking the version of the App in settings
-      //console.log('versions, old:', settings.version, ' new:', translate('version') as string);
       if (settings.version === null) {
         // this is a fresh install
         setFirstLaunchingMessage(LaunchingModeEnum.installing);
@@ -214,7 +212,6 @@ export default function LoadingApp(props: LoadingAppProps) {
 
       // first I need to know if this launch is a fresh install...
       // if firstInstall is true -> 100% is the first time.
-      //console.log('first install', settings.firstInstall);
       if (settings.firstInstall) {
         // basic mode
         setMode(ModeEnum.basic);
@@ -246,7 +243,6 @@ export default function LoadingApp(props: LoadingAppProps) {
       ) {
         setLanguage(settings.language);
         i18n.locale = settings.language;
-        //console.log('apploading settings', settings.language, settings.currency);
       } else {
         const lang =
           languageTag === LanguageEnum.en ||
@@ -259,7 +255,6 @@ export default function LoadingApp(props: LoadingAppProps) {
         setLanguage(lang);
         i18n.locale = lang;
         await SettingsFileImpl.writeSettings(SettingsNameEnum.language, lang);
-        //console.log('apploading NO settings', languageTag);
       }
       if (
         settings.currency === CurrencyEnum.noCurrency ||
@@ -387,8 +382,6 @@ export default function LoadingApp(props: LoadingAppProps) {
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  //console.log('render loadingApp - 2', translate('version'));
 
   if (loading) {
     return (
@@ -547,8 +540,6 @@ export class LoadingAppClass extends Component<
 
     this.fetchZingolibVersion();
 
-    //console.log('DID MOUNT APPLOADING...');
-
     // to start the App the first time in this session
     // the user have to pass the security of the device
     if (this.state.startingApp) {
@@ -562,7 +553,6 @@ export class LoadingAppClass extends Component<
         // - true      -> the user do pass the authentication
         // - false     -> the user do NOT pass the authentication
         // - undefined -> no biometric authentication available -> Passcode.
-        //console.log('BIOMETRIC --------> ', resultBio);
         if (resultBio === false) {
           this.setState({ biometricsFailed: true });
           return;
@@ -591,7 +581,7 @@ export class LoadingAppClass extends Component<
           this.setState({ donation: true });
           SettingsFileImpl.writeSettings(SettingsNameEnum.donation, true);
         })
-        .catch(() => {});
+        .catch(() => {}); // user cancelled the alert — expected
     }
 
     // has the device the Wallet Keys stored?
@@ -628,9 +618,7 @@ export class LoadingAppClass extends Component<
 
     // Second, check if a wallet exists. Do it async so the basic screen has time to render
     await AsyncStorage.setItem(GlobalConst.background, GlobalConst.no);
-    //console.log('&&&&& background no in storage &&&&&');
     const exists = await RPCModule.walletExists();
-    //console.log('Wallet Exists result', this.state.screen, exists);
 
     if (exists && exists !== GlobalConst.false) {
       this.setState({ walletExists: true });
@@ -645,7 +633,6 @@ export class LoadingAppClass extends Component<
       // for testing
       //await delay(5000);
 
-      //console.log('Load Wallet Exists result', result);
       let error = false;
       let errorText = '';
       if (result && !result.toLowerCase().startsWith(GlobalConst.error)) {
@@ -653,7 +640,6 @@ export class LoadingAppClass extends Component<
           // here result can have an `error` field for watch-only which is actually OK.
           const resultJson: RPCSeedType & RPCUfvkType =
             await JSON.parse(result);
-          //console.log('Load Wallet Exists result JSON', resultJson);
           if (!resultJson.error) {
             // Load the wallet and navigate to the vts screen
             let readOnly: boolean = false;
@@ -661,7 +647,6 @@ export class LoadingAppClass extends Component<
             let saplingPool: boolean = false;
             let transparentPool: boolean = false;
             const walletKindStr: string = await RPCModule.walletKindInfo();
-            //console.log('KIND...', walletKindStr);
             try {
               const walletKindJSON: RPCWalletKindType =
                 await JSON.parse(walletKindStr);
@@ -686,8 +671,10 @@ export class LoadingAppClass extends Component<
               transparentPool = walletKindJSON.transparent;
               // if the seed & birthday are not stored in Keychain/Keystore, do it now.
               if (this.state.recoveryWalletInfoOnDevice) {
-                const wallet: WalletType = await RPC.rpcFetchWallet(readOnly);
-                await createUpdateRecoveryWalletInfo(wallet);
+                const wallet = await RPC.rpcFetchWallet(readOnly);
+                if (wallet) {
+                  await createUpdateRecoveryWalletInfo(wallet);
+                }
               } else {
                 // needs to delete the seed from the Keychain/Keystore, do it now.
                 if (this.state.hasRecoveryWalletInfoSaved) {
@@ -702,7 +689,6 @@ export class LoadingAppClass extends Component<
                 actionButtonsDisabled: false,
               });
             } catch (e) {
-              //console.log('CATCH ERROR', walletKindStr);
               this.setState({
                 readOnly,
                 orchardPool,
@@ -737,7 +723,6 @@ export class LoadingAppClass extends Component<
               newWallet,
               this.state.firstLaunchingMessage,
             );
-            //console.log('navigate to LoadedApp');
           } else {
             error = true;
             errorText = resultJson.error;
@@ -759,7 +744,6 @@ export class LoadingAppClass extends Component<
         );
       }
     } else {
-      //console.log('Loading new wallet', this.state.screen, this.state.walletExists);
       if (this.state.mode === ModeEnum.basic) {
         // setting the prop basicFirstViewSeed to false.
         // this means when the user have funds, the seed screen will show up.
@@ -800,7 +784,6 @@ export class LoadingAppClass extends Component<
               true,
               this.state.firstLaunchingMessage,
             );
-            //console.log('navigate to LoadedApp');
           }
         }
       } else {
@@ -820,7 +803,6 @@ export class LoadingAppClass extends Component<
     this.appstate = AppState.addEventListener(
       EventListenerEnum.change,
       async nextAppState => {
-        //console.log('LOADING', 'prior', this.state.appStateStatus, 'next', nextAppState);
         // let's catch the prior value
         const priorAppState = this.state.appStateStatus;
         this.setState({ appStateStatus: nextAppState });
@@ -829,12 +811,10 @@ export class LoadingAppClass extends Component<
             priorAppState === AppStateStatusEnum.background) &&
           nextAppState === AppStateStatusEnum.active
         ) {
-          //console.log('App LOADING has come to the foreground!');
           // reading background task info
           this.fetchBackgroundSyncInfo();
           // setting value for background task Android
           await AsyncStorage.setItem(GlobalConst.background, GlobalConst.no);
-          //console.log('&&&&& background no in storage &&&&&');
           if (
             this.state.backgroundError &&
             (this.state.backgroundError.title ||
@@ -855,7 +835,6 @@ export class LoadingAppClass extends Component<
           console.log('App LOADING is gone to the background!');
           // setting value for background task Android
           await AsyncStorage.setItem(GlobalConst.background, GlobalConst.yes);
-          //console.log('&&&&& background yes in storage &&&&&');
         }
       },
     );
@@ -881,12 +860,10 @@ export class LoadingAppClass extends Component<
           });
           if (isConnected !== state.isConnected) {
             if (!state.isConnected) {
-              //console.log('EVENT Loading: No internet connection.');
               this.setState({
                 customServerShow: false,
               });
             } else {
-              //console.log('EVENT Loading: YESSSSS internet connection.');
               // if it is offline & there is no wallet file
               // the screen is going to be empty
               // show the custom server component
@@ -974,7 +951,6 @@ export class LoadingAppClass extends Component<
       // the 15 seconds timout was fired.
       someServerIsWorking = false;
     }
-    //console.log(server);
     console.log(fasterServer);
     this.setState({
       server: fasterServer,
@@ -1105,12 +1081,12 @@ export class LoadingAppClass extends Component<
           const someServerIsWorking = await this.selectTheBestServer(true);
           if (someServerIsWorking) {
             if (start) {
-              this.setState({
-                startingApp: false,
-                serverErrorTries: 1,
-                screen,
-              });
-              this.componentDidMount();
+              this.setState(
+                { startingApp: false, serverErrorTries: 1, screen },
+                () => {
+                  this.componentDidMount();
+                },
+              );
             } else {
               createAlert(
                 this.setBackgroundError,
@@ -1509,8 +1485,6 @@ export class LoadingAppClass extends Component<
       );
     }
 
-    //console.log(seedUfvk);
-    //console.log(result);
     let error = false;
     let errorText = '';
     if (result && !result.toLowerCase().startsWith(GlobalConst.error)) {
@@ -1557,7 +1531,6 @@ export class LoadingAppClass extends Component<
           try {
             const walletKindJSON: RPCWalletKindType =
               await JSON.parse(walletKindStr);
-            //console.log('KIND... JSON', walletKindJSON);
             // there are 4 kinds:
             // 1. seed
             // 2. USK
@@ -1578,8 +1551,10 @@ export class LoadingAppClass extends Component<
             transparentPool = walletKindJSON.transparent;
             // if the seed & birthday are not stored in Keychain/Keystore, do it now.
             if (this.state.recoveryWalletInfoOnDevice) {
-              const wallet: WalletType = await RPC.rpcFetchWallet(readOnly);
-              await createUpdateRecoveryWalletInfo(wallet);
+              const wallet = await RPC.rpcFetchWallet(readOnly);
+              if (wallet) {
+                await createUpdateRecoveryWalletInfo(wallet);
+              }
             } else {
               // needs to delete the seed from the Keychain/Keystore, do it now.
               if (this.state.hasRecoveryWalletInfoSaved) {
@@ -1594,7 +1569,6 @@ export class LoadingAppClass extends Component<
               actionButtonsDisabled: false,
             });
           } catch (e) {
-            //console.log('CATCH ERROR', walletKindStr);
             this.setState({
               readOnly,
               orchardPool,
@@ -1687,13 +1661,14 @@ export class LoadingAppClass extends Component<
   };
 
   changeMode = async (mode: ModeEnum.basic | ModeEnum.advanced) => {
-    this.setState({ mode, screen: 0 });
     await SettingsFileImpl.writeSettings(SettingsNameEnum.mode, mode);
     this.props.toggleTheme(mode);
     // if the user selects advanced mode & wants to change to another wallet
     // and then the user wants to go to basic mode in the first screen
     // the result will be the same -> create a new wallet.
-    this.componentDidMount();
+    this.setState({ mode, screen: 0 }, () => {
+      this.componentDidMount();
+    });
   };
 
   recoverRecoveryWalletInfo = async (security: boolean) => {
@@ -1703,6 +1678,12 @@ export class LoadingAppClass extends Component<
     // then the Alert can be too fast.
     if (wallet.seed || wallet.ufvk) {
       const txt = (wallet.seed || wallet.ufvk) + '\n\n' + wallet.birthday;
+      const preview = wallet.seed
+        ? (() => {
+            const words = wallet.seed.split(' ');
+            return `${words[0]} ... ${words[words.length - 1]}`;
+          })()
+        : `${(wallet.ufvk || '').slice(0, 5)} ... ${(wallet.ufvk || '').slice(-5)}`;
       setTimeout(
         () => {
           Alert.alert(
@@ -1710,12 +1691,13 @@ export class LoadingAppClass extends Component<
             (security
               ? ''
               : ((this.props.translate('loadingapp.recoverkeysinstall') +
-                  '\n\n') as string)) + txt,
+                  '\n\n') as string)) + preview,
             [
               {
                 text: this.props.translate('copy') as string,
                 onPress: () => {
                   Clipboard.setString(txt);
+                  setTimeout(() => Clipboard.setString(''), 60 * 1000);
                   this.addLastSnackbar({
                     message: this.props.translate('txtcopied') as string,
                     duration: SnackbarDurationEnum.short,
@@ -1770,7 +1752,6 @@ export class LoadingAppClass extends Component<
       this.setState({
         zingolibVersion: zingolibStr,
       });
-      //console.log('=========================================== > set zingolib version - ', Date.now() - start2);
     } catch (error) {
       console.log(`Critical Error info ${error}`);
       return;
@@ -1797,8 +1778,6 @@ export class LoadingAppClass extends Component<
       saplingPool,
       transparentPool,
     } = this.state;
-
-    //console.log('render loadingAppClass - 3', this.state.privacy);
 
     const context = {
       // context

--- a/app/rpc/RPC.ts
+++ b/app/rpc/RPC.ts
@@ -165,7 +165,6 @@ export default class RPC {
           Date.now() - start,
         );
       }
-      //console.log(resultStr);
 
       if (resultStr) {
         if (resultStr.toLowerCase().startsWith(GlobalConst.error)) {
@@ -204,7 +203,6 @@ export default class RPC {
   static async rpcShieldFunds(): Promise<string> {
     try {
       const shieldStr: string = await RPCModule.confirmProcess();
-      //console.log(shieldStr);
       if (shieldStr) {
         if (shieldStr.toLowerCase().startsWith(GlobalConst.error)) {
           console.log(`Error shield ${shieldStr}`);
@@ -222,7 +220,7 @@ export default class RPC {
     }
   }
 
-  static async rpcFetchWallet(readOnly: boolean): Promise<WalletType> {
+  static async rpcFetchWallet(readOnly: boolean): Promise<WalletType | null> {
     if (readOnly) {
       // only viewing key & birthday
       try {
@@ -237,11 +235,11 @@ export default class RPC {
         if (ufvkStr) {
           if (ufvkStr.toLowerCase().startsWith(GlobalConst.error)) {
             console.log(`Error ufvk ${ufvkStr}`);
-            return {} as WalletType;
+            return null;
           }
         } else {
           console.log('Internal Error ufvk');
-          return {} as WalletType;
+          return null;
         }
         const RPCufvk: WalletType = await JSON.parse(ufvkStr);
 
@@ -256,7 +254,7 @@ export default class RPC {
         return wallet;
       } catch (error) {
         console.log(`Critical Error ufvk ${error}`);
-        return {} as WalletType;
+        return null;
       }
     } else {
       // only seed & birthday
@@ -272,11 +270,11 @@ export default class RPC {
         if (seedStr) {
           if (seedStr.toLowerCase().startsWith(GlobalConst.error)) {
             console.log(`Error seed ${seedStr}`);
-            return {} as WalletType;
+            return null;
           }
         } else {
           console.log('Internal Error seed');
-          return {} as WalletType;
+          return null;
         }
         const RPCseed: RPCSeedType = await JSON.parse(seedStr);
 
@@ -291,13 +289,12 @@ export default class RPC {
         return wallet;
       } catch (error) {
         console.log(`Critical Error seed ${error}`);
-        return {} as WalletType;
+        return null;
       }
     }
   }
 
   async runTaskPromises(): Promise<void> {
-    //console.log('+++++++++++++++++ interval update 5 secs ALL', this.timers);
     this.sanitizeTimers();
 
     // this run only once.
@@ -343,7 +340,6 @@ export default class RPC {
       taskPromises.push(
         new Promise<void>(async resolve => {
           await this.fetchSyncPoll();
-          //console.log('INTERVAL poll sync');
           resolve();
         }),
       );
@@ -367,7 +363,6 @@ export default class RPC {
         taskPromises.push(
           new Promise<void>(async resolve => {
             await this.fetchSyncPoll();
-            //console.log('INTERVAL poll sync');
             resolve();
           }),
         );
@@ -376,7 +371,6 @@ export default class RPC {
         taskPromises.push(
           new Promise<void>(async resolve => {
             await this.fetchSyncPoll();
-            //console.log('INTERVAL poll sync');
             resolve();
           }),
         );
@@ -384,7 +378,6 @@ export default class RPC {
           new Promise<void>(async resolve => {
             //const s = Date.now();
             await this.fetchWalletHeight();
-            //console.log('wallet height - ', Date.now() - s);
             resolve();
           }),
         );
@@ -392,7 +385,6 @@ export default class RPC {
           new Promise<void>(async resolve => {
             //const s = Date.now();
             await this.fetchWalletBirthdaySeedUfvk();
-            //console.log('wallet birthday - ', Date.now() - s);
             resolve();
           }),
         );
@@ -400,7 +392,6 @@ export default class RPC {
           new Promise<void>(async resolve => {
             //const s = Date.now();
             await this.fetchInfoAndServerHeight();
-            //console.log('info & server height - ', Date.now() - s);
             resolve();
           }),
         );
@@ -408,7 +399,6 @@ export default class RPC {
           new Promise<void>(async resolve => {
             //const s = Date.now();
             await this.fetchAddresses();
-            //console.log('addresses - ', Date.now() - s);
             resolve();
           }),
         );
@@ -416,7 +406,6 @@ export default class RPC {
           new Promise<void>(async resolve => {
             //const s = Date.now();
             await this.fetchTotalBalance();
-            //console.log('balance - ', Date.now() - s);
             resolve();
           }),
         );
@@ -438,7 +427,6 @@ export default class RPC {
           new Promise<void>(async resolve => {
             //const s = Date.now();
             await this.fetchTandZandOValueTransfers();
-            //console.log('value transfers - ', Date.now() - s);
             resolve();
           }),
         );
@@ -446,14 +434,13 @@ export default class RPC {
           new Promise<void>(async resolve => {
             //const s = Date.now();
             await this.fetchTandZandOMessages();
-            //console.log('messages - ', Date.now() - s);
             resolve();
           }),
         );
       }
     }
 
-    Promise.allSettled(taskPromises);
+    await Promise.allSettled(taskPromises);
   }
 
   // this is only for the first time when the App is booting, but
@@ -479,7 +466,6 @@ export default class RPC {
     // every 5 seconds the App update part of the data
     if (!this.updateTimerID) {
       this.updateTimerID = setInterval(() => this.runTaskPromises(), 5 * 1000); // 5 secs
-      //console.log('create update timer', this.updateVTTimerID);
       this.timers.push(this.updateTimerID);
     }
 
@@ -509,14 +495,12 @@ export default class RPC {
     if (this.updateTimerID) {
       clearInterval(this.updateTimerID);
       this.updateTimerID = undefined;
-      //console.log('kill update timer', this.updateVTTimerID);
     }
 
     // and now the array of timers...
     while (this.timers.length > 0) {
       const inter = this.timers.pop();
       clearInterval(inter);
-      //console.log('kill item array timers', inter);
     }
   }
 
@@ -529,7 +513,6 @@ export default class RPC {
       } else {
         clearInterval(this.timers[i]);
         deleted.push(i);
-        //console.log('sanitize - kill item array timers', this.timers[i]);
       }
     }
     // remove the cleared timers.
@@ -541,7 +524,6 @@ export default class RPC {
   async refreshSync(fullRescan?: boolean) {
     try {
       if (this.refreshSyncLock && !fullRescan) {
-        //console.log('REFRESH ----> in execution already');
         return;
       }
       this.refreshSyncLock = true;
@@ -576,7 +558,6 @@ export default class RPC {
             Date.now() - start,
           );
         }
-        //console.log('rescan RUN', rescanStr);
         if (
           rescanStr &&
           rescanStr.toLowerCase().startsWith(GlobalConst.error)
@@ -610,7 +591,6 @@ export default class RPC {
   async fetchSyncStatus(): Promise<void> {
     try {
       if (this.fetchSyncStatusLock) {
-        //console.log('sync status locked');
         return;
       }
       this.fetchSyncStatusLock = true;
@@ -643,15 +623,12 @@ export default class RPC {
         return;
       }
 
-      //console.log('SYNC STATUS', ss);
       console.log(
         'SYNC STATUS',
         ss.scan_ranges?.length,
         ss.percentage_total_outputs_scanned,
         ss.percentage_total_blocks_scanned,
       );
-
-      //console.log('interval sync/rescan, secs', this.secondsBatch, 'timer', this.syncStatusTimerID);
 
       // avoiding 0.00, minimum 0.01, maximun 100
       // fixing when is:
@@ -919,7 +896,6 @@ export default class RPC {
           Date.now() - start,
         );
       }
-      //console.log(spendableStr);
       let spendableJSON: RPCSpendablebalanceType =
         {} as RPCSpendablebalanceType;
       if (spendableStr) {
@@ -971,7 +947,6 @@ export default class RPC {
         totalSpendableBalance: (spendableJSON.spendable_balance || 0) / 10 ** 8,
         //totalSpendableBalance: ((balanceJSON.confirmed_orchard_balance + balanceJSON.confirmed_sapling_balance) || 0) / 10 ** 8,
       };
-      //console.log(balance);
       this.fnSetTotalBalance(balance);
       this.fetchTotalBalanceLock = false;
     } catch (error) {
@@ -1072,8 +1047,6 @@ export default class RPC {
           );
           allAddresses.push(t);
         });
-
-      //console.log(allAddresses);
 
       this.fnSetAllAddresses(allAddresses);
       this.fetchAddressesLock = false;
@@ -1270,7 +1243,6 @@ export default class RPC {
   async fetchTandZandOValueTransfers() {
     try {
       if (this.fetchTandZandOValueTransfersLock) {
-        //console.log('VT LOCKKKKKKKKKKKKKKKKKKKKKKK');
         return;
       }
       this.fetchTandZandOValueTransfersLock = true;
@@ -1296,8 +1268,6 @@ export default class RPC {
         console.log('Internal Error server height');
       }
 
-      //console.log('SERVER HEIGHT', this.lastServerBlockHeight);
-
       const start2 = Date.now();
       const valueTransfersStr: string = await RPCModule.getValueTransfersList();
       if (Date.now() - start2 > 4000) {
@@ -1306,7 +1276,6 @@ export default class RPC {
           Date.now() - start2,
         );
       }
-      //console.log(valueTransfersStr);
       if (valueTransfersStr) {
         if (valueTransfersStr.toLowerCase().startsWith(GlobalConst.error)) {
           console.log(`Error value transfers ${valueTransfersStr}`);
@@ -1321,8 +1290,6 @@ export default class RPC {
       }
       const valueTransfersJSON: RPCValueTransfersType =
         await JSON.parse(valueTransfersStr);
-
-      //console.log(valueTransfersJSON);
 
       let vtList: ValueTransferType[] = [];
 
@@ -1404,12 +1371,9 @@ export default class RPC {
             //  console.log(vt);
             //}
 
-            //console.log(currentValueTransferList);
             vtList.push(currentValueTransferList);
           },
         );
-
-      //console.log(vtlist);
 
       this.fnSetValueTransfersList(vtList, vtList.length);
       this.fetchTandZandOValueTransfersLock = false;
@@ -1428,7 +1392,6 @@ export default class RPC {
   async fetchTandZandOMessages() {
     try {
       if (this.fetchTandZandOMessagesLock) {
-        //console.log('MESSAGES LOCKKKKKKKKKKKKKKKKKKKKKKK');
         return;
       }
       this.fetchTandZandOMessagesLock = true;
@@ -1440,7 +1403,6 @@ export default class RPC {
           Date.now() - start,
         );
       }
-      //console.log(messagesStr);
       if (messagesStr) {
         if (messagesStr.toLowerCase().startsWith(GlobalConst.error)) {
           console.log(`Error value transfers messages ${messagesStr}`);
@@ -1454,8 +1416,6 @@ export default class RPC {
         return;
       }
       const messagesJSON: RPCValueTransfersType = await JSON.parse(messagesStr);
-
-      //console.log(valueTransfersJSON);
 
       let mList: ValueTransferType[] = [];
 
@@ -1530,11 +1490,8 @@ export default class RPC {
           //  console.log(m);
           //}
 
-          //console.log(currentValueTransferList);
           mList.push(currentMessageList);
         });
-
-      //console.log(mlist);
 
       this.fnSetMessagesList(mList, mList.length);
       this.fetchTandZandOMessagesLock = false;
@@ -1618,12 +1575,10 @@ export default class RPC {
       this.setInSend(false);
 
       if (sendTxids) {
-        //console.log('00000000 RESOLVE send');
         resolve(sendTxids);
         return;
       }
       if (sendError) {
-        //console.log('00000000 REJECT send');
         reject(sendError);
         return;
       }
@@ -1635,7 +1590,6 @@ export default class RPC {
   async changeWallet() {
     const exists = await RPCModule.walletExists();
 
-    //console.log('jc change wallet', exists);
     if (exists && exists !== GlobalConst.false) {
       await this.pauseSyncProcess();
       await RPCModule.doSaveBackup();
@@ -1653,7 +1607,6 @@ export default class RPC {
   async changeWalletNoBackup() {
     const exists = await RPCModule.walletExists();
 
-    //console.log('jc change wallet', exists);
     if (exists && exists !== GlobalConst.false) {
       await this.pauseSyncProcess();
       const result = await RPCModule.deleteExistingWallet();
@@ -1670,11 +1623,9 @@ export default class RPC {
   async restoreBackup() {
     const existsBackup = await RPCModule.walletBackupExists();
 
-    //console.log('jc restore backup', existsBackup);
     if (existsBackup && existsBackup !== GlobalConst.false) {
       const existsWallet = await RPCModule.walletExists();
 
-      //console.log('jc restore wallet', existsWallet);
       if (existsWallet && existsWallet !== GlobalConst.false) {
         await this.pauseSyncProcess();
         await RPCModule.restoreExistingWalletBackup();

--- a/app/uris/parseZcashURI.ts
+++ b/app/uris/parseZcashURI.ts
@@ -113,6 +113,11 @@ const parseZcashURI = async (
           // Parse as base64
           try {
             const decoded = Base64.decode(value);
+            if (decoded.length > GlobalConst.memoMaxLength) {
+              console.log(
+                `URI memo truncated from ${decoded.length} to ${GlobalConst.memoMaxLength} bytes`,
+              );
+            }
             target.memoString = decoded.slice(0, GlobalConst.memoMaxLength);
             target.memoBase64 = Base64.encode(target.memoString);
           } catch (e) {
@@ -126,7 +131,7 @@ const parseZcashURI = async (
           break;
         }
         const a = parseFloat(value);
-        if (isNaN(a)) {
+        if (isNaN(a) || a < 0 || a > 21_000_000) {
           errors.push(`${translate('uris.amount')} "${value}"`);
           break;
         }

--- a/app/utils/Utils.ts
+++ b/app/utils/Utils.ts
@@ -14,7 +14,6 @@ import {
   SendJsonToTypeType,
   SendPageStateClass,
   ServerType,
-  ToAddrClass,
   TranslateType,
   ValueTransferType,
   BlockExplorerEnum,
@@ -281,57 +280,47 @@ export default class Utils {
     server: ServerType,
     donation: boolean,
   ): Promise<SendJsonToTypeType[]> {
-    let donationAddress: boolean = false;
-    const json: Promise<SendJsonToTypeType[][]> = Promise.all(
-      [sendPageState.toaddr].map(async (to: ToAddrClass) => {
-        const memo = Utils.buildMemo(to.memo, to.includeUAMemo, uAddress);
-        const amount = parseInt(
-          (Utils.parseStringLocaleToNumberFloat(to.amount) * 10 ** 8).toFixed(
-            0,
-          ),
-          10,
-        );
+    const to = sendPageState.toaddr;
+    const donationAddress: boolean =
+      to.to === (await Utils.getDonationAddress(server.chainName)) ||
+      to.to === (await Utils.getZenniesDonationAddress(server.chainName)) ||
+      to.to === (await Utils.getNymDonationAddress(server.chainName));
 
-        donationAddress =
-          to.to === (await Utils.getDonationAddress(server.chainName)) ||
-          to.to === (await Utils.getZenniesDonationAddress(server.chainName)) ||
-          to.to === (await Utils.getNymDonationAddress(server.chainName));
-
-        if (memo === '') {
-          return [{ address: to.to, amount } as SendJsonToTypeType];
-        } else if (
-          Buffer.byteLength(memo, GlobalConst.utf8 as BufferEncoding) <=
-          GlobalConst.memoMaxLength
-        ) {
-          return [{ address: to.to, amount, memo } as SendJsonToTypeType];
-        } else {
-          // If the memo is more than 511 bytes, then we split it into multiple transactions.
-          // Each memo will be `(xx/yy)memo part`. The prefix "(xx/yy)" is 7 bytes long, so
-          // we'll split the memo into 511-7 = 505 bytes length
-          // this make sense if we make long memos... in the future.
-          const splits = Utils.utf16Split(memo, GlobalConst.memoMaxLength - 7);
-          const tos = [];
-
-          // The first one contains all the tx value
-          tos.push({
-            address: to.to,
-            amount,
-            memo: `(1/${splits.length})${splits[0]}`,
-          } as SendJsonToTypeType);
-
-          for (let i = 1; i < splits.length; i++) {
-            tos.push({
-              address: to.to,
-              amount: 0,
-              memo: `(${i + 1}/${splits.length})${splits[i]}`,
-            } as SendJsonToTypeType);
-          }
-
-          return tos;
-        }
-      }),
+    const memo = Utils.buildMemo(to.memo, to.includeUAMemo, uAddress);
+    const amount = parseInt(
+      (Utils.parseStringLocaleToNumberFloat(to.amount) * 10 ** 8).toFixed(0),
+      10,
     );
-    const jsonFlat: SendJsonToTypeType[] = (await json).flat();
+
+    let jsonFlat: SendJsonToTypeType[];
+    if (memo === '') {
+      jsonFlat = [{ address: to.to, amount } as SendJsonToTypeType];
+    } else if (
+      Buffer.byteLength(memo, GlobalConst.utf8 as BufferEncoding) <=
+      GlobalConst.memoMaxLength
+    ) {
+      jsonFlat = [{ address: to.to, amount, memo } as SendJsonToTypeType];
+    } else {
+      // If the memo is more than 511 bytes, then we split it into multiple transactions.
+      // Each memo will be `(xx/yy)memo part`. The prefix "(xx/yy)" is 7 bytes long, so
+      // we'll split the memo into 511-7 = 505 bytes length
+      // this make sense if we make long memos... in the future.
+      const splits = Utils.utf16Split(memo, GlobalConst.memoMaxLength - 7);
+      jsonFlat = [
+        {
+          address: to.to,
+          amount,
+          memo: `(1/${splits.length})${splits[0]}`,
+        } as SendJsonToTypeType,
+      ];
+      for (let i = 1; i < splits.length; i++) {
+        jsonFlat.push({
+          address: to.to,
+          amount: 0,
+          memo: `(${i + 1}/${splits.length})${splits[i]}`,
+        } as SendJsonToTypeType);
+      }
+    }
 
     const donationTransaction: SendJsonToTypeType[] = [];
 

--- a/components/History/History.tsx
+++ b/components/History/History.tsx
@@ -481,15 +481,6 @@ const History: React.FunctionComponent<HistoryProps> = ({
     setHeightLayout(10);
   }, []);
 
-  console.log(
-    'render History - 4',
-    filterKind,
-    filterFailed,
-    filterMemos,
-    filterWithFunds,
-  );
-  //console.log(valueTransfersSliced[0]);
-
   return (
     <ToastProvider>
       <Snackbars

--- a/components/History/components/ValueTransferDetail.tsx
+++ b/components/History/components/ValueTransferDetail.tsx
@@ -321,13 +321,6 @@ const ValueTransferDetail: React.FunctionComponent<
     );
   };
 
-  //console.log('render History Detail', valueTransferIndex, valueTransfer);
-
-  //if (valueTransfer.status === RPCValueTransfersStatusEnum.calculated || valueTransfer.status === RPCValueTransfersStatusEnum.transmitted) {
-  //  console.log('server', info.latestBlock, 'VT', valueTransfer.blockheight, 'expire', GlobalConst.expireBlocks);
-  //  console.log(info.latestBlock - valueTransfer.blockheight < GlobalConst.expireBlocks);
-  //}
-
   return (
     <ToastProvider>
       <Snackbars

--- a/components/Seed/Seed.tsx
+++ b/components/Seed/Seed.tsx
@@ -100,9 +100,9 @@ const Seed: React.FunctionComponent<SeedProps> = ({
       setLoadingSeed(true);
       const seedInfo = recoveryWalletInfoOnDevice
         ? await getRecoveryWalletInfo()
-        : await RPC.rpcFetchWallet(false);
+        : ((await RPC.rpcFetchWallet(false)) ?? ({} as WalletType));
       const ufvkInfo = await RPC.rpcFetchWallet(true);
-      setFetchedWallet({ ...seedInfo, ufvk: ufvkInfo.ufvk });
+      setFetchedWallet({ ...seedInfo, ufvk: ufvkInfo?.ufvk });
       setLoadingSeed(false);
     })();
   }, [recoveryWalletInfoOnDevice]);
@@ -241,10 +241,6 @@ const Seed: React.FunctionComponent<SeedProps> = ({
     }
   };
 
-  //console.log('=================================');
-  //console.log(wallet.seed, wallet.birthday);
-  //console.log('render seed', privacy);
-
   return (
     <ToastProvider>
       <Snackbars
@@ -324,6 +320,7 @@ const Seed: React.FunctionComponent<SeedProps> = ({
                   onPress={() => {
                     if (seedPhrase) {
                       Clipboard.setString(seedPhrase);
+                      setTimeout(() => Clipboard.setString(''), 60 * 1000);
                       if (addLastSnackbar) {
                         addLastSnackbar({
                           message: translate(
@@ -364,6 +361,7 @@ const Seed: React.FunctionComponent<SeedProps> = ({
                     onPress={() => {
                       if (seedPhrase) {
                         Clipboard.setString(seedPhrase);
+                        setTimeout(() => Clipboard.setString(''), 60 * 1000);
                         if (addLastSnackbar) {
                           addLastSnackbar({
                             message: translate(

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -370,7 +370,6 @@ const Send: React.FunctionComponent<SendProps> = ({
         ? totalBalance.totalSpendableBalance
         : 0;
       let zenniesForZingo = donationAddress ? false : donation;
-      //console.log('SPENDABLEBALANCE', addressPar, zenniesForZingo, spendableBalance);
       const start = Date.now();
       const runSpendableBalanceStr =
         await RPCModule.getSpendableBalanceWithAddressInfo(
@@ -493,7 +492,6 @@ const Send: React.FunctionComponent<SendProps> = ({
     }
 
     if (amountPar !== null) {
-      //console.log('update field', amount);
       const amountTemp = amountPar.substring(0, 20);
       if (isNaN(Utils.parseStringLocaleToNumberFloat(amountTemp))) {
         setAmountCurrencyText('');
@@ -512,7 +510,6 @@ const Send: React.FunctionComponent<SendProps> = ({
     }
 
     if (amountCurrencyPar !== null) {
-      //console.log('update field', amountCurrency);
       const amountCurrencyTemp = amountCurrencyPar.substring(0, 15);
       if (isNaN(Utils.parseStringLocaleToNumberFloat(amountCurrencyTemp))) {
         setAmountText('');
@@ -759,11 +756,9 @@ const Send: React.FunctionComponent<SendProps> = ({
       setKeyboardListenersDone(true);
       Keyboard.addListener('keyboardDidShow', () => {
         setKeyboardVisible(true);
-        //console.log('OPENNNNNNNNNN', titleViewHeightPar, slideAnim.value);
       });
       Keyboard.addListener('keyboardDidHide', () => {
         setKeyboardVisible(false);
-        //console.log('CLOSEEEEEEEEE', titleViewHeightPar, slideAnim.value);
       });
     }
   };
@@ -896,7 +891,6 @@ const Send: React.FunctionComponent<SendProps> = ({
     }
 
     setTimeout(() => {
-      //console.log('sendtx error', error);
       // if the App is in background I need to store the error
       // and when the App come back to foreground shows it to the user.
       createAlert(
@@ -934,7 +928,6 @@ const Send: React.FunctionComponent<SendProps> = ({
 
   const scrollToEnd = () => {
     if (scrollViewRef.current) {
-      //console.log('scrolling to end', keyboardVisible);
       scrollViewRef.current.scrollTo({ y: contentHeight, animated: true });
     }
   };
@@ -981,7 +974,6 @@ const Send: React.FunctionComponent<SendProps> = ({
     });
   };
 
-  //console.log(
   //  'Render, spendable',
   //  spendable,
   //  'maxAmount',
@@ -991,8 +983,6 @@ const Send: React.FunctionComponent<SendProps> = ({
   //  keyboardVisible,
   //  contentHeight,
   //);
-
-  //console.log(slideAnim.value);
 
   const returnPage = (
     <ToastProvider>
@@ -1017,7 +1007,6 @@ const Send: React.FunctionComponent<SendProps> = ({
           onLayout={e => {
             const { height } = e.nativeEvent.layout;
             keyboardListeners(height);
-            //console.log('LAYOUTTT', height);
           }}
         >
           <Header
@@ -2132,7 +2121,6 @@ const Send: React.FunctionComponent<SendProps> = ({
                         try {
                           parseAddressInfoJSON = await JSON.parse(result);
                         } catch (e) {
-                          //console.log(e);
                           parseAddressInfoJSON = {} as RPCParseAddressType;
                         }
                       }
@@ -2180,7 +2168,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                                 // fill the fields in the screen with the donation data
                                 update = true;
                               })
-                              .catch(() => {});
+                              .catch(() => {}); // user cancelled the alert — expected
                           } else {
                             // fill the fields in the screen with the donation data
                             update = true;

--- a/components/Ufvk/ShowUfvk.tsx
+++ b/components/Ufvk/ShowUfvk.tsx
@@ -13,6 +13,8 @@ import {
   Alert,
   ActivityIndicator,
   Dimensions,
+  Text,
+  TouchableOpacity,
 } from 'react-native';
 
 import { useTheme } from '@react-navigation/native';
@@ -102,7 +104,7 @@ const ShowUfvk: React.FunctionComponent<ShowUfvkProps> = ({
         setFetchedWallet(info);
       } else {
         const info = await RPC.rpcFetchWallet(true);
-        setFetchedWallet(info);
+        setFetchedWallet(info ?? ({} as WalletType));
       }
       setLoadingUfvk(false);
     })();
@@ -212,7 +214,11 @@ const ShowUfvk: React.FunctionComponent<ShowUfvkProps> = ({
   );
 
   const doCopy = () => {
-    Clipboard.setString(fetchedWallet.ufvk ? fetchedWallet.ufvk : '');
+    if (!fetchedWallet.ufvk) {
+      return;
+    }
+    Clipboard.setString(fetchedWallet.ufvk);
+    setTimeout(() => Clipboard.setString(''), 60 * 1000);
     addLastSnackbar({
       message: translate('seed.tapcopy-ufvk-message') as string,
       duration: SnackbarDurationEnum.short,
@@ -287,14 +293,29 @@ const ShowUfvk: React.FunctionComponent<ShowUfvkProps> = ({
                 }}
               >
                 {!!fetchedWallet.ufvk && (
-                  <SingleAddress
-                    ufvk={fetchedWallet.ufvk}
-                    screenName={screenName}
-                    index={0}
-                    setIndex={() => {}}
-                    total={1}
-                    show={() => show('EA')}
-                  />
+                  <>
+                    <SingleAddress
+                      ufvk={fetchedWallet.ufvk}
+                      screenName={screenName}
+                      index={0}
+                      setIndex={() => {}}
+                      total={1}
+                      show={() => show('EA')}
+                    />
+                    <TouchableOpacity onPress={doCopy}>
+                      <Text
+                        style={{
+                          color: colors.text,
+                          textDecorationLine: 'underline',
+                          padding: 10,
+                          textAlign: 'center',
+                          minHeight: 48,
+                        }}
+                      >
+                        {translate('seed.tapcopy') as string}
+                      </Text>
+                    </TouchableOpacity>
+                  </>
                 )}
               </View>
 

--- a/ios/RPCModule.swift
+++ b/ios/RPCModule.swift
@@ -54,7 +54,12 @@ class RPCModule: NSObject {
   }
 
   func writeFile(_ fileName: String, fileBase64EncodedString: String) throws {
-    try fileBase64EncodedString.write(toFile: getFileName(fileName), atomically: true, encoding: .utf8)
+    let filePath = try getFileName(fileName)
+    try fileBase64EncodedString.write(toFile: filePath, atomically: true, encoding: .utf8)
+    var fileURL = URL(fileURLWithPath: filePath)
+    var resourceValues = URLResourceValues()
+    resourceValues.isExcludedFromBackup = true
+    try? fileURL.setResourceValues(resourceValues)
   }
 
   func deleteFile(_ fileName: String) throws {
@@ -202,7 +207,7 @@ class RPCModule: NSObject {
           if correct == "true" {
             try self.saveWalletFile(walletEncodedString)
           } else {
-            let err = "Error: [Native] Couldn't save the wallet. The Encoded content is incorrect: \(walletEncodedString)"
+            let err = "Error: [Native] Couldn't save the wallet. The Encoded content is incorrect. Size: \(walletEncodedString.count)"
             NSLog(err)
             throw FileError.saveFileError(err)
           }


### PR DESCRIPTION
## Summary

- Replace `wallet: WalletType` with `birthday: number` in `AppContextLoaded` and `LoadedApp` state; rename `setWallet`/`fnSetWallet` → `setBirthday`/`fnSetBirthday` (receives `number` directly)
- `rpcFetchWallet` return type changed to `Promise<WalletType | null>`; all error paths return `null` instead of `{} as WalletType`
- `GlobalConst.error` changed from `'error'` to `'error:'` — Rust always formats errors as `"error: <msg>"`, preventing false positives with seed words that start with the word "error"
- Alert dialogs no longer expose the full seed/UFVK — shows `first ... last` word preview for seeds, `xxxxx ... xxxxx` for UFVK
- Clipboard auto-clears after 60 s wherever seed, UFVK, or birthday is copied (seed screen ×2, UFVK screen, rescan screen)
- Added missing `await` on `Promise.allSettled` in RPC polling loop
- Fixed `setState` + `componentDidMount` sequencing using the callback form of `setState`
- URI amount validation extended: rejects negative values and amounts above 21 000 000 ZEC
- Memo truncation now logs a warning when a URI memo exceeds the max length
- `getSendManyJSON` refactored: removed unnecessary `Promise.all` and async closure mutation
- Test isolation: all 20 snapshot test files now spread `defaultAppContextLoaded` instead of sharing a reference
- Removed ~161 commented-out `console.log` lines across `RPC.ts`, `LoadingApp.tsx`, `Send.tsx`, `Seed.tsx`, and others