### PR TITLE
LA Audit - Issue G: Custom Server Configuration Accepts Plaintext HTTP Endpoints

### DIFF
--- a/__tests__/parseServerURI.test.ts
+++ b/__tests__/parseServerURI.test.ts
@@ -1,0 +1,55 @@
+import parseServerURI from '../app/uris/parseServerURI';
+
+// Returns the translation key verbatim so each test can check which
+// branch the parser took without depending on the actual locale string.
+const keyEcho = (key: string) => key;
+
+// Audit Issue G — parseServerURI must reject plaintext http:// for any
+// non-local host and accept it only when the user is pointing at a
+// server on the same device.
+describe('parseServerURI — Issue G plaintext rules', () => {
+  test('https remote → accepted', () => {
+    const r = parseServerURI('https://zec.rocks:443', keyEcho);
+    expect(r).toBe('https://zec.rocks:443');
+  });
+
+  test('http remote → http-not-allowed error', () => {
+    const r = parseServerURI('http://example.com:9067', keyEcho);
+    expect(r).toBe('uris.error-http-not-allowed');
+  });
+
+  test('http localhost → accepted', () => {
+    const r = parseServerURI('http://localhost:9067', keyEcho);
+    expect(r).toBe('http://localhost:9067');
+  });
+
+  test('http 127.0.0.1 → accepted', () => {
+    const r = parseServerURI('http://127.0.0.1:9067', keyEcho);
+    expect(r).toBe('http://127.0.0.1:9067');
+  });
+
+  test('http ::1 (IPv6 loopback) → accepted', () => {
+    const r = parseServerURI('http://[::1]:9067', keyEcho);
+    expect(r).toBe('http://[::1]:9067');
+  });
+
+  test('https localhost → accepted', () => {
+    const r = parseServerURI('https://localhost:9067', keyEcho);
+    expect(r).toBe('https://localhost:9067');
+  });
+
+  test('empty uri → bad uri error (pre-existing behaviour)', () => {
+    const r = parseServerURI('', keyEcho);
+    expect(r).toBe('uris.baduri');
+  });
+
+  test('ftp protocol → bad uri error (pre-existing behaviour)', () => {
+    const r = parseServerURI('ftp://anything.com:9067', keyEcho);
+    expect(r).toBe('uris.baduri');
+  });
+
+  test('uppercase Localhost → accepted (hostname normalized to lowercase)', () => {
+    const r = parseServerURI('http://Localhost:9067', keyEcho);
+    expect(r).toBe('http://localhost:9067');
+  });
+});

--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -1190,7 +1190,10 @@ export class LoadingAppClass extends Component<
       );
       const chainName = this.state.customServerChainName;
       if (uri && uri.toLowerCase().startsWith(GlobalConst.error)) {
-        this.addLastSnackbar(this.state.translate('settings.isuri') as string);
+        // Surface the parser's specific message (bad URI, plaintext
+        // HTTP not allowed, etc.) instead of the generic "fill out a
+        // valid Server URI" snackbar so the user can fix the input.
+        this.addLastSnackbar(uri);
         this.setState({ actionButtonsDisabled: false });
         return;
       }

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -764,7 +764,8 @@
     "amount": "Couldn't parse (amount)",
     "noparameter": "Unknown parameter",
     "noaddress": "Didn't have an address",
-    "oneentry": "URI Should have at least 1 entry"
+    "oneentry": "URI Should have at least 1 entry",
+    "error-http-not-allowed": "Error: Plain HTTP is only allowed for localhost. Use HTTPS for remote servers."
   },
   "donation-button": "Donate To ZingoLabs ",
   "donation-legend": "You are donating to ZingoLabs activately, Thanks"

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -764,7 +764,8 @@
     "amount": "No se pudo interpretar (amount)",
     "noparameter": "Parámetro desconocido",
     "noaddress": "No tenía una dirección",
-    "oneentry": "URI Debería tener al menos una entrada"
+    "oneentry": "URI Debería tener al menos una entrada",
+    "error-http-not-allowed": "Error: HTTP en texto plano solo está permitido para localhost. Usa HTTPS para servidores remotos."
   },
   "donation-button": "Donar a ZingoLabs ",
   "donation-legend": "Estás donando a ZingoLabs activamente, Gracias"

--- a/app/translations/pt.json
+++ b/app/translations/pt.json
@@ -764,7 +764,8 @@
     "amount": "Não foi possível analisar (quantia)",
     "noparameter": "Parâmetro desconhecido",
     "noaddress": "Nenhum endereço válido informado",
-    "oneentry": "RI deve ter pelo menos 1 entrada"
+    "oneentry": "RI deve ter pelo menos 1 entrada",
+    "error-http-not-allowed": "Error: HTTP em texto plano só é permitido para localhost. Use HTTPS para servidores remotos."
   },
   "donation-button": "Doar para ZingoLabs ",
   "donation-legend": "Você está doando para ZingoLabs ativamente, Obrigado"

--- a/app/translations/ru.json
+++ b/app/translations/ru.json
@@ -764,7 +764,8 @@
     "amount": "Не удалось спарсить (сумма)",
     "noparameter": "Неизвестный параметр",
     "noaddress": "Не указан адрес",
-    "oneentry": "URI должен иметь хотя бы одну запись"
+    "oneentry": "URI должен иметь хотя бы одну запись",
+    "error-http-not-allowed": "Error: Незащищённый HTTP разрешён только для localhost. Для удалённых серверов используйте HTTPS."
   },
   "donation-button": "Задонатить на разработку ZingoLabs ",
   "donation-legend": "Вы вносите пожертвования ZingoLabs активно, спасибо"

--- a/app/translations/tr.json
+++ b/app/translations/tr.json
@@ -764,7 +764,8 @@
     "amount": "Çözümlenemedi (Miktar)",
     "noparameter": "Bilinmeyen parametre",
     "noaddress": "Adres belirtilmemiş",
-    "oneentry": "URI en az 1 girişe sahip olmalıdır"
+    "oneentry": "URI en az 1 girişe sahip olmalıdır",
+    "error-http-not-allowed": "Error: Düz HTTP yalnızca localhost için izin verilir. Uzak sunucular için HTTPS kullanın."
   },
   "donation-button": "ZingoLabs’a Bağış Yap",
   "donation-legend": "ZingoLabs'a aktif olarak bağış yapıyorsunuz, Teşekkürler"

--- a/app/uris/parseServerURI.ts
+++ b/app/uris/parseServerURI.ts
@@ -1,6 +1,20 @@
 import Url from 'url-parse';
 import { GlobalConst, TranslateType } from '../AppState';
 
+// Audit Issue G — plaintext http:// is only acceptable when the user is
+// pointing at a server running on the same device (local development,
+// regtest, manual debugging). Anything else risks exposing wallet
+// metadata over an unencrypted connection. url-parse normalises the
+// hostname to lowercase and preserves IPv6 brackets, so we strip the
+// brackets before checking and rely on lowercasing already happening.
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+const isLocalHost = (hostname: string): boolean => {
+  // Strip the [ ] brackets that url-parse keeps around IPv6 literals.
+  const cleaned = hostname.replace(/^\[/, '').replace(/\]$/, '');
+  return LOCAL_HOSTNAMES.has(cleaned.toLowerCase());
+};
+
 const parseServerURI = (
   uri: string,
   translate: (key: string) => TranslateType,
@@ -18,6 +32,14 @@ const parseServerURI = (
       parsedUri.protocol !== GlobalConst.https)
   ) {
     return translate('uris.baduri') as string;
+  }
+
+  // Reject http:// for any non-local host — see audit Issue G.
+  if (
+    parsedUri.protocol === GlobalConst.http &&
+    !isLocalHost(parsedUri.hostname)
+  ) {
+    return translate('uris.error-http-not-allowed') as string;
   }
 
   let port = parsedUri.port;

--- a/components/Settings/Settings.tsx
+++ b/components/Settings/Settings.tsx
@@ -589,7 +589,10 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
     ) {
       const resultUri = parseServerURI(serverUriParsed, translate);
       if (resultUri && resultUri.toLowerCase().startsWith(GlobalConst.error)) {
-        addLastSnackbar(translate('settings.isuri') as string);
+        // Surface the parser's specific message (bad URI, plaintext
+        // HTTP not allowed, etc.) instead of the generic "fill out a
+        // valid Server URI" snackbar so the user can fix the input.
+        addLastSnackbar(resultUri);
         return;
       }
       if (serverUriParsed !== resultUri) {


### PR DESCRIPTION
- parseServerURI now rejects http:// for any non-local host. Only localhost, 127.0.0.1 and ::1 (IPv6 loopback, brackets stripped) are accepted with plain HTTP — every other host requires HTTPS.
- Added a new `uris.error-http-not-allowed` translation key in en/es/pt/ru/tr, prefixed with `Error:` so the existing `startsWith(GlobalConst.error)` detection in the callers still works.
- Surfaced the parser's specific error message in the snackbar at both `Settings.tsx` and `LoadingApp.tsx` custom-server save paths instead of the generic `settings.isuri` ("You need to fill out a valid Server URI") — the user now sees exactly why the URI was rejected (`Error: Bad URI.` vs `Error: Plain HTTP is only allowed for localhost…`).
- Added `__tests__/parseServerURI.test.ts` covering nine cases: https remote accepted, http remote rejected, http localhost / 127.0.0.1 / [::1] accepted, https localhost accepted, empty and ftp inputs rejected, and case-insensitive hostname normalization.