### PR TITLE
LA Audit - Issue N: Wallet and Settings Are Stored on Device Without Encryption or Authentication

### DIFF
--- a/__mocks__/react-native-encrypted-storage.js
+++ b/__mocks__/react-native-encrypted-storage.js
@@ -1,0 +1,17 @@
+let store = {};
+
+export default {
+  setItem: jest.fn((key, value) => {
+    store[key] = value;
+    return Promise.resolve();
+  }),
+  getItem: jest.fn(key => Promise.resolve(store[key] ?? null)),
+  removeItem: jest.fn(key => {
+    delete store[key];
+    return Promise.resolve();
+  }),
+  clear: jest.fn(() => {
+    store = {};
+    return Promise.resolve();
+  }),
+};

--- a/components/Settings/SettingsFileImpl.ts
+++ b/components/Settings/SettingsFileImpl.ts
@@ -1,3 +1,4 @@
+import EncryptedStorage from 'react-native-encrypted-storage';
 import * as RNFS from 'react-native-fs';
 
 import {
@@ -17,8 +18,15 @@ import { serverUris } from '../../app/uris';
 import { isEqual } from 'lodash';
 import { RPCPerformanceLevelEnum } from '../../app/walletBackend/enums/RPCPerformanceLevelEnum';
 
+// Audit Issue N: settings are persisted in EncryptedStorage instead of a
+// plaintext JSON file. Android → EncryptedSharedPreferences (Jetpack Security,
+// AES-256-GCM, key in Android Keystore). iOS → Keychain Services.
+const STORAGE_KEY = 'settings';
+
 export default class SettingsFileImpl {
-  static async getFileName() {
+  // Kept for the one-time migration path that reads the legacy plaintext file
+  // from DocumentDirectory. Not used for writes anymore.
+  static async getLegacyFileName() {
     return RNFS.DocumentDirectoryPath + '/settings.json';
   }
 
@@ -27,36 +35,92 @@ export default class SettingsFileImpl {
     name: SettingsNameEnum,
     value: string | boolean | ServerType | SecurityType,
   ) {
-    const fileName = await this.getFileName();
     const settings = await this.readSettings();
     const newSettings: SettingsFileClass = { ...settings, [name]: value };
 
-    //console.log(' settings write', newSettings);
-
-    await RNFS.writeFile(
-      fileName,
-      JSON.stringify(newSettings),
-      GlobalConst.utf8,
-    );
+    await EncryptedStorage.setItem(STORAGE_KEY, JSON.stringify(newSettings));
   }
 
   // Read the server setting
   static async readSettings(): Promise<SettingsFileClass> {
+    const defaults = (): SettingsFileClass =>
+      ({ firstInstall: true, version: null }) as SettingsFileClass;
+
+    let raw: string | null = null;
+
+    // Step 1: read encrypted storage. On failure, fall through to legacy
+    // recovery rather than masking as fresh install.
     try {
-      const fileName = await this.getFileName();
-      const fileExits: boolean = await RNFS.exists(fileName);
-      if (!fileExits) {
-        console.log('settings read file: The file does not exists');
-        const settings: SettingsFileClass = {
-          firstInstall: true,
-          version: null,
-        } as SettingsFileClass;
-        return settings;
+      raw = await EncryptedStorage.getItem(STORAGE_KEY);
+    } catch (err) {
+      console.log('settings: encrypted read failed, will try legacy:', err);
+    }
+
+    // Step 2: one-time migration from plaintext settings.json, or recovery
+    // when encrypted storage is unreadable but the legacy file is still around.
+    if (raw === null) {
+      const legacyPath = await this.getLegacyFileName();
+      let legacyExists = false;
+      try {
+        legacyExists = await RNFS.exists(legacyPath);
+      } catch (_) {
+        // best-effort
       }
 
-      const settings: SettingsFileClass = await JSON.parse(
-        (await RNFS.readFile(fileName, GlobalConst.utf8)).toString(),
+      if (legacyExists) {
+        let legacyRaw: string | null = null;
+        try {
+          legacyRaw = await RNFS.readFile(legacyPath, GlobalConst.utf8);
+        } catch (err) {
+          console.log('settings: legacy read failed:', err);
+          return defaults();
+        }
+
+        // Commit to encrypted storage. If this fails we still use legacyRaw
+        // for this session and retry the migration on the next launch.
+        let migrated = false;
+        try {
+          await EncryptedStorage.setItem(STORAGE_KEY, legacyRaw);
+          migrated = true;
+        } catch (err) {
+          console.log(
+            'settings: migration write failed, using legacy this session:',
+            err,
+          );
+        }
+
+        raw = legacyRaw;
+
+        // Only delete the legacy file once encrypted commit succeeded.
+        // If unlink itself fails it is non-fatal: subsequent boots will read
+        // from encrypted storage and skip this block entirely.
+        if (migrated) {
+          try {
+            await RNFS.unlink(legacyPath);
+          } catch (err) {
+            console.log('settings: legacy unlink failed (non-fatal):', err);
+          }
+        }
+      }
+    }
+
+    if (raw === null) {
+      console.log('settings read: no stored settings, fresh install');
+      return defaults();
+    }
+
+    let settings: SettingsFileClass;
+    try {
+      settings = JSON.parse(raw) as SettingsFileClass;
+    } catch (err) {
+      console.log(
+        'settings: JSON parse failed, treating as fresh install:',
+        err,
       );
+      return defaults();
+    }
+
+    try {
       // If server as string is found, I need to convert to: ServerType
       // if not, I'm losing the value
       if (!settings.hasOwnProperty(SettingsNameEnum.server)) {
@@ -244,14 +308,10 @@ export default class SettingsFileImpl {
       }
       return settings;
     } catch (err) {
-      // The File doesn't exist, so return nothing
-      // Here I know 100% it is a fresh install or the user cleaned the device staorage
-      console.log('settings read file:', err);
-      const settings: SettingsFileClass = {
-        firstInstall: true,
-        version: null,
-      } as SettingsFileClass;
-      return settings;
+      // Normalization failed on malformed data (e.g. a settings.server with
+      // unexpected shape). Fall back to defaults rather than propagating.
+      console.log('settings: normalization failed:', err);
+      return defaults();
     }
   }
 }

--- a/ios/Zingo.xcodeproj/project.pbxproj
+++ b/ios/Zingo.xcodeproj/project.pbxproj
@@ -25,9 +25,9 @@
 		1FA935B32BE457B100117DF5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F7D321C2B71D44800D2879C /* SystemConfiguration.framework */; };
 		1FC1E2172BE443270064963B /* ZingoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC1E2162BE443270064963B /* ZingoTest.swift */; };
 		1FE8E9AC296B85FC004A256B /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE8E9AB296B85FC004A256B /* BackgroundTasks.framework */; };
-		4ED39A9E9AA6FBD386854CB5 /* libPods-Zingo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 05959E646C3C1B8FBE23A1CC /* libPods-Zingo.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		9D5EFA1A21B676257145363B /* libPods-Zingo-ZingoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 85F04C90D9E3422FA4475E09 /* libPods-Zingo-ZingoTests.a */; };
+		857EF0CAD420162B57610268 /* libPods-Zingo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 933091B21301638F6FEC48C2 /* libPods-Zingo.a */; };
+		D3FE1A937147D32E9DC9D0A5 /* libPods-Zingo-ZingoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A8F57CD1DC1E67BED5947AA5 /* libPods-Zingo-ZingoTests.a */; };
 		FBBD6650421A473A90DAF827 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB06295A2A14F70A7A5B566 /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
@@ -42,17 +42,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		007775E07EB9BFAECB8CB5C9 /* Pods-Zingo.release-beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo.release-beta.xcconfig"; path = "Target Support Files/Pods-Zingo/Pods-Zingo.release-beta.xcconfig"; sourceTree = "<group>"; };
 		00E356EE1AD99517003FC87E /* ZingoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZingoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		05959E646C3C1B8FBE23A1CC /* libPods-Zingo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Zingo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0C9919E8C1562DEEC88DBBA4 /* Pods-Zingo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo.release.xcconfig"; path = "Target Support Files/Pods-Zingo/Pods-Zingo.release.xcconfig"; sourceTree = "<group>"; };
-		12374D015CD0E5622F991437 /* Pods-Zingo-ZingoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo-ZingoTests.debug.xcconfig"; path = "Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		0594908E68F171628ECA1ABB /* Pods-Zingo-ZingoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo-ZingoTests.release.xcconfig"; path = "Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Zingo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Zingo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Zingo/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Zingo/Info.plist; sourceTree = "<group>"; };
 		1F0338182C48782D00A3FC49 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		1F0893FE2BA4C4380089FD88 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		1F354A866663E7CF2F54EA76 /* Pods-Zingo.debug-beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo.debug-beta.xcconfig"; path = "Target Support Files/Pods-Zingo/Pods-Zingo.debug-beta.xcconfig"; sourceTree = "<group>"; };
 		1F5569252BBCB4D900F2CD6C /* RPCModule-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RPCModule-Bridging-Header.h"; sourceTree = "<group>"; };
 		1F5569262BBCB4D900F2CD6C /* RPCModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCModule.swift; sourceTree = "<group>"; };
 		1F5569282BBCB98100F2CD6C /* RPCModuleBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RPCModuleBridge.m; sourceTree = "<group>"; };
@@ -64,14 +62,16 @@
 		1FA935B62BE474CD00117DF5 /* ZingoTest-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZingoTest-Bridging-Header.h"; sourceTree = "<group>"; };
 		1FC1E2162BE443270064963B /* ZingoTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZingoTest.swift; sourceTree = "<group>"; };
 		1FE8E9AB296B85FC004A256B /* BackgroundTasks.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BackgroundTasks.framework; path = System/Library/Frameworks/BackgroundTasks.framework; sourceTree = SDKROOT; };
-		28B2869A84DAB00C91D251EC /* Pods-Zingo-ZingoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo-ZingoTests.release.xcconfig"; path = "Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests.release.xcconfig"; sourceTree = "<group>"; };
 		2DB06295A2A14F70A7A5B566 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		2FB96F1BB4E62BBAFF753413 /* Pods-Zingo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo.debug.xcconfig"; path = "Target Support Files/Pods-Zingo/Pods-Zingo.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Zingo/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		85F04C90D9E3422FA4475E09 /* libPods-Zingo-ZingoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Zingo-ZingoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		875F04487213B9D63FBB8C6F /* Pods-Zingo-ZingoTests.release-beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo-ZingoTests.release-beta.xcconfig"; path = "Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests.release-beta.xcconfig"; sourceTree = "<group>"; };
-		9200DD5AC7C733E3DE643E2C /* Pods-Zingo-ZingoTests.debug-beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo-ZingoTests.debug-beta.xcconfig"; path = "Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests.debug-beta.xcconfig"; sourceTree = "<group>"; };
-		B0E7757931EC9699988BA64F /* Pods-Zingo.debug-beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo.debug-beta.xcconfig"; path = "Target Support Files/Pods-Zingo/Pods-Zingo.debug-beta.xcconfig"; sourceTree = "<group>"; };
+		853A68CA3F260BB98FEB2CB8 /* Pods-Zingo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo.debug.xcconfig"; path = "Target Support Files/Pods-Zingo/Pods-Zingo.debug.xcconfig"; sourceTree = "<group>"; };
+		933091B21301638F6FEC48C2 /* libPods-Zingo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Zingo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A8F57CD1DC1E67BED5947AA5 /* libPods-Zingo-ZingoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Zingo-ZingoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE6ED4F0C75AAF63D1302073 /* Pods-Zingo-ZingoTests.release-beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo-ZingoTests.release-beta.xcconfig"; path = "Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests.release-beta.xcconfig"; sourceTree = "<group>"; };
+		B16B07761ADEE9DB5CB551D5 /* Pods-Zingo-ZingoTests.debug-beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo-ZingoTests.debug-beta.xcconfig"; path = "Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests.debug-beta.xcconfig"; sourceTree = "<group>"; };
+		DEDA52A1B660E5506DBDFF6C /* Pods-Zingo-ZingoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo-ZingoTests.debug.xcconfig"; path = "Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		E10EECB8224CD6F04BA52FF7 /* Pods-Zingo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo.release.xcconfig"; path = "Target Support Files/Pods-Zingo/Pods-Zingo.release.xcconfig"; sourceTree = "<group>"; };
+		E844C194A8FC081F2BE4EBF7 /* Pods-Zingo.release-beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zingo.release-beta.xcconfig"; path = "Target Support Files/Pods-Zingo/Pods-Zingo.release-beta.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -82,7 +82,7 @@
 			files = (
 				1FA935B32BE457B100117DF5 /* SystemConfiguration.framework in Frameworks */,
 				1F9FDA9C2FBD5CEC000C5248 /* Zingolib.xcframework in Frameworks */,
-				9D5EFA1A21B676257145363B /* libPods-Zingo-ZingoTests.a in Frameworks */,
+				D3FE1A937147D32E9DC9D0A5 /* libPods-Zingo-ZingoTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,7 +93,7 @@
 				1FE8E9AC296B85FC004A256B /* BackgroundTasks.framework in Frameworks */,
 				1F9FDA9B2FBD5CEC000C5248 /* Zingolib.xcframework in Frameworks */,
 				1F7D321D2B71D44800D2879C /* SystemConfiguration.framework in Frameworks */,
-				4ED39A9E9AA6FBD386854CB5 /* libPods-Zingo.a in Frameworks */,
+				857EF0CAD420162B57610268 /* libPods-Zingo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -142,8 +142,8 @@
 				1FE8E9AB296B85FC004A256B /* BackgroundTasks.framework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				1F9FDA9A2FBD5CEC000C5248 /* Zingolib.xcframework */,
-				05959E646C3C1B8FBE23A1CC /* libPods-Zingo.a */,
-				85F04C90D9E3422FA4475E09 /* libPods-Zingo-ZingoTests.a */,
+				933091B21301638F6FEC48C2 /* libPods-Zingo.a */,
+				A8F57CD1DC1E67BED5947AA5 /* libPods-Zingo-ZingoTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -184,14 +184,14 @@
 		8BB7EBE9935B479E64CBB9A8 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2FB96F1BB4E62BBAFF753413 /* Pods-Zingo.debug.xcconfig */,
-				B0E7757931EC9699988BA64F /* Pods-Zingo.debug-beta.xcconfig */,
-				0C9919E8C1562DEEC88DBBA4 /* Pods-Zingo.release.xcconfig */,
-				007775E07EB9BFAECB8CB5C9 /* Pods-Zingo.release-beta.xcconfig */,
-				12374D015CD0E5622F991437 /* Pods-Zingo-ZingoTests.debug.xcconfig */,
-				9200DD5AC7C733E3DE643E2C /* Pods-Zingo-ZingoTests.debug-beta.xcconfig */,
-				28B2869A84DAB00C91D251EC /* Pods-Zingo-ZingoTests.release.xcconfig */,
-				875F04487213B9D63FBB8C6F /* Pods-Zingo-ZingoTests.release-beta.xcconfig */,
+				853A68CA3F260BB98FEB2CB8 /* Pods-Zingo.debug.xcconfig */,
+				1F354A866663E7CF2F54EA76 /* Pods-Zingo.debug-beta.xcconfig */,
+				E10EECB8224CD6F04BA52FF7 /* Pods-Zingo.release.xcconfig */,
+				E844C194A8FC081F2BE4EBF7 /* Pods-Zingo.release-beta.xcconfig */,
+				DEDA52A1B660E5506DBDFF6C /* Pods-Zingo-ZingoTests.debug.xcconfig */,
+				B16B07761ADEE9DB5CB551D5 /* Pods-Zingo-ZingoTests.debug-beta.xcconfig */,
+				0594908E68F171628ECA1ABB /* Pods-Zingo-ZingoTests.release.xcconfig */,
+				AE6ED4F0C75AAF63D1302073 /* Pods-Zingo-ZingoTests.release-beta.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -203,12 +203,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "ZingoTests" */;
 			buildPhases = (
-				016E388900046B2DD8523D31 /* [CP] Check Pods Manifest.lock */,
+				4CF4362D731864718EFD663A /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				8ED8FF957521FBC2BC73079B /* [CP] Embed Pods Frameworks */,
-				6E4FF168233F72A7CBACDA4E /* [CP] Copy Pods Resources */,
+				22CD4CD2FC0DCFC596C7CBD1 /* [CP] Embed Pods Frameworks */,
+				891EE291902C3E494AE7B6B8 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -224,15 +224,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Zingo" */;
 			buildPhases = (
-				B7609B2D3BBB8EC62AB2E1C2 /* [CP] Check Pods Manifest.lock */,
+				5138FD11A1C7FB3385BDA53F /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				1F67CE4E2E6798530075192B /* ShellScript */,
-				F2ECEF5313DF984A90AEA192 /* [CP] Embed Pods Frameworks */,
-				66AF43BE03B758D410A0F622 /* [CP] Copy Pods Resources */,
+				EC9B7869FE528D665B00234A /* [CP] Embed Pods Frameworks */,
+				4A00F149451C2569266F23E5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -316,7 +316,58 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \". $WITH_ENVIRONMENT && $REACT_NATIVE_XCODE\"\n";
 		};
-		016E388900046B2DD8523D31 /* [CP] Check Pods Manifest.lock */ = {
+		1F67CE4E2E6798530075192B /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\n# Solo para Archive/Release y Release-Beta\ncase \"${CONFIGURATION}\" in Release|Release-Beta) ;; *) exit 0;; esac\n\n# Cargar NODE_BINARY de .xcode.env (Xcode no sourcea ~/.zshrc).\nif [ -f \"${PROJECT_DIR}/.xcode.env\" ]; then . \"${PROJECT_DIR}/.xcode.env\"; fi\nif [ -f \"${PROJECT_DIR}/.xcode.env.local\" ]; then . \"${PROJECT_DIR}/.xcode.env.local\"; fi\nNODE_BIN=\"${NODE_BINARY:-node}\"\n\n# Leer la versión de react-native desde package.json (alineado con el\n# post_install hook del Podfile que descarga los dSYMs en esa misma ruta).\nRN_VERSION=$(\"$NODE_BIN\" -p \"require('${PROJECT_DIR}/../package.json').dependencies['react-native'].replace(/[^0-9.]/g, '')\")\n\n# Ruta donde el Podfile post_install descargó el dSYM de Hermes\nHERMES_DSYM_SRC=\"${PROJECT_DIR}/vendor/hermes-dsyms/RN-${RN_VERSION}/ios-arm64/release/iphoneos/hermes.framework.dSYM\"\n\n# Carpeta donde Xcode recopila los dSYM al archivar\nDSYM_DST=\"${DWARF_DSYM_FOLDER_PATH}\"\n\nif [ -d \"${HERMES_DSYM_SRC}\" ]; then\n  echo \"Copiando Hermes dSYM (RN ${RN_VERSION}) a ${DSYM_DST}\"\n  rsync -a \"${HERMES_DSYM_SRC}\" \"${DSYM_DST}/\"\nelse\n  echo \"ERROR: No se encontró Hermes.framework.dSYM en ${HERMES_DSYM_SRC}\" >&2\n  exit 1\nfi\n";
+		};
+		22CD4CD2FC0DCFC596C7CBD1 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4A00F149451C2569266F23E5 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Zingo/Pods-Zingo-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Zingo/Pods-Zingo-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zingo/Pods-Zingo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4CF4362D731864718EFD663A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -338,75 +389,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1F67CE4E2E6798530075192B /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n# Solo para Archive/Release y Release-Beta\ncase \"${CONFIGURATION}\" in Release|Release-Beta) ;; *) exit 0;; esac\n\n# Cargar NODE_BINARY de .xcode.env (Xcode no sourcea ~/.zshrc).\nif [ -f \"${PROJECT_DIR}/.xcode.env\" ]; then . \"${PROJECT_DIR}/.xcode.env\"; fi\nif [ -f \"${PROJECT_DIR}/.xcode.env.local\" ]; then . \"${PROJECT_DIR}/.xcode.env.local\"; fi\nNODE_BIN=\"${NODE_BINARY:-node}\"\n\n# Leer la versión de react-native desde package.json (alineado con el\n# post_install hook del Podfile que descarga los dSYMs en esa misma ruta).\nRN_VERSION=$(\"$NODE_BIN\" -p \"require('${PROJECT_DIR}/../package.json').dependencies['react-native'].replace(/[^0-9.]/g, '')\")\n\n# Ruta donde el Podfile post_install descargó el dSYM de Hermes\nHERMES_DSYM_SRC=\"${PROJECT_DIR}/vendor/hermes-dsyms/RN-${RN_VERSION}/ios-arm64/release/iphoneos/hermes.framework.dSYM\"\n\n# Carpeta donde Xcode recopila los dSYM al archivar\nDSYM_DST=\"${DWARF_DSYM_FOLDER_PATH}\"\n\nif [ -d \"${HERMES_DSYM_SRC}\" ]; then\n  echo \"Copiando Hermes dSYM (RN ${RN_VERSION}) a ${DSYM_DST}\"\n  rsync -a \"${HERMES_DSYM_SRC}\" \"${DSYM_DST}/\"\nelse\n  echo \"ERROR: No se encontró Hermes.framework.dSYM en ${HERMES_DSYM_SRC}\" >&2\n  exit 1\nfi\n";
-		};
-		66AF43BE03B758D410A0F622 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Zingo/Pods-Zingo-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Zingo/Pods-Zingo-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zingo/Pods-Zingo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6E4FF168233F72A7CBACDA4E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8ED8FF957521FBC2BC73079B /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B7609B2D3BBB8EC62AB2E1C2 /* [CP] Check Pods Manifest.lock */ = {
+		5138FD11A1C7FB3385BDA53F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -428,7 +411,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F2ECEF5313DF984A90AEA192 /* [CP] Embed Pods Frameworks */ = {
+		891EE291902C3E494AE7B6B8 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zingo-ZingoTests/Pods-Zingo-ZingoTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EC9B7869FE528D665B00234A /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -505,7 +505,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 12374D015CD0E5622F991437 /* Pods-Zingo-ZingoTests.debug.xcconfig */;
+			baseConfigurationReference = DEDA52A1B660E5506DBDFF6C /* Pods-Zingo-ZingoTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = 788KRST4S8;
@@ -540,7 +540,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 28B2869A84DAB00C91D251EC /* Pods-Zingo-ZingoTests.release.xcconfig */;
+			baseConfigurationReference = 0594908E68F171628ECA1ABB /* Pods-Zingo-ZingoTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COPY_PHASE_STRIP = NO;
@@ -572,7 +572,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2FB96F1BB4E62BBAFF753413 /* Pods-Zingo.debug.xcconfig */;
+			baseConfigurationReference = 853A68CA3F260BB98FEB2CB8 /* Pods-Zingo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Prod";
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -615,7 +615,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0C9919E8C1562DEEC88DBBA4 /* Pods-Zingo.release.xcconfig */;
+			baseConfigurationReference = E10EECB8224CD6F04BA52FF7 /* Pods-Zingo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Prod";
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -814,7 +814,7 @@
 		};
 		BE7AC0DE000000000000F941 /* Debug-Beta */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B0E7757931EC9699988BA64F /* Pods-Zingo.debug-beta.xcconfig */;
+			baseConfigurationReference = 1F354A866663E7CF2F54EA76 /* Pods-Zingo.debug-beta.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -857,7 +857,7 @@
 		};
 		BE7AC0DE000000000000F951 /* Release-Beta */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 007775E07EB9BFAECB8CB5C9 /* Pods-Zingo.release-beta.xcconfig */;
+			baseConfigurationReference = E844C194A8FC081F2BE4EBF7 /* Pods-Zingo.release-beta.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -1056,7 +1056,7 @@
 		};
 		BE7AC0DE0000000000E356F6 /* Debug-Beta */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9200DD5AC7C733E3DE643E2C /* Pods-Zingo-ZingoTests.debug-beta.xcconfig */;
+			baseConfigurationReference = B16B07761ADEE9DB5CB551D5 /* Pods-Zingo-ZingoTests.debug-beta.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = 788KRST4S8;
@@ -1091,7 +1091,7 @@
 		};
 		BE7AC0DE0000000000E356F7 /* Release-Beta */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 875F04487213B9D63FBB8C6F /* Pods-Zingo-ZingoTests.release-beta.xcconfig */;
+			baseConfigurationReference = AE6ED4F0C75AAF63D1302073 /* Pods-Zingo-ZingoTests.release-beta.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COPY_PHASE_STRIP = NO;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-native-biometrics": "^3.0.1",
     "react-native-bouncy-checkbox": "^4.1.2",
     "react-native-device-info": "^15.0.2",
+    "react-native-encrypted-storage": "^4.0.3",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "2.31.2",
     "react-native-gifted-charts": "^1.4.77",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7159,6 +7159,11 @@ react-native-device-info@^15.0.2:
   resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-15.0.2.tgz#c7de1bb6baeb07e1bab70159ad540c5705cb8dc0"
   integrity sha512-dd71eXG2l3Cwp66IvKNadMTB8fhU3PEjyVddI97sYan+D4bgIAUmgGDhbSOFvHcGavksb2U17kiQYaDiK2WK2g==
 
+react-native-encrypted-storage@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-encrypted-storage/-/react-native-encrypted-storage-4.0.3.tgz#2a4d65459870511e8f4ccd22f02433dab7fa5e91"
+  integrity sha512-0pJA4Aj2S1PIJEbU7pN/Qvf7JIJx3hFywx+i+bLHtgK0/6Zryf1V2xVsWcrD50dfiu3jY1eN2gesQ5osGxE7jA==
+
 react-native-fs@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.20.0.tgz#05a9362b473bfc0910772c0acbb73a78dbc810f6"


### PR DESCRIPTION
- Settings persistence migrates from plaintext `settings.json` in `DocumentDirectory` to `react-native-encrypted-storage`. Android backs it with `EncryptedSharedPreferences` (Jetpack Security, AES-256-GCM, key in Android Keystore, hardware-backed when TEE/StrongBox is available). iOS backs it with Keychain Services and is excluded from iCloud backup by default.
- AES-GCM is authenticated encryption, so this also catches tampering of the `security.*` flags (the real integrity risk: an attacker with sandbox write access could otherwise flip biometric gates to `false`).
- One-time migration: on first read after upgrade, if encrypted storage is empty and the legacy `settings.json` still exists, we read it, commit it to encrypted storage, and unlink the legacy file. Each step is in its own `try` so a partial failure (unlink errors, write errors, parse errors) cannot masquerade as a fresh install and destroy real data — worst case the migration retries on the next launch.
- Wallet & wallet backup files now are stored with encryption in both platforms.