### PR TITLE
LA Audit - Issue I: Android Activity Lacks Tapjacking Protection

### DIFF
--- a/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/MainActivity.kt
@@ -18,6 +18,9 @@ class MainActivity : ReactActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.i("ON_CREATE", "Starting main activity")
         super.onCreate(null)
+        // Audit Issue I: tapjacking protection — drop touches if another
+        // window (e.g. SYSTEM_ALERT_WINDOW overlay) is on top of ours.
+        window.decorView.filterTouchesWhenObscured = true
     }
 
     override fun createReactActivityDelegate(): ReactActivityDelegate {


### PR DESCRIPTION
- Set `window.decorView.filterTouchesWhenObscured = true` in `MainActivity.onCreate`, so Android drops any touch event that arrives while another window (e.g. a malicious `SYSTEM_ALERT_WINDOW` overlay) is on top of ours.
- Single global flag at the Activity level covers every React Native screen — no per-screen wiring needed, and the decor view exists before any RN content mounts so there is no timing gap.
