### PR TITLE
fix: decode typed rejections and restart sync only for a broken client

### DIFF
--- a/__tests__/walletBackend.offlineRejection.unit.test.ts
+++ b/__tests__/walletBackend.offlineRejection.unit.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Offline must be survivable. Every routed getter rejects typed when the
+ * device has no network, and DataService's polling methods run on a
+ * five-second cadence — so a rejection that merely means "offline" must
+ * not tear down and reconfigure the sync coordinator on every tick, and
+ * the local value-transfer history must still render without a server.
+ *
+ * These tests pin the decoding contract: DataService decodes the
+ * ZingolibError variant from a bridge rejection and restarts sync only
+ * for the variants that signal a broken client (a poisoned lock, a
+ * missing client, a panic), never for the transient read family.
+ */
+jest.mock('../app/RPCModule', () =>
+  require('../__mocks__/rpcModuleProxy').rpcModuleProxyMock(),
+);
+
+import RPCModule from '../app/RPCModule';
+import { DataService } from '../app/walletBackend/modules/DataService';
+import {
+  ZingolibErrorVariant,
+  decodeZingolibErrorVariant,
+} from '../app/walletBackend/utils/zingolibRejection';
+
+const bridge = RPCModule as unknown as Record<string, jest.Mock>;
+
+// The two shapes a typed ZingolibError rejection wears by the time React
+// Native hands it to JS. Android surfaces the Rust Display rendering
+// verbatim as the exception message; iOS surfaces String(describing:) of
+// the Swift enum case wrapping that same rendering. The code property
+// carries the FFI's name on both platforms.
+function androidRejection(ffi: string, display: string): Error {
+  return Object.assign(new Error(display), { code: ffi });
+}
+function iosRejection(ffi: string, variant: string, display: string): Error {
+  return Object.assign(new Error(`${variant}(message: "${display}")`), {
+    code: ffi,
+  });
+}
+
+// The Read variant's Display for a failed server dial — the rejection an
+// offline device produces on every polling tick.
+const offlineDisplay = 'Error: read: transport error: connection refused';
+
+function makeDataService() {
+  const onError = jest.fn();
+  const onSyncError = jest.fn();
+  const onValueTransfersChanged = jest.fn();
+  const config = {
+    onError,
+    onValueTransfersChanged,
+    onBalanceChanged: jest.fn(),
+    server: { uri: 'https://server.example' },
+  } as unknown as ConstructorParameters<typeof DataService>[0];
+  const dataService = new DataService(config);
+  dataService.onSyncError = onSyncError;
+  return { dataService, onError, onSyncError, onValueTransfersChanged };
+}
+
+describe('an offline rejection is transient: no sync-coordinator restart', () => {
+  it.each([
+    [
+      'Android shape',
+      androidRejection('get_latest_block_server', offlineDisplay),
+    ],
+    [
+      'iOS shape',
+      iosRejection('get_latest_block_server', 'Read', offlineDisplay),
+    ],
+  ])('%s', async (_shape, rejection) => {
+    const { dataService, onSyncError, onValueTransfersChanged } =
+      makeDataService();
+    bridge.getLatestBlockServerInfo.mockRejectedValueOnce(rejection);
+    bridge.getValueTransfersList.mockResolvedValueOnce(
+      '{"value_transfers":[]}',
+    );
+
+    await dataService.fetchTandZandOValueTransfers();
+
+    // Both halves of the contract: the coordinator is left alone, and the
+    // local history — a wallet read that needs no server — still renders.
+    expect(onSyncError).not.toHaveBeenCalled();
+    expect(onValueTransfersChanged).toHaveBeenCalledWith([], 0);
+  });
+});
+
+describe('a broken-client rejection still restarts the sync coordinator', () => {
+  it.each([
+    [
+      'a poisoned lock, Android shape',
+      androidRejection('get_balance', 'Error: Lightclient lock poisoned'),
+    ],
+    [
+      'a missing client, iOS shape',
+      iosRejection(
+        'get_balance',
+        'LightclientNotInitialized',
+        'Error: Lightclient is not initialized',
+      ),
+    ],
+    // A rejection no decoder recognizes keeps the conservative default.
+    ['an undecodable rejection', new Error('bridge exploded')],
+  ])('%s', async (_case, rejection) => {
+    const { dataService, onError, onSyncError } = makeDataService();
+    bridge.getSpendableBalanceTotalInfo.mockRejectedValueOnce(rejection);
+
+    await dataService.fetchTotalBalance();
+
+    expect(onSyncError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining('Error'));
+  });
+});
+
+describe('the decoder recovers every variant from both platform shapes', () => {
+  // Each variant with its Rust Display rendering, verbatim from the
+  // #[error(...)] attributes in rust/lib/src/lib.rs.
+  const variants: Array<[ZingolibErrorVariant, string]> = [
+    [
+      ZingolibErrorVariant.LightclientNotInitialized,
+      'Error: Lightclient is not initialized',
+    ],
+    [
+      ZingolibErrorVariant.LightclientLockPoisoned,
+      'Error: Lightclient lock poisoned',
+    ],
+    [ZingolibErrorVariant.Panic, 'Error: panic: boom'],
+    [ZingolibErrorVariant.Save, 'Error: saving wallet: disk full'],
+    [ZingolibErrorVariant.Init, 'Error: initializing wallet: bad seed'],
+    [ZingolibErrorVariant.Sync, 'Error: sync: server hung up'],
+    [ZingolibErrorVariant.Rescan, 'Error: rescan: server hung up'],
+    [ZingolibErrorVariant.Read, offlineDisplay],
+    [
+      ZingolibErrorVariant.Drain,
+      'Error: draining orchard to ironwood: sync already running',
+    ],
+  ];
+
+  it.each(variants)('%s, Android shape', (variant, display) => {
+    expect(decodeZingolibErrorVariant(androidRejection('any', display))).toBe(
+      variant,
+    );
+  });
+
+  it.each(variants)('%s, iOS shape', (variant, display) => {
+    expect(
+      decodeZingolibErrorVariant(iosRejection('any', variant, display)),
+    ).toBe(variant);
+  });
+
+  it.each([
+    ['prose no variant emits', new Error('bridge exploded')],
+    ['a Swift case outside the enum', new Error('FileError(message: "gone")')],
+    ['a non-Error rejection', 42],
+  ])('%s decodes to Unknown', (_case, rejection) => {
+    expect(decodeZingolibErrorVariant(rejection)).toBe(
+      ZingolibErrorVariant.Unknown,
+    );
+  });
+});

--- a/app/walletBackend/modules/DataService.ts
+++ b/app/walletBackend/modules/DataService.ts
@@ -37,6 +37,7 @@ import { RPCWalletVersionType } from '../types/RPCWalletVersionType';
 import { WalletBackendConfig } from '../config/WalletBackendConfig';
 import { transformValueTransfer } from '../transforms/valueTransferTransform';
 import { fetchWallet } from '../utils/walletUtils';
+import { isBrokenClientRejection } from '../utils/zingolibRejection';
 
 export class DataService {
   config: WalletBackendConfig;
@@ -55,7 +56,11 @@ export class DataService {
   fetchZingolibVersionLock: boolean = false;
   getWalletSaveRequiredLock: boolean = false;
 
-  // Set by WalletBackend after SyncCoordinator is created, to restart sync on critical errors.
+  // Set by WalletBackend after SyncCoordinator is created, to restart sync
+  // on broken-client errors. Every escalation site gates on
+  // isBrokenClientRejection: a transient rejection — an offline device on
+  // the five-second polling cadence — retries on the next tick instead of
+  // tearing the coordinator down.
   onSyncError: () => Promise<void> = async () => {};
 
   constructor(config: WalletBackendConfig) {
@@ -116,7 +121,9 @@ export class DataService {
     } catch (error) {
       console.log(`Critical Error balances ${error}`);
       this.config.onError(`Error balance: ${error}`);
-      await this.onSyncError();
+      if (isBrokenClientRejection(error)) {
+        await this.onSyncError();
+      }
     } finally {
       this.fetchTotalBalanceLock = false;
     }
@@ -196,7 +203,9 @@ export class DataService {
     } catch (error) {
       console.log(`Critical Error addresses ${error}`);
       this.config.onError(`Error addresses: ${error}`);
-      await this.onSyncError();
+      if (isBrokenClientRejection(error)) {
+        await this.onSyncError();
+      }
     } finally {
       this.fetchAddressesLock = false;
     }
@@ -225,7 +234,9 @@ export class DataService {
     } catch (error) {
       console.log(`Critical Error wallet height ${error}`);
       this.config.onError(`Error wallet height: ${error}`);
-      await this.onSyncError();
+      if (isBrokenClientRejection(error)) {
+        await this.onSyncError();
+      }
     } finally {
       this.fetchWalletHeightLock = false;
     }
@@ -287,7 +298,9 @@ export class DataService {
     } catch (error) {
       console.log(`Critical Error info & server block height ${error}`);
       this.config.onError(`Error info: ${error}`);
-      await this.onSyncError();
+      if (isBrokenClientRejection(error)) {
+        await this.onSyncError();
+      }
     } finally {
       this.fetchInfoAndServerHeightLock = false;
     }
@@ -338,7 +351,9 @@ export class DataService {
     } catch (error) {
       console.log(`Critical Error wallet birthday ${error}`);
       this.config.onError(`Error wallet birthday: ${error}`);
-      await this.onSyncError();
+      if (isBrokenClientRejection(error)) {
+        await this.onSyncError();
+      }
     } finally {
       this.fetchWalletBirthdaySeedUfvkLock = false;
     }
@@ -351,9 +366,22 @@ export class DataService {
     this.fetchTandZandOValueTransfersLock = true;
     try {
       const start = Date.now();
-      const heightStr: string = await RPCModule.getLatestBlockServerInfo(
-        this.config.server.uri,
-      );
+      // The server dial rejects whenever the device is offline. The local
+      // value-transfer list must still render without a server, so a
+      // transient rejection is reported and contained here; only a
+      // broken-client rejection escapes to the owning catch below.
+      let heightStr: string = '';
+      try {
+        heightStr = await RPCModule.getLatestBlockServerInfo(
+          this.config.server.uri,
+        );
+      } catch (error) {
+        if (isBrokenClientRejection(error)) {
+          throw error;
+        }
+        console.log(`Transient Error server height ${error}`);
+        this.config.onError(`Error server height: ${error}`);
+      }
       if (Date.now() - start > 4000) {
         console.log(
           '=========================================== > server height - ',
@@ -362,8 +390,6 @@ export class DataService {
       }
       if (heightStr) {
         this.lastServerBlockHeight = Number(heightStr);
-      } else {
-        console.log('Internal Error server height');
       }
 
       const start2 = Date.now();
@@ -402,7 +428,9 @@ export class DataService {
     } catch (error) {
       console.log(`Critical Error value transfers ${error}`);
       this.config.onError(`Error value transfers: ${error}`);
-      await this.onSyncError();
+      if (isBrokenClientRejection(error)) {
+        await this.onSyncError();
+      }
     } finally {
       this.fetchTandZandOValueTransfersLock = false;
     }
@@ -447,7 +475,9 @@ export class DataService {
     } catch (error) {
       console.log(`Critical Error value transfers messages ${error}`);
       this.config.onError(`Error value transfers messages: ${error}`);
-      await this.onSyncError();
+      if (isBrokenClientRejection(error)) {
+        await this.onSyncError();
+      }
     } finally {
       this.fetchTandZandOMessagesLock = false;
     }

--- a/app/walletBackend/utils/zingolibRejection.ts
+++ b/app/walletBackend/utils/zingolibRejection.ts
@@ -1,0 +1,97 @@
+/**
+ * Decodes the ZingolibError variant from a bridge rejection.
+ *
+ * The native bridges reject with the FFI's name as the code and the
+ * typed ZingolibError as the underlying error (zingo-mobile#1151). By
+ * the time React Native surfaces the rejection to JS, the variant
+ * survives only in the message: Android carries the Rust Display
+ * rendering verbatim, and iOS carries String(describing:) of the Swift
+ * enum case wrapping that same rendering. Each variant's Display opens
+ * with a stable, mutually non-prefixing marker (rust/lib/src/lib.rs,
+ * ZingolibError), so those two renderings are the decoding contract.
+ * This decodes the one wire format a typed error crosses in — it never
+ * inspects a resolved value, so the success channel stays unclassified.
+ */
+
+export enum ZingolibErrorVariant {
+  LightclientNotInitialized = 'LightclientNotInitialized',
+  LightclientLockPoisoned = 'LightclientLockPoisoned',
+  Panic = 'Panic',
+  Save = 'Save',
+  Init = 'Init',
+  Sync = 'Sync',
+  Rescan = 'Rescan',
+  Read = 'Read',
+  Drain = 'Drain',
+  Unknown = 'Unknown',
+}
+
+type KnownVariant = Exclude<ZingolibErrorVariant, ZingolibErrorVariant.Unknown>;
+
+// Each variant's Rust Display prefix, verbatim from the #[error(...)]
+// attributes in rust/lib/src/lib.rs. The record is total over the known
+// variants, so adding a variant without its marker fails to compile.
+const displayMarker: Record<KnownVariant, string> = {
+  [ZingolibErrorVariant.LightclientNotInitialized]:
+    'Error: Lightclient is not initialized',
+  [ZingolibErrorVariant.LightclientLockPoisoned]:
+    'Error: Lightclient lock poisoned',
+  [ZingolibErrorVariant.Panic]: 'Error: panic:',
+  [ZingolibErrorVariant.Save]: 'Error: saving wallet:',
+  [ZingolibErrorVariant.Init]: 'Error: initializing wallet:',
+  [ZingolibErrorVariant.Sync]: 'Error: sync:',
+  [ZingolibErrorVariant.Rescan]: 'Error: rescan:',
+  [ZingolibErrorVariant.Read]: 'Error: read:',
+  [ZingolibErrorVariant.Drain]: 'Error: draining orchard to ironwood:',
+};
+
+export function decodeZingolibErrorVariant(
+  rejection: unknown,
+): ZingolibErrorVariant {
+  const message =
+    rejection instanceof Error
+      ? rejection.message
+      : typeof rejection === 'string'
+        ? rejection
+        : '';
+
+  // The iOS shape leads with the Swift case name: `Read(message: "...")`.
+  const swiftCase = message.match(/^([A-Za-z]+)\(message:/);
+  if (swiftCase && swiftCase[1] in displayMarker) {
+    return swiftCase[1] as ZingolibErrorVariant;
+  }
+
+  // The Android shape is the Rust Display rendering itself.
+  for (const [variant, marker] of Object.entries(displayMarker)) {
+    if (message.startsWith(marker)) {
+      return variant as ZingolibErrorVariant;
+    }
+  }
+
+  return ZingolibErrorVariant.Unknown;
+}
+
+// Whether each variant signals a broken client that restarting the sync
+// coordinator could help. The transient variants mean the client itself
+// is healthy — a server dial failed, a sync pass errored — and the next
+// polling tick retries them for free, so a restart would only add
+// teardown churn (an offline device hits one of these every five
+// seconds). Unknown keeps the conservative pre-decoding behavior. The
+// record is total over the enum, so adding a variant without deciding
+// its escalation fails to compile.
+const brokenClientVariant: Record<ZingolibErrorVariant, boolean> = {
+  [ZingolibErrorVariant.LightclientNotInitialized]: true,
+  [ZingolibErrorVariant.LightclientLockPoisoned]: true,
+  [ZingolibErrorVariant.Panic]: true,
+  [ZingolibErrorVariant.Save]: true,
+  [ZingolibErrorVariant.Init]: true,
+  [ZingolibErrorVariant.Sync]: false,
+  [ZingolibErrorVariant.Rescan]: false,
+  [ZingolibErrorVariant.Read]: false,
+  [ZingolibErrorVariant.Drain]: false,
+  [ZingolibErrorVariant.Unknown]: true,
+};
+
+export function isBrokenClientRejection(rejection: unknown): boolean {
+  return brokenClientVariant[decodeZingolibErrorVariant(rejection)];
+}


### PR DESCRIPTION
## What this changes

DataService's catch blocks escalated every rejection to `onSyncError`, which tears down and reconfigures the sync coordinator. Because the routed getters reject typed when the device is offline, an offline device paid that full teardown-and-reconfigure cycle on every five-second polling tick, and the rejection-routed server dial in `fetchTandZandOValueTransfers` also aborted the local history render, which needs no server at all. This was the remaining HIGH finding from the #1170 review.

The new `zingolibRejection` module decodes the `ZingolibError` variant from the one wire format a typed rejection crosses in: Android surfaces the Rust `Display` rendering verbatim, and iOS surfaces `String(describing:)` of the Swift case wrapping that same rendering, so the variants' mutually non-prefixing `Display` markers are the decoding contract. Two total records over the variant enum carry the policy — one maps each variant to its marker, the other decides whether it signals a broken client — so adding a variant without deciding either fails to compile. Every escalation site now restarts the coordinator only for the broken-client family (a missing client, a poisoned lock, a panic, and the conservative Unknown default); the transient read family retries on the next tick for free. The server dial in `fetchTandZandOValueTransfers` is contained separately, so the local value-transfer list still renders offline.

## Testing

The new jest suite was observed red first: an offline typed rejection in either platform shape left the coordinator alone and rendered the local history only after the fix, while a poisoned lock, a missing client, and an undecodable rejection all still restart the coordinator. The suite also pins the decoder over every variant in both platform shapes and the Unknown fallback, so a Rust-side wording change fails loudly. Verified with the full jest run (55 suites, 298 tests), `tsc --noEmit`, eslint, and prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
