### PR TITLE
LA Audit - Issue A: Serialized Wallet Exports Are Logged on Save Failure (left overs...)

### DIFF
--- a/ios/RPCModule.swift
+++ b/ios/RPCModule.swift
@@ -434,7 +434,9 @@ class RPCModule: NSObject {
           resolve("true")
         }
       } else {
-        NSLog("Error: [Native] Couldn't save the wallet backup. The Encoded content is incorrect: \(backupEncodedData)")
+        // Audit Issue A — redact the payload. Mirrors the saveExistingWallet
+        // path at L240: log only the size, never the encoded wallet bytes.
+        NSLog("Error: [Native] Couldn't save the wallet backup. The Encoded content is incorrect. Size: \(backupEncodedData.count)")
         DispatchQueue.main.async {
           resolve("false")
         }


### PR DESCRIPTION
- `restoreExistingWalletBackup` no longer logs the raw `backupEncodedData` when the backup file fails base64 validation. Replaced with the size-only redaction already used in `saveWalletInternal` at L240. The base64 bytes are recovery-grade material — even on a corrupt-backup branch they should never reach `logcat`/Console.app.
- The remaining `walletEncodedString` log at L248 was left untouched because it only fires when the Rust side returned an `"error:"`-prefixed message (i.e., the string is a diagnostic error, not wallet bytes).
