### PR TITLE
fix: ListenableFuture compile break from notifee's Guava (+ early Kotlin-compile CI)

### DIFF
--- a/.github/workflows/android-kotlin-compile.yaml
+++ b/.github/workflows/android-kotlin-compile.yaml
@@ -1,0 +1,45 @@
+name: Android Kotlin compile
+
+on:
+  workflow_call:
+
+jobs:
+  android-kotlin-compile:
+    name: Android Kotlin compile (fast)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.18.0
+          cache: yarn
+
+      - run: yarn
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # The app module compiles the UniFFI bindings from
+      # build/generated/source/uniffi/release/java. The full pipeline
+      # generates them by building the Rust natives; this job stages the
+      # checked-in copy instead, so the Kotlin compile runs in minutes and
+      # surfaces classpath breakage (for example dependency-resolution
+      # conflicts) long before the ~20-minute native builds finish.
+      - name: Stage checked-in UniFFI bindings
+        run: |
+          mkdir -p android/app/build/generated/source/uniffi/release/java/uniffi/zingo
+          cp rust/lib/src/uniffi/zingo/zingo.kt \
+            android/app/build/generated/source/uniffi/release/java/uniffi/zingo/
+
+      - name: Compile release Kotlin
+        working-directory: ./android
+        run: ./gradlew :app:compileProdReleaseKotlin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Runs from t=0 with no dependencies: catches app-module Kotlin compile
+  # breakage (e.g. classpath conflicts) in a few minutes, long before the
+  # native builds and emulator jobs report.
+  android-kotlin-compile:
+    uses: ./.github/workflows/android-kotlin-compile.yaml
+
   jest-test:
     uses: ./.github/workflows/jest-test.yaml
     secrets: inherit

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -345,6 +345,11 @@ dependencies {
 
     val workVersion = "2.10.0"
 
+    // notifee brings Guava onto the runtime classpath, which retires the
+    // standalone listenablefuture jar that androidx.work compiles against;
+    // declare Guava here so the compile classpath sees the class too.
+    implementation("com.google.guava:guava:33.3.1-android")
+
     // (Java only)
     implementation("androidx.work:work-runtime:$workVersion")
 


### PR DESCRIPTION
Fixes the Android Ubuntu Build failures on #1187 (`BackgroundSyncWorker.kt:347: Cannot access class 'ListenableFuture'`) and adds a fast CI job so app-module compile breakage reports in minutes instead of after the ~20-minute native builds.

**Root cause.** Notifee's Android project declares `implementation("com.google.guava:guava:33.3.1-android")`. Guava's metadata pulls `com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava` — a deliberately empty jar that supersedes the real `listenablefuture:1.0` which `androidx.work` depends on, on the theory that full Guava supplies the class instead. On the app's *runtime* classpath that theory holds. But AGP's consistent resolution copies the runtime verdict onto the *compile* classpath as a strict constraint, while Guava itself stays off the compile classpath (notifee declares it `implementation`, so it is invisible to consumers at compile time). `gradlew :app:dependencyInsight --dependency listenablefuture --configuration prodReleaseCompileClasspath` shows it directly:

```
com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
   Selection reasons:
      - By constraint: version resolved in configuration
        ':app:prodReleaseRuntimeClasspath' by consistent resolution
```

So at compile time the only jar that ever contained `ListenableFuture` is swapped for an empty one, and the jar that provides it at runtime is not visible. `BackgroundSyncWorker.kt:347` (`getWorkInfosForUniqueWork(...).get()`, which returns a `ListenableFuture<List<WorkInfo>>`) is simply the first pre-existing code to notice.

**The fix** (first commit) declares the provider in the app module, next to the WorkManager dependencies. Because Guava is already on the runtime classpath via notifee, the shipped APK does not change — the compiler simply gets to see the class the runtime already has. Excluding or force-pinning `listenablefuture` back to `1.0` would re-create the duplicate-class hazard the empty jar exists to prevent, so the Guava declaration is the canonical remedy.

**Verified locally by A/B compile** at `ff84fd73`: without the fix, `:app:compileProdReleaseKotlin` fails with exactly CI's two errors (2m 4s); with the one-line fix and nothing else changed, `BUILD SUCCESSFUL`.

**The early CI check** (second commit) adds a dependency-free `android-kotlin-compile` job, registered first in `ci.yaml`: it stages the checked-in UniFFI bindings (`rust/lib/src/uniffi/zingo/zingo.kt`) instead of building the Rust natives, then runs `:app:compileProdReleaseKotlin`. This PR's own pipeline exercises it, so if the fix were wrong we would know within minutes and could iterate here without waiting for the emulator jobs.

Replaces the analysis previously posted as a comment on #1187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)