### PR TITLE
LA Audit - Issue H: Invalid URIs Can Update Send State

### DIFF
--- a/__tests__/parseZcashURI.test.ts
+++ b/__tests__/parseZcashURI.test.ts
@@ -1,0 +1,167 @@
+import { Base64 } from 'js-base64';
+import { ChainNameEnum, ServerType } from '../app/AppState';
+
+// Mock Utils so the parser's `Utils.isValidAddress` call resolves to a
+// controllable result without dragging the native RPC bridge into Jest.
+jest.mock('../app/utils', () => ({
+  __esModule: true,
+  default: {
+    isValidAddress: jest.fn(),
+  },
+}));
+
+import parseZcashURI from '../app/uris/parseZcashURI';
+import Utils from '../app/utils';
+
+const mockIsValidAddress = Utils.isValidAddress as jest.Mock;
+
+// Returns the translation key verbatim so each test can check which
+// branch the parser took without depending on the actual locale string.
+const keyEcho = (key: string) => key as never;
+
+const mainnetServer: ServerType = {
+  uri: 'https://mainnet.lightwalletd.com:9067',
+  chainName: ChainNameEnum.mainChainName,
+};
+
+const VALID_ADDR = 't1validAddrPlaceholderForUnitTestsOnly';
+const INVALID_ADDR = 'not-an-address';
+
+// Audit Issue H — parseZcashURI must guarantee that when `error` is
+// non-empty the returned `target` is empty, so callers cannot prefill
+// Send state with attacker-controlled values from a malformed URI.
+describe('parseZcashURI — Issue H: errors must yield empty target', () => {
+  beforeEach(() => {
+    mockIsValidAddress.mockReset();
+    mockIsValidAddress.mockResolvedValue({
+      isValid: true,
+      onlyOrchardUA: '',
+    });
+  });
+
+  test('valid path-as-address → target populated, no error', async () => {
+    const r = await parseZcashURI(
+      `zcash:${VALID_ADDR}`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).toBe('');
+    expect(r.target.address).toBe(VALID_ADDR);
+  });
+
+  test('valid address + amount + memo → all populated, no error', async () => {
+    const memoB64 = Base64.encode('hello');
+    const r = await parseZcashURI(
+      `zcash:${VALID_ADDR}?amount=0.1&memo=${memoB64}`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).toBe('');
+    expect(r.target.address).toBe(VALID_ADDR);
+    expect(r.target.amount).toBe(0.1);
+    expect(r.target.memoString).toBe('hello');
+  });
+
+  test('invalid path-as-address → empty target, error present', async () => {
+    mockIsValidAddress.mockResolvedValue({
+      isValid: false,
+      onlyOrchardUA: '',
+    });
+    const r = await parseZcashURI(
+      `zcash:${INVALID_ADDR}`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).not.toBe('');
+    expect(r.target.address).toBeUndefined();
+    expect(r.target.amount).toBeUndefined();
+    expect(r.target.memoString).toBeUndefined();
+  });
+
+  test('invalid query-string address → empty target', async () => {
+    mockIsValidAddress.mockResolvedValue({
+      isValid: false,
+      onlyOrchardUA: '',
+    });
+    const r = await parseZcashURI(
+      `zcash:?address=${INVALID_ADDR}`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).not.toBe('');
+    expect(r.target.address).toBeUndefined();
+  });
+
+  test('negative amount → empty target (address never leaks)', async () => {
+    const r = await parseZcashURI(
+      `zcash:${VALID_ADDR}?amount=-1`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).not.toBe('');
+    expect(r.target.address).toBeUndefined();
+    expect(r.target.amount).toBeUndefined();
+  });
+
+  test('amount above 21,000,000 cap → empty target', async () => {
+    const r = await parseZcashURI(
+      `zcash:${VALID_ADDR}?amount=21000001`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).not.toBe('');
+    expect(r.target.address).toBeUndefined();
+  });
+
+  test('unknown parameter → empty target', async () => {
+    const r = await parseZcashURI(
+      `zcash:${VALID_ADDR}?foo=bar`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).not.toBe('');
+    expect(r.target.address).toBeUndefined();
+  });
+
+  test('duplicate address (path + query both set address) → empty target', async () => {
+    const r = await parseZcashURI(
+      `zcash:${VALID_ADDR}?address=${VALID_ADDR}`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).not.toBe('');
+    expect(r.target.address).toBeUndefined();
+  });
+
+  test('extra-dotted parameter (address.1.2) → empty target', async () => {
+    const r = await parseZcashURI(
+      `zcash:${VALID_ADDR}?address.1.2=${VALID_ADDR}`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).not.toBe('');
+    expect(r.target.address).toBeUndefined();
+  });
+
+  test('empty URI → baduri error, empty target', async () => {
+    const r = await parseZcashURI('', keyEcho, mainnetServer);
+    expect(r.error).toBe('uris.baduri');
+    expect(r.target.address).toBeUndefined();
+  });
+
+  test('non-zcash protocol → baduri error, empty target', async () => {
+    const r = await parseZcashURI(
+      `bitcoin:${VALID_ADDR}`,
+      keyEcho,
+      mainnetServer,
+    );
+    expect(r.error).toBe('uris.baduri');
+    expect(r.target.address).toBeUndefined();
+  });
+
+  test('zcash: without address but with amount → empty target', async () => {
+    const r = await parseZcashURI('zcash:?amount=1', keyEcho, mainnetServer);
+    expect(r.error).not.toBe('');
+    expect(r.target.address).toBeUndefined();
+  });
+});

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -1019,6 +1019,15 @@ export class LoadedAppClass extends Component<
         this.state.server,
       );
 
+      // Audit Issue H — surface the parser error and abort before any
+      // Send-state mutation. parseZcashURI now returns an empty target
+      // when error is non-empty, but the explicit guard keeps intent
+      // obvious here and protects against future contract changes.
+      if (error) {
+        this.addLastSnackbar(error);
+        return;
+      }
+
       if (target) {
         let update = false;
         if (

--- a/app/uris/parseZcashURI.ts
+++ b/app/uris/parseZcashURI.ts
@@ -9,6 +9,10 @@ import {
 } from '../AppState';
 import Utils from '../utils';
 
+// Audit Issue H — when `error` is non-empty the returned `target` is
+// guaranteed to be a fresh empty ZcashURITargetClass. Callers may treat
+// `error` and `target` as mutually exclusive: a non-empty error means
+// no fields are safe to apply to UI state.
 const parseZcashURI = async (
   uri: string,
   translate: (key: string) => TranslateType,
@@ -155,7 +159,15 @@ const parseZcashURI = async (
     errors.push(`${0}. ${translate('uris.noaddress')}`);
   }
 
-  return { error: errors.join(', '), target: firstTarget };
+  // Audit Issue H — any parser error invalidates the whole target. The
+  // path-as-address and query-string address branches assign t.address
+  // before validating, so a target with a non-empty address can still
+  // accompany a non-empty errors list. Returning a fresh empty target
+  // here closes that gap for every caller.
+  if (errors.length > 0) {
+    return { error: errors.join(', '), target: new ZcashURITargetClass() };
+  }
+  return { error: '', target: firstTarget };
 };
 
 export default parseZcashURI;

--- a/components/AddressBook/components/AbDetail.tsx
+++ b/components/AddressBook/components/AbDetail.tsx
@@ -139,7 +139,15 @@ const AbDetail: React.FunctionComponent<AbDetailProps> = ({
         translate,
         server,
       );
-      //console.log(targets);
+
+      // Audit Issue H — surface the parser error and abort before any
+      // address-state mutation. parseZcashURI returns an empty target
+      // when error is non-empty, but the explicit guard keeps intent
+      // obvious here and protects against future contract changes.
+      if (errorTarget) {
+        setError(errorTarget);
+        return;
+      }
 
       if (target) {
         // redo the to addresses
@@ -148,11 +156,6 @@ const AbDetail: React.FunctionComponent<AbDetailProps> = ({
             setAddress(tgt.address);
           }
         });
-      }
-      if (errorTarget) {
-        // Show the error message as a toast
-        setError(errorTarget);
-        //return;
       }
     } else {
       setAddress(addr.replace(/[ \t\n\r]+/g, '')); // Remove spaces

--- a/components/Receive/components/VerifyAddress.tsx
+++ b/components/Receive/components/VerifyAddress.tsx
@@ -82,7 +82,15 @@ const VerifyAddress: React.FunctionComponent<VerifyAddressProps> = ({
       addr.toLowerCase().includes(':')
     ) {
       const { error, target } = await parseZcashURI(addr, translate, server);
-      //console.log(targets);
+
+      // Audit Issue H — surface the parser error and abort before any
+      // address-state mutation. parseZcashURI returns an empty target
+      // when error is non-empty, but the explicit guard keeps intent
+      // obvious here and protects against future contract changes.
+      if (error) {
+        addLastSnackbar(error);
+        return;
+      }
 
       if (target) {
         // redo the to addresses
@@ -91,11 +99,6 @@ const VerifyAddress: React.FunctionComponent<VerifyAddressProps> = ({
             setAddress(tgt.address);
           }
         });
-      }
-      if (error) {
-        // Show the error message as a toast
-        addLastSnackbar(error);
-        //return;
       }
     } else {
       setAddress(addr.replace(/[ \t\n\r]+/g, '')); // Remove spaces

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -606,6 +606,15 @@ const Send: React.FunctionComponent<SendProps> = ({
           server,
         );
 
+        // Audit Issue H — surface the parser error and abort before any
+        // Send-state mutation. parseZcashURI now returns an empty target
+        // when error is non-empty, but the explicit guard keeps intent
+        // obvious here and protects against future contract changes.
+        if (error) {
+          addLastSnackbar(error);
+          return;
+        }
+
         if (target) {
           // redo the to addresses
           [target].forEach(tgt => {
@@ -621,10 +630,6 @@ const Send: React.FunctionComponent<SendProps> = ({
               setMemoText(tgt.memoString);
             }
           });
-        }
-        if (error) {
-          // Show the error message as a toast
-          addLastSnackbar(error);
         }
       } else {
         setAddressText(addressPar.replace(/[ \t\n\r]+/g, '')); // Remove spaces
@@ -2173,23 +2178,22 @@ const Send: React.FunctionComponent<SendProps> = ({
                         setMemoText('');
                         updateToField(null, null, null, '', false);
                       }
-                      // calculating for Privacy Level
-                      let parseAddressInfoJSON: RPCParseAddressType;
-                      const result: string = await parseAddress(addressText);
-                      if (result) {
-                        if (
-                          result.toLowerCase().startsWith(GlobalConst.error)
-                        ) {
-                          parseAddressInfoJSON = {} as RPCParseAddressType;
-                        } else {
-                          try {
-                            parseAddressInfoJSON = await JSON.parse(result);
-                          } catch (e) {
-                            parseAddressInfoJSON = {} as RPCParseAddressType;
-                          }
-                        }
-                      } else {
-                        parseAddressInfoJSON = {} as RPCParseAddressType;
+                      // Prefetch the parsed address for the Confirm screen
+                      // so its Privacy Level badge renders without waiting on
+                      // an RPC round-trip there. The address itself was
+                      // already validated upstream — any failure here (RPC
+                      // error string, non-JSON output, transient network)
+                      // degrades gracefully to a '-' badge in Confirm.tsx;
+                      // the validated address string is what actually drives
+                      // the transaction, so no Send state is corrupted.
+                      let parseAddressInfoJSON: RPCParseAddressType =
+                        {} as RPCParseAddressType;
+                      try {
+                        parseAddressInfoJSON = JSON.parse(
+                          await parseAddress(addressText),
+                        );
+                      } catch (_) {
+                        // best-effort prefetch; fall through to {}
                       }
                       setConfirmModalShow(parseAddressInfoJSON);
                       Keyboard.dismiss();


### PR DESCRIPTION
- `parseZcashURI` now returns a fresh empty `ZcashURITargetClass` whenever the accumulated `errors` array is non-empty. The path-as-address branch (`t.address = address` before `isValidAddress`) and the query-string `address` branch (`target.address = value` regardless of validation) used to ship a populated address alongside a non-empty error string. Now `error` and `target` are mutually exclusive — added a function-header comment documenting the new contract.
- `LoadedApp.readUrl` and `Send.updateToField` snackbar the parser error and `return` before any state mutation, instead of the prior `if (target) { mutate } if (error) { snackbar }` order. Belt-and-suspenders against the parser contract changing in the future.
- Same guard applied to two extra `parseZcashURI` callers the audit did not cite but had identical vulnerable shape: `VerifyAddress.updateAddress` (Receive verify-address flow) and `AbDetail.updateAddress` (address book entry edit).
