### PR TITLE
LA Audit - Issue P: Wallet File May Be Lost If Application Crashes or Write Fails

### DIFF
--- a/android/app/src/main/java/org/ZingoLabs/Zingo/Constants.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/Constants.kt
@@ -4,6 +4,10 @@ enum class Constants(val value: String) {
     // wallet files
     WalletFileName("wallet.dat"),
     WalletBackupFileName("wallet.backup.dat"),
+    // Marker file for Audit Issue P (b) — only present mid-swap during
+    // restoreExistingWalletBackup. Its existence at app startup signals
+    // an interrupted swap that must be completed.
+    WalletTempSwapFileName("wallet.swap.tmp"),
 
     BackgroundFileName("background.json"),
     ErrorPrefix("error"),

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
@@ -184,15 +184,72 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
         }
     }
 
+    // Audit Issue P (b) — wallet ↔ backup swap recovery.
+    //
+    // `restoreExistingWalletBackup` does its swap as:
+    //   (1) write temp(originalMain)   — preserves the wallet that would
+    //                                    otherwise only live in memory
+    //   (2) write main(originalBackup)
+    //   (3) write backup(originalMain)
+    //   (4) delete temp
+    // Jetpack Security `EncryptedFile` binds its keyset to the file path,
+    // so the iOS atomic-rename pattern doesn't apply on Android: we need
+    // to re-encrypt at each new path and recover by content comparison.
+    //
+    // Possible interrupted states (temp exists with originalMain):
+    //   between (1)–(2): main == temp  → write main(backup), write backup(temp)
+    //   between (2)–(3): main != temp AND backup != temp → write backup(temp)
+    //   between (3)–(4): main != temp AND backup == temp → nothing to write
+    // Idempotent — no-op when no temp file is present.
+    fun completePendingSwap() {
+        val tempFile = java.io.File(applicationContext.filesDir, WalletTempSwapFileName.value)
+        if (!tempFile.exists()) return
+        try {
+            val tempContent = readFileAsB64(WalletTempSwapFileName.value)
+            if (fileExists(WalletFileName.value)) {
+                val mainContent = readFileAsB64(WalletFileName.value)
+                if (mainContent == tempContent) {
+                    // (1)–(2) window: main not yet overwritten.
+                    if (fileExists(WalletBackupFileName.value)) {
+                        val backupContent = readFileAsB64(WalletBackupFileName.value)
+                        writeEncryptedFile(WalletFileName.value, backupContent)
+                    }
+                    writeEncryptedFile(WalletBackupFileName.value, tempContent)
+                } else {
+                    // (2)–(3) or post-(3) window: main already holds the new content.
+                    val backupExists = fileExists(WalletBackupFileName.value)
+                    val backupContent = if (backupExists) readFileAsB64(WalletBackupFileName.value) else null
+                    if (backupContent != tempContent) {
+                        // (2)–(3) window or backup missing — write the lost content.
+                        writeEncryptedFile(WalletBackupFileName.value, tempContent)
+                    }
+                    // else: post-(3), backup already correct.
+                }
+            } else {
+                // Main missing — restore from temp.
+                writeEncryptedFile(WalletFileName.value, tempContent)
+            }
+            deleteFile(WalletTempSwapFileName.value)
+            Log.i("MAIN", "[Native] completePendingSwap: interrupted swap recovered")
+        } catch (e: Exception) {
+            // Leave temp in place for diagnosis / the next attempt — deleting
+            // it here would lose the only copy of the original main wallet
+            // if we couldn't write it back into position.
+            Log.e("MAIN", "Error: [Native] completePendingSwap failed: $e", e)
+        }
+    }
+
     @ReactMethod
     fun walletExists(promise: Promise) {
         // Check if a wallet already exists
+        completePendingSwap()
         promise.resolve(fileExists(WalletFileName.value))
     }
 
     @ReactMethod
     fun walletBackupExists(promise: Promise) {
         // Check if a wallet backup already exists
+        completePendingSwap()
         promise.resolve(fileExists(WalletBackupFileName.value))
     }
 
@@ -366,10 +423,22 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
         try {
             val backup = readFileAsB64(WalletBackupFileName.value)
             if (fileExists(WalletFileName.value)) {
-                // Both files exist: swap wallet ↔ backup
+                // Audit Issue P (b) — durable swap via temp file. The original
+                // main wallet only lives in memory while we overwrite main
+                // with backup; a crash before step (3) would lose it. By
+                // writing it to temp FIRST (step 1), any later crash leaves a
+                // recoverable on-disk copy that `completePendingSwap` can
+                // restore on the next launch.
+                //
+                // Belt-and-braces: recover any orphan temp from a prior crash
+                // before starting a new swap — deleting the temp blindly
+                // would destroy the only copy of that crash's original main.
+                completePendingSwap()
                 val wallet = readFileAsB64(WalletFileName.value)
-                writeEncryptedFile(WalletFileName.value, backup)
-                writeEncryptedFile(WalletBackupFileName.value, wallet)
+                writeEncryptedFile(WalletTempSwapFileName.value, wallet)   // (1) temp = original main
+                writeEncryptedFile(WalletFileName.value, backup)            // (2) main = backup
+                writeEncryptedFile(WalletBackupFileName.value, wallet)      // (3) backup = original main
+                deleteFile(WalletTempSwapFileName.value)                    // (4) cleanup
             } else {
                 // No wallet exists: restore backup as wallet and delete backup
                 writeEncryptedFile(WalletFileName.value, backup)

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
@@ -184,6 +184,81 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
         }
     }
 
+    // Audit Issue P (a) — durable wrapper around writeEncryptedFile.
+    //
+    // The raw `writeEncryptedFile` deletes the target file before writing
+    // (forced by EncryptedFile.openFileOutput which won't overwrite). A
+    // crash between the delete and the write leaves the user with no
+    // file at the target path — the entire wallet is lost.
+    //
+    // This wrapper preserves a copy of the previous content at
+    // "$fileName.write.tmp" (own keyset, written via a separate
+    // writeEncryptedFile call) BEFORE the destructive delete. If a crash
+    // lands in the racy window of the inner write, `completePendingWrite`
+    // at the next launch detects the temp and restores the original.
+    //
+    // Cost: one extra read + one extra write per save (≈3× I/O vs the
+    // raw call). Saves happen on sync milestones, not on the hot path,
+    // so the cost is acceptable. iOS doesn't need this — its `writeFile`
+    // uses `String.write(toFile: atomically: true)` which is OS-atomic.
+    private fun writeEncryptedFileDurably(fileName: String, content: String) {
+        val tempName = "$fileName.write.tmp"
+        if (fileExists(fileName)) {
+            try {
+                val previous = readFileAsB64(fileName)
+                writeEncryptedFile(tempName, previous)
+            } catch (e: Exception) {
+                // Original is unreadable already — saving new content over
+                // it can't make things worse. Proceed without temp protection
+                // for this single write.
+                Log.w("MAIN", "[$fileName] could not stash original to temp; durable write degraded to raw: $e")
+            }
+        }
+        writeEncryptedFile(fileName, content)
+        // Best-effort cleanup. If we crash before reaching here,
+        // completePendingWrite will see the orphan temp and clean it up
+        // (the target file is now valid).
+        try {
+            File(applicationContext.filesDir, tempName).delete()
+        } catch (e: Exception) {
+            Log.w("MAIN", "[$tempName] orphan temp cleanup failed: $e")
+        }
+    }
+
+    // Audit Issue P (a) — durable-write recovery.
+    //
+    // If `writeEncryptedFileDurably` crashed between the inner delete and
+    // the inner write, the target file is missing and a temp file with
+    // the original content sits at "$fileName.write.tmp". Restore from
+    // the temp. If the target file is already valid, the temp is just a
+    // post-write cleanup orphan and gets deleted.
+    //
+    // Idempotent — no-op when no temp files are present.
+    fun completePendingWrite() {
+        for (fileName in listOf(WalletFileName.value, WalletBackupFileName.value)) {
+            val tempName = "$fileName.write.tmp"
+            if (!fileExists(tempName)) continue
+            try {
+                val targetReadable = fileExists(fileName) && try {
+                    readFileAsB64(fileName)
+                    true
+                } catch (_: Exception) {
+                    false
+                }
+                if (!targetReadable) {
+                    // Crash during the inner write — restore original from temp.
+                    val tempContent = readFileAsB64(tempName)
+                    writeEncryptedFile(fileName, tempContent)
+                    Log.i("MAIN", "[Native] completePendingWrite: restored $fileName from $tempName")
+                }
+                deleteFile(tempName)
+            } catch (e: Exception) {
+                Log.e("MAIN", "Error: [Native] completePendingWrite for $fileName failed: $e", e)
+                // Leave temp in place for diagnosis / next attempt.
+            }
+        }
+    }
+
     // Audit Issue P (b) — wallet ↔ backup swap recovery.
     //
     // `restoreExistingWalletBackup` does its swap as:
@@ -241,14 +316,19 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
 
     @ReactMethod
     fun walletExists(promise: Promise) {
-        // Check if a wallet already exists
+        // Check if a wallet already exists.
+        // Write recovery runs first: a half-written save can leave main
+        // missing, which would make a pending swap unable to read main.
+        completePendingWrite()
         completePendingSwap()
         promise.resolve(fileExists(WalletFileName.value))
     }
 
     @ReactMethod
     fun walletBackupExists(promise: Promise) {
-        // Check if a wallet backup already exists
+        // Check if a wallet backup already exists. See walletExists for
+        // why write recovery runs before swap recovery.
+        completePendingWrite()
         completePendingSwap()
         promise.resolve(fileExists(WalletBackupFileName.value))
     }
@@ -299,7 +379,7 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
             }
 
             Log.i("MAIN", "[Native] file size: ${b64encoded.length} chars (Base64)")
-            writeEncryptedFile(WalletFileName.value, b64encoded)
+            writeEncryptedFileDurably(WalletFileName.value, b64encoded)
             return true
         } catch (e: Exception) {
             Log.e("MAIN", "Error: [Native] Unexpected error. Couldn't save the wallet. $e")
@@ -310,7 +390,7 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
     private fun saveWalletBackupFile(): Boolean {
         return try {
             val content = readFileAsB64(WalletFileName.value)
-            writeEncryptedFile(WalletBackupFileName.value, content)
+            writeEncryptedFileDurably(WalletBackupFileName.value, content)
             true
         } catch (e: Exception) {
             Log.e("MAIN", "Error: [Native] Couldn't save the wallet backup: $e")

--- a/ios/Constants.swift
+++ b/ios/Constants.swift
@@ -11,6 +11,10 @@ enum Constants: String {
     // wallet files
     case WalletFileName = "wallet.dat.txt"
     case WalletBackupFileName = "wallet.backup.dat.txt"
+    // Marker file for Audit Issue P (b) — only present mid-swap during
+    // restoreExistingWalletBackup. Its existence at app startup signals
+    // an interrupted swap that must be completed.
+    case WalletTempSwapFileName = "wallet.swap.tmp"
 
     case BackgroundFileName = "background.json"
     case ErrorPrefix = "error"

--- a/ios/RPCModule.swift
+++ b/ios/RPCModule.swift
@@ -96,9 +96,47 @@ class RPCModule: NSObject {
   func deleteFile(_ fileName: String) throws {
     try FileManager.default.removeItem(atPath: getFileName(fileName))
   }
+
+  // Audit Issue P (b) — wallet ↔ backup swap recovery.
+  //
+  // `restoreExistingWalletBackup` does its swap as three atomic renames:
+  //   (1) main → temp
+  //   (2) backup → main
+  //   (3) temp → backup
+  // A crash between (1)–(2) or (2)–(3) leaves the temp file on disk.
+  // Calling this helper at startup detects that and finishes the swap.
+  //
+  // Possible interrupted states (temp exists, by construction):
+  //   between (1)–(2): main does NOT exist, backup exists → complete (2) then (3)
+  //   between (2)–(3): main exists,         backup does NOT → complete (3)
+  // Both branches end at the intended final state. Idempotent — when no
+  // temp file is present this is a near-zero-cost no-op.
+  func completePendingSwap() {
+    let fm = FileManager.default
+    guard let tempPath = try? getFileName(Constants.WalletTempSwapFileName.rawValue),
+          fm.fileExists(atPath: tempPath) else { return }
+    guard let mainPath = try? getFileName(Constants.WalletFileName.rawValue),
+          let backupPath = try? getFileName(Constants.WalletBackupFileName.rawValue) else {
+      NSLog("Error: [Native] completePendingSwap: could not resolve wallet paths")
+      return
+    }
+    do {
+      if fm.fileExists(atPath: backupPath) {
+        // Crash between (1) and (2): backup still in original position.
+        try fm.moveItem(atPath: backupPath, toPath: mainPath)
+      }
+      // Crash between (2) and (3): main now holds the former backup;
+      // only (3) is left.
+      try fm.moveItem(atPath: tempPath, toPath: backupPath)
+      NSLog("[Native] completePendingSwap: interrupted swap recovered")
+    } catch {
+      NSLog("Error: [Native] completePendingSwap failed: \(error.localizedDescription)")
+    }
+  }
   
   @objc(walletExists:reject:)
   func walletExists(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    completePendingSwap()
     do {
       let result = try fileExists(Constants.WalletFileName.rawValue)
       DispatchQueue.main.async {
@@ -114,6 +152,7 @@ class RPCModule: NSObject {
 
   @objc(walletBackupExists:reject:)
   func walletBackupExists(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    completePendingSwap()
     do {
       let result = try fileExists(Constants.WalletBackupFileName.rawValue)
       DispatchQueue.main.async {
@@ -421,10 +460,27 @@ class RPCModule: NSObject {
       // check if the content is correct. Stored Encoded.
       if isValidBase64(backupEncodedData) {
         if try fileExists(Constants.WalletFileName.rawValue) == "true" {
-          // Both files exist: swap wallet ↔ backup
-          let walletEncodedData = try self.readWalletUtf8String()
-          try self.saveWalletFile(backupEncodedData)
-          try self.saveWalletBackupFile(walletEncodedData)
+          // Audit Issue P (b) — atomic swap via three renames. APFS
+          // rename is atomic AND preserves the file's protection class
+          // and isExcludedFromBackup attribute, so this is strictly
+          // safer than the previous read-into-memory + two writes
+          // pattern, which lost the original main wallet on a crash
+          // between writes. `completePendingSwap` (called early on
+          // walletExists/walletBackupExists) finishes the swap if a
+          // crash interrupts these three steps.
+          // Belt-and-braces: if a previous swap left a temp behind and
+          // `completePendingSwap` was never called (e.g. JS jumped
+          // straight into restore without checking walletExists first),
+          // recover it before starting a new swap — deleting the temp
+          // would lose the orphaned original-main content.
+          self.completePendingSwap()
+          let fm = FileManager.default
+          let mainPath   = try getFileName(Constants.WalletFileName.rawValue)
+          let backupPath = try getFileName(Constants.WalletBackupFileName.rawValue)
+          let tempPath   = try getFileName(Constants.WalletTempSwapFileName.rawValue)
+          try fm.moveItem(atPath: mainPath,   toPath: tempPath)   // (1) main → temp
+          try fm.moveItem(atPath: backupPath, toPath: mainPath)   // (2) backup → main
+          try fm.moveItem(atPath: tempPath,   toPath: backupPath) // (3) temp → backup
         } else {
           // No wallet exists: restore backup as wallet and delete backup
           try self.saveWalletFile(backupEncodedData)


### PR DESCRIPTION
- `restoreExistingWalletBackup` on iOS now performs the wallet ↔ backup swap as three atomic APFS renames (main → temp, backup → main, temp → backup) instead of the previous read-into-memory + two-writes pattern. A crash between writes used to leave the original main wallet only in memory and overwrite both files with the backup contents; the rename sequence preserves the original main on disk at every step.
- Added `completePendingSwap()` on iOS, called at the top of `walletExists` / `walletBackupExists` and again belt-and-braces at the top of the swap path. If a previous run crashed mid-swap the temp file is still on disk; the helper detects which of the two interrupt windows occurred (backup-still-in-place vs main-already-swapped) and finishes the remaining rename(s). Idempotent — no-op when no temp file is present.
- New `WalletTempSwapFileName = "wallet.swap.tmp"` constant in `Constants.swift` so the marker file has a stable, audit-traceable name.
- Android side: same audit issue, different constraint. Jetpack Security `EncryptedFile` keys its keyset by file path, so the iOS rename pattern would invalidate decryption. Implemented the equivalent with a four-step durable write: `(1) write temp = original main`, `(2) write main = backup`, `(3) write backup = original main`, `(4) delete temp`. The original main is on disk from step (1) onward, so any crash after step (1) is recoverable.
- `completePendingSwap()` on Android recovers by content comparison rather than rename: it reads the temp file and uses `mainContent == tempContent` / `backupContent == tempContent` to identify which write window the crash interrupted, then writes only the missing piece(s). On failure the helper deliberately does NOT delete the temp — that would destroy the only on-disk copy of the original main wallet.
- New `WalletTempSwapFileName("wallet.swap.tmp")` constant in `Constants.kt`.
