### PR TITLE
LA Audit - Issue K: Sensitive Data Is Logged

### DIFF
--- a/app/utils/Utils.ts
+++ b/app/utils/Utils.ts
@@ -335,10 +335,6 @@ export default class Utils {
       });
     }
 
-    console.log('Sending:');
-    console.log(jsonFlat);
-    console.log(donationTransaction);
-
     return [...jsonFlat, ...donationTransaction];
   }
 

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -436,7 +436,6 @@ const Send: React.FunctionComponent<SendProps> = ({
         runProposeStr.toLowerCase().startsWith(GlobalConst.error)
       ) {
         // snack with error
-        console.log(runProposeStr);
         setProposeSendLastError(runProposeStr);
         //Alert.alert('Calculating the FEE', runProposeStr);
       } else {
@@ -477,7 +476,6 @@ const Send: React.FunctionComponent<SendProps> = ({
           }
         } catch (e) {
           // snack with error
-          console.log(runProposeStr);
           setProposeSendLastError(runProposeStr);
           //Alert.alert('Calculating the FEE', runProposeJson.error);
         }
@@ -531,13 +529,11 @@ const Send: React.FunctionComponent<SendProps> = ({
           Date.now() - start,
         );
       }
-      console.log(runSpendableBalanceStr);
       if (
         runSpendableBalanceStr &&
         runSpendableBalanceStr.toLowerCase().startsWith(GlobalConst.error)
       ) {
         // snack with error
-        console.log(runSpendableBalanceStr);
         setSpendableBalanceLastError(runSpendableBalanceStr);
         //Alert.alert('Calculating the FEE', runProposeStr);
       } else {
@@ -555,11 +551,6 @@ const Send: React.FunctionComponent<SendProps> = ({
           }
         } catch (e) {
           // snack with error
-          console.log(
-            'SPENDABLEBALANCE error',
-            runSpendableBalanceStr,
-            e instanceof Error ? e.message : String(e),
-          );
           setSpendableBalanceLastError(
             runSpendableBalanceStr +
               ' ' +
@@ -978,8 +969,6 @@ const Send: React.FunctionComponent<SendProps> = ({
           // all of the servers return an error because they are unreachable probably.
           // the 15 seconds timout was fired.
         }
-        console.log(serverChecked);
-        console.log(fasterServer);
         if (fasterServer.uri !== server.uri) {
           await setServerOption(fasterServer, selectServer, false, true);
         }

--- a/components/Send/components/Confirm.tsx
+++ b/components/Send/components/Confirm.tsx
@@ -259,9 +259,6 @@ const Confirm: React.FunctionComponent<ConfirmProps> = ({
       ),
     );
 
-    //console.log('total', totalAmount);
-    //console.log('header spendable', totalBalance?.totalSpendableBalance);
-
     // amount + fee
     if (
       totalAmount <= (totalBalance ? totalBalance.confirmedOrchardBalance : 0)
@@ -278,13 +275,9 @@ const Confirm: React.FunctionComponent<ConfirmProps> = ({
       from = PrivacyLevelFromEnum.saplingPrivacyLevel;
     }
 
-    //console.log(from);
-
     if (from === PrivacyLevelFromEnum.nonePrivacyLevel) {
       return '-';
     }
-
-    //console.log('parse-address', sendPageState.toaddr.to, resultJSON.status === RPCParseStatusEnum.successParse);
 
     if (
       parseAddressInfoJSON.status !==
@@ -293,8 +286,6 @@ const Confirm: React.FunctionComponent<ConfirmProps> = ({
     ) {
       return '-';
     }
-
-    //console.log(from, result, resultJSON);
 
     // Private -> orchard to orchard (UA with orchard receiver)
     if (

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';
 
+// Audit Issue K: silence debug logs in release builds so RPC payloads, wallet
+// state, and other potentially sensitive values never reach logcat in
+// production. console.warn/error are kept for crash diagnostics.
 if (!__DEV__) {
   console.log = () => {};
   console.debug = () => {};


### PR DESCRIPTION
- The existing `__DEV__` guard in `index.js` already neutralizes `console.log/debug/info` in release, so the audit's "PII in logcat" concern is closed at the build-mode level. Added a comment on the guard so future readers know it's load-bearing for the audit finding.
- Deleted the `Utils.ts` `console.log('Sending:'); console.log(jsonFlat); console.log(donationTransaction);` trio — every send was dumping recipient address, amount and memo to the dev console for no operational reason.
- Deleted six RPC payload dumps in `Send.tsx` (`runProposeStr` ×2, `runSpendableBalanceStr` ×3 including the multi-line catch dump, and the `serverChecked` / `fasterServer` pair) and five dead `//console.log` lines in `Confirm.tsx`.
