### PR TITLE
fix: fail Android test scripts fast on impossible emulation requests

### DIFF
--- a/scripts/android_integration_tests.sh
+++ b/scripts/android_integration_tests.sh
@@ -5,7 +5,15 @@ set_abi=false
 set_test_name=false
 set_api_level=false
 set_api_target=false
-intel_host_os=true
+# The emulator can only virtualize its host's own architecture family, so the
+# host determines whether ABIs map to x86 or ARM system images. '-A' remains
+# as an explicit override.
+host_arch=$(uname -m)
+if [ "${host_arch}" = "aarch64" ] || [ "${host_arch}" = "arm64" ]; then
+    intel_host_os=false
+else
+    intel_host_os=true
+fi
 create_snapshot=false
 test_name_default="ExecuteVersionFromSeed"
 valid_api_levels=("26" "27" "28" "29" "30" "31" "32" "33" "34" "35" "36")
@@ -111,7 +119,7 @@ while getopts 'a:Al:e:t:sx:h' OPTION; do
             echo -e "      \t\t  'arm64-v8a' - default system image: API 30 google_apis_playstore x86_64"
             echo -e "      \t\t  'armeabi-v7a' - default system image: API 30 google_apis_playstore x86"
             echo -e "\n  -A\t\tSets default system image of arm abis to arm instead of x86 (optional)"
-            echo -e "      \t\t  Use this option if the host OS is arm"
+            echo -e "      \t\t  ARM hosts are auto-detected; this flag forces the ARM mapping"
             echo -e "\n  -e\t\tSelect test name or test suite (optional)"
             echo -e "      \t\t  Default: ExecuteVersionFromSeed"
             echo -e "\n  -l\t\tSelect API level (optional)"
@@ -189,6 +197,24 @@ case "$abi" in
         echo "Error: Invalid ABI" >&2
         echo "Try '$(basename $0) -h' for more information." >&2
         exit 1
+        ;;
+esac
+
+# Fail fast on an impossible emulation request instead of installing an image
+# the emulator cannot boot and hanging until the launch timeout.
+case "${arch}" in
+    arm64-v8a)
+        if [ "${host_arch}" != "aarch64" ] && [ "${host_arch}" != "arm64" ]; then
+            echo "Error: ABI ${abi} was mapped to an ${arch} system image, which this host (${host_arch}) cannot emulate." >&2
+            echo "On Intel hosts, omit '-A': ARM ABIs run on x86 images through ARM translation." >&2
+            exit 1
+        fi
+        ;;
+    x86|x86_64)
+        if [ "${host_arch}" != "x86_64" ]; then
+            echo "Error: ABI ${abi} was mapped to an ${arch} system image, which this host (${host_arch}) cannot emulate." >&2
+            exit 1
+        fi
         ;;
 esac
 

--- a/scripts/e2e_tests.sh
+++ b/scripts/e2e_tests.sh
@@ -47,10 +47,15 @@ function wait_for() {
     fi
 }
 
-while getopts 'a:e:sx:h' OPTION; do
+while getopts 'a:Ae:sx:h' OPTION; do
     case "$OPTION" in
         a)
             arch="$OPTARG"
+            ;;
+        A)
+            # Accepted for compatibility with the Rust test harness, which
+            # passes -A on ARM hosts; the host architecture is now detected
+            # automatically.
             ;;
         e)
             test_name="$OPTARG"

--- a/scripts/e2e_tests.sh
+++ b/scripts/e2e_tests.sh
@@ -67,6 +67,8 @@ while getopts 'a:e:sx:h' OPTION; do
         h)
             echo -e "\nRun end-to-end tests. Requires Android SDK Command-line Tools."
             echo -e "\n  -a\t\tSet ABI/architecture (optional, default: x86_64)"
+            echo -e "      \t\t  armeabi-v7a runs on an arm64-v8a emulator image"
+            echo -e "      \t\t  ARM images require an ARM host, x86 images an x86_64 host"
             echo -e "\n  -e\t\tSelect test name"
             echo -e "\n  -x\t\tSet timeout in seconds for emulator launch and AVD boot-up (optional)"
             echo -e "      \t\t  Default: 1800"
@@ -78,11 +80,38 @@ while getopts 'a:e:sx:h' OPTION; do
             ;;
     esac
 done
-if [[ $set_test_name == false ]]; then 
+if [[ $set_test_name == false ]]; then
     echo "Error: Test not specified" >&2
     echo "Try '$(basename $0) -h' for more information." >&2
     exit 1
 fi
+
+# Google publishes no armeabi-v7a system images for this API level, so 32-bit
+# ARM app code runs on a 64-bit ARM image, as it does in CI.
+if [ "${arch}" = "armeabi-v7a" ]; then
+    avd_arch="arm64-v8a"
+else
+    avd_arch="${arch}"
+fi
+
+# The emulator can only virtualize its host's own architecture family.
+host_arch=$(uname -m)
+case "${avd_arch}" in
+    arm64-v8a)
+        if [ "${host_arch}" != "aarch64" ] && [ "${host_arch}" != "arm64" ]; then
+            echo "Error: ABI ${arch} needs an ${avd_arch} AVD, which this host (${host_arch}) cannot emulate." >&2
+            echo "ARM end-to-end tests run in CI; on this host use '-a x86_64' or '-a x86'." >&2
+            exit 1
+        fi
+        ;;
+    x86|x86_64)
+        if [ "${host_arch}" != "x86_64" ]; then
+            echo "Error: ABI ${arch} needs an ${avd_arch} AVD, which this host (${host_arch}) cannot emulate." >&2
+            echo "On this host use '-a arm64-v8a' or '-a armeabi-v7a'." >&2
+            exit 1
+        fi
+        ;;
+esac
 
 # Setup working directory
 cd $(git rev-parse --show-toplevel)
@@ -100,8 +129,8 @@ echo "Installing latest emulator..."
 sdkmanager --install emulator --channel=0
 
 echo "Installing system image..."
-avd_name="${device}_api-${api_level}_${api_target}_${arch}"
-sdk="system-images;android-${api_level};${api_target};${arch}"
+avd_name="${device}_api-${api_level}_${api_target}_${avd_arch}"
+sdk="system-images;android-${api_level};${api_target};${avd_arch}"
 sdkmanager --install "${sdk}"
 echo y | sdkmanager --licenses
 


### PR DESCRIPTION
Both Android test scripts could be asked to emulate an architecture the host cannot run. `e2e_tests.sh -a armeabi-v7a` requested `system-images;android-30;google_apis_playstore;armeabi-v7a`, a package that has never existed (Google publishes no 32-bit ARM system images at this API level), and died inside sdkmanager after a yarn install and several downloads. `android_integration_tests.sh` assumed an Intel host unless `-A` was passed, so a wrong flag or host installed an unbootable image and hung until the 1800-second launch timeout.

This change makes both scripts fail immediately, before any install work, with a diagnostic that names the ABI, the mapped image architecture, and the host. `e2e_tests.sh` now maps armeabi-v7a to an arm64-v8a emulator image, as CI already does in `android-ubuntu-integration-test-ci.yaml`. `android_integration_tests.sh` now detects the host architecture with `uname -m` instead of assuming Intel; `-A` remains as an explicit override, and on Intel hosts ARM ABIs continue to run on x86 images through ARM translation.

Two compatibility fixes ride along. The executable bit of `android_integration_tests.sh` is restored, without which the Rust test harness's `./scripts/android_integration_tests.sh` invocation has always failed with exit code 126. And `e2e_tests.sh` now accepts `-A` as a no-op, because `zingomobile_utils::android_e2e_test` passes it on ARM hosts and the script's getopts used to reject the whole invocation.

Verified on an x86_64 Linux host: `bash -n` passes on both scripts, shellcheck reports nothing on the changed lines, ARM requests exit 1 immediately with the new diagnostic, and the default armeabi-v7a mapping proceeds past the architecture check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)