### PR TITLE
LA Audit - Issue C: Sensitive Information Is Visible Without Passing Biometric Authentication

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import { ModeEnum, RouteEnum } from './app/AppState';
 import { BackHandler, LogBox, StatusBar } from 'react-native';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import AppErrorBoundary from './components/ErrorBoundary/AppErrorBoundary';
+import BiometricBlankingOverlay from './app/BiometricBlankingOverlay';
 
 LogBox.ignoreLogs([
   '[Reanimated] Reduced motion setting is enabled on this device.',
@@ -157,6 +158,7 @@ const App: React.FunctionComponent = () => {
       <KeyboardProvider>
         <SafeAreaProvider>
           <StatusBar backgroundColor={theme.colors.background} />
+          <BiometricBlankingOverlay />
           <NavigationContainer ref={navigationRef} theme={theme}>
             <SafeAreaView
               edges={['top', 'left', 'right']}

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
@@ -1,7 +1,11 @@
 package org.ZingoLabs.Zingo
 
+import android.app.ActivityManager
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -17,6 +21,22 @@ class MainActivity : ReactActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.i("ON_CREATE", "Starting main activity")
+        // Block screenshots, screen recording, and the recents-screen thumbnail.
+        // Kept off in debug so Detox/Maestro screenshot-on-failure still works.
+        if (!BuildConfig.DEBUG) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
+        // Recents card background when FLAG_SECURE blanks the thumbnail.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            setTaskDescription(
+                ActivityManager.TaskDescription.Builder()
+                    .setBackgroundColor(Color.BLACK)
+                    .build()
+            )
+        }
         super.onCreate(null)
     }
 

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
@@ -22,13 +22,10 @@ class MainActivity : ReactActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.i("ON_CREATE", "Starting main activity")
         // Block screenshots, screen recording, and the recents-screen thumbnail.
-        // Kept off in debug so Detox/Maestro screenshot-on-failure still works.
-        if (!BuildConfig.DEBUG) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        }
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
         // Recents card background when FLAG_SECURE blanks the thumbnail.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             setTaskDescription(

--- a/app/BiometricBlankingOverlay.tsx
+++ b/app/BiometricBlankingOverlay.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import {
+  DeviceEventEmitter,
+  Modal,
+  Platform,
+  StyleSheet,
+  View,
+} from 'react-native';
+
+import { BIOMETRIC_BLANKING_EVENT } from './simpleBiometrics';
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'black' },
+});
+
+const BiometricBlankingOverlay: React.FunctionComponent = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+    const sub = DeviceEventEmitter.addListener(
+      BIOMETRIC_BLANKING_EVENT,
+      (show: boolean) => setVisible(show),
+    );
+    return () => sub.remove();
+  }, []);
+
+  if (!visible) {
+    return null;
+  }
+  return (
+    <Modal
+      visible
+      transparent={false}
+      animationType="none"
+      statusBarTranslucent
+      hardwareAccelerated
+      onRequestClose={() => {}}
+    >
+      <View style={styles.overlay} />
+    </Modal>
+  );
+};
+
+export default BiometricBlankingOverlay;

--- a/app/simpleBiometrics.ts
+++ b/app/simpleBiometrics.ts
@@ -1,3 +1,5 @@
+import { DeviceEventEmitter, Platform } from 'react-native';
+
 import { GlobalConst, TranslateType } from './AppState';
 
 import ReactNativeBiometrics from 'react-native-biometrics';
@@ -7,12 +9,25 @@ type simpleBiometricsProps = {
   translate: (key: string) => TranslateType;
 };
 
+// Emitted with a boolean payload (true=show, false=hide) so a root-level
+// overlay can cover the activity while the system BiometricPrompt is up.
+// Audit Issue C: on Android the prompt does not cover the whole screen and
+// sensitive content stays visible behind it. iOS already gets this from the
+// SceneDelegate privacyWindow (LocalAuthentication triggers willResignActive).
+export const BIOMETRIC_BLANKING_EVENT = 'biometric-blanking';
+
 const simpleBiometrics = async (
   props: simpleBiometricsProps,
 ): Promise<boolean | undefined> => {
   const rnBiometrics = new ReactNativeBiometrics({
     allowDeviceCredentials: true,
   });
+
+  if (Platform.OS === 'android') {
+    DeviceEventEmitter.emit(BIOMETRIC_BLANKING_EVENT, true);
+    // Yield one frame so the overlay paints before the system prompt opens.
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+  }
 
   try {
     const result = await rnBiometrics.simplePrompt({
@@ -32,6 +47,9 @@ const simpleBiometrics = async (
     console.log('biometrics: no auth method available', e);
     return undefined;
   } finally {
+    if (Platform.OS === 'android') {
+      DeviceEventEmitter.emit(BIOMETRIC_BLANKING_EVENT, false);
+    }
     // iOS interprets the auth prompt as the app going to background;
     // restore the foreground flag so background-state handling doesn't trip.
     await AsyncStorage.setItem(GlobalConst.background, GlobalConst.no);

--- a/ios/SceneDelegate.swift
+++ b/ios/SceneDelegate.swift
@@ -7,6 +7,7 @@ import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
+    private var privacyWindow: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = scene as? UIWindowScene else { return }
@@ -22,10 +23,40 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
+        hidePrivacyOverlay()
         (UIApplication.shared.delegate as? AppDelegate)?.handleForeground()
+    }
+
+    // iOS captures the app-switcher snapshot between willResignActive and
+    // didEnterBackground, so the overlay has to be installed here.
+    func sceneWillResignActive(_ scene: UIScene) {
+        showPrivacyOverlay(on: scene)
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        hidePrivacyOverlay()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         (UIApplication.shared.delegate as? AppDelegate)?.handleBackground()
+    }
+
+    private func showPrivacyOverlay(on scene: UIScene) {
+        guard privacyWindow == nil,
+              let windowScene = scene as? UIWindowScene else { return }
+
+        let overlay = UIWindow(windowScene: windowScene)
+        overlay.windowLevel = .alert + 1
+        overlay.backgroundColor = .black
+        let vc = UIViewController()
+        vc.view.backgroundColor = .black
+        overlay.rootViewController = vc
+        overlay.isHidden = false
+        privacyWindow = overlay
+    }
+
+    private func hidePrivacyOverlay() {
+        privacyWindow?.isHidden = true
+        privacyWindow = nil
     }
 }


### PR DESCRIPTION
on top of: #1092 
- app/simpleBiometrics.ts — exports a new BIOMETRIC_BLANKING_EVENT and, on Android only, emits true immediately before invoking rnBiometrics.simplePrompt(...) and false in the finally block. A one-frame requestAnimationFrame yield is inserted between the emit and the prompt so the overlay paints before the system dialog opens.
- app/BiometricBlankingOverlay.tsx — a small component that subscribes to the event via DeviceEventEmitter, renders a full-screen black Modal with statusBarTranslucent and hardwareAccelerated, and unmounts when the prompt resolves. The listener is registered only on Android; iOS short-circuits.
- App.tsx — mounts <BiometricBlankingOverlay /> inside SafeAreaProvider, above NavigationContainer, so the Modal sits at the top of the React tree and covers every screen, including those rendered inside BottomSheetModalProvider portals.