### PR TITLE
LA Audit - Issue B: Sensitive Information May Be Captured in Screenshots and Application Switcher

### DIFF
--- a/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
@@ -1,7 +1,11 @@
 package org.ZingoLabs.Zingo
 
+import android.app.ActivityManager
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -17,6 +21,22 @@ class MainActivity : ReactActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.i("ON_CREATE", "Starting main activity")
+        // Block screenshots, screen recording, and the recents-screen thumbnail.
+        // Kept off in debug so Detox/Maestro screenshot-on-failure still works.
+        if (!BuildConfig.DEBUG) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
+        // Recents card background when FLAG_SECURE blanks the thumbnail.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            setTaskDescription(
+                ActivityManager.TaskDescription.Builder()
+                    .setBackgroundColor(Color.BLACK)
+                    .build()
+            )
+        }
         super.onCreate(null)
     }
 

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
@@ -22,13 +22,10 @@ class MainActivity : ReactActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.i("ON_CREATE", "Starting main activity")
         // Block screenshots, screen recording, and the recents-screen thumbnail.
-        // Kept off in debug so Detox/Maestro screenshot-on-failure still works.
-        if (!BuildConfig.DEBUG) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        }
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
         // Recents card background when FLAG_SECURE blanks the thumbnail.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             setTaskDescription(

--- a/ios/SceneDelegate.swift
+++ b/ios/SceneDelegate.swift
@@ -7,6 +7,7 @@ import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
+    private var privacyWindow: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = scene as? UIWindowScene else { return }
@@ -22,10 +23,40 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
+        hidePrivacyOverlay()
         (UIApplication.shared.delegate as? AppDelegate)?.handleForeground()
+    }
+
+    // iOS captures the app-switcher snapshot between willResignActive and
+    // didEnterBackground, so the overlay has to be installed here.
+    func sceneWillResignActive(_ scene: UIScene) {
+        showPrivacyOverlay(on: scene)
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        hidePrivacyOverlay()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         (UIApplication.shared.delegate as? AppDelegate)?.handleBackground()
+    }
+
+    private func showPrivacyOverlay(on scene: UIScene) {
+        guard privacyWindow == nil,
+              let windowScene = scene as? UIWindowScene else { return }
+
+        let overlay = UIWindow(windowScene: windowScene)
+        overlay.windowLevel = .alert + 1
+        overlay.backgroundColor = .black
+        let vc = UIViewController()
+        vc.view.backgroundColor = .black
+        overlay.rootViewController = vc
+        overlay.isHidden = false
+        privacyWindow = overlay
+    }
+
+    private func hidePrivacyOverlay() {
+        privacyWindow?.isHidden = true
+        privacyWindow = nil
     }
 }


### PR DESCRIPTION
Android — MainActivity.kt
- Sets WindowManager.LayoutParams.FLAG_SECURE on the window in onCreate(). This blocks manual screenshots, blocks screen recording, and blanks the app-switcher thumbnail in a single call.
- The flag is applied in all build types, including debug. We considered gating it behind !BuildConfig.DEBUG so Detox/Maestro could still screenshot on failure, but our CI workflows already build Detox (android-ubuntu-integration-test-ci.yaml) and Maestro (maestro-nightly.yaml) against assembleProdRelease — they cannot use debug because CI does not run a Metro packager. A debug-only gate would have left CI unprotected while breaking nothing. Applying the flag unconditionally keeps the protection coherent across all builds; the trade-off is that Detox loses screenshot-on-failure (Maestro still records video).
- Adds an ActivityManager.TaskDescription with a black backgroundColor so that, when the system blanks the recents card, it is rendered black instead of the default white window background.

iOS — SceneDelegate.swift
- Adds a dedicated privacyWindow (a UIWindow at windowLevel = .alert + 1 with a black rootViewController) that is installed on sceneWillResignActive and removed on sceneDidBecomeActive.
- The overlay is installed in willResignActive rather than didEnterBackground because iOS captures the app-switcher snapshot between those two callbacks; installing it later would let the snapshot be taken with sensitive content still on screen.
- As a side benefit, the overlay also covers the screen while the biometric prompt is displayed (LocalAuthentication triggers willResignActive), which mitigates the iOS half of Issue C ("Sensitive Information Is Visible Without Passing Biometric Authentication").