### PR TITLE
test: regenerate History snapshots for the warning banner restyle

### DIFF
--- a/__tests__/__snapshots__/History.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/History.snapshot.tsx.snap
@@ -40,8 +40,8 @@ exports[`Component History - test History currency USD, privacy high & mode adva
         <View
           style={
             {
-              "backgroundColor": "#262527",
-              "borderColor": "#65491C",
+              "backgroundColor": "#1A1200",
+              "borderColor": "#3D2A00",
               "borderRadius": 10,
               "borderWidth": 1,
               "marginBottom": 10,
@@ -263,8 +263,8 @@ exports[`Component History - test History no currency, privacy normal & mode bas
         <View
           style={
             {
-              "backgroundColor": "#262527",
-              "borderColor": "#65491C",
+              "backgroundColor": "#1A1200",
+              "borderColor": "#3D2A00",
               "borderRadius": 10,
               "borderWidth": 1,
               "marginBottom": 10,


### PR DESCRIPTION
Commit 2eb2c7f3 changed the IronwoodMigrationBanner border and background colors but did not regenerate the two History snapshots that render the banner, which is the jest-test failure CI reports on #1187. The regenerated snapshots differ only in those two color values, verified by inspecting the diff before updating. With this commit the full Jest suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)