### PR TITLE
build(android): prune unused dependencies and enforce with CI

### DIFF
--- a/.github/workflows/android-dependency-analysis.yaml
+++ b/.github/workflows/android-dependency-analysis.yaml
@@ -1,0 +1,46 @@
+name: Android dependency analysis
+
+on:
+  workflow_call:
+
+jobs:
+  android-dependency-analysis:
+    name: Android dependency analysis
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.18.0
+          cache: yarn
+
+      - run: yarn
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # The analysis compiles every variant's Kotlin, which needs the
+      # generated uniffi bindings on the source path. The generated file is
+      # checked in, so staging it beats running the full Rust NDK build.
+      - name: Stage uniffi bindings
+        run: |
+          for build_type in debug debugOptimized release; do
+            bindings_dir="android/app/build/generated/source/uniffi/${build_type}/java/uniffi/zingo"
+            mkdir -p "${bindings_dir}"
+            cp rust/lib/src/uniffi/zingo/zingo.kt "${bindings_dir}/zingo.kt"
+          done
+
+      # Fails on dependencies nothing compiles against (the Kotlin analog
+      # of the rust-shear job); scope and transitive advice is warn-only.
+      - name: Dependency analysis
+        working-directory: ./android
+        run: ./gradlew buildHealth

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,10 @@ jobs:
   js-depcheck:
     uses: ./.github/workflows/js-depcheck.yaml
 
+  android-dependency-analysis:
+    uses: ./.github/workflows/android-dependency-analysis.yaml
+    secrets: inherit
+
   create-timestamp:
     uses: ./.github/workflows/create-timestamp.yaml
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.android.application")
     id("com.facebook.react")
     id("org.jetbrains.kotlin.android")
+    id("com.autonomousapps.dependency-analysis")
 }
 
 /**

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -326,7 +326,6 @@ dependencies {
     androidTestImplementation("com.wix:detox:20.51.4")
     implementation("androidx.appcompat:appcompat:1.7.0")
 
-    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation(project(":react-native-device-info")) {
         exclude(group = "com.google.firebase")
         exclude(group = "com.google.android.gms")
@@ -334,8 +333,9 @@ dependencies {
     }
     implementation("com.facebook.soloader:soloader:0.10.5")
 
-    // Detox tests getAttributes() needs this
-    debugImplementation("com.google.android.material:material:1.12.0")
+    // Detox tests getAttributes() reaches this by reflection at runtime, so
+    // it is runtime-only: no source references exist for compile analysis.
+    debugRuntimeOnly("com.google.android.material:material:1.12.0")
 
     // Hermes is always enabled in RN 0.74+
     implementation("com.facebook.react:hermes-android")
@@ -343,19 +343,23 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${rootProject.extra["kotlinVersion"] as String}")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.5.0")
 
+    // Coroutines are used directly (CoroutineScope/Dispatchers in RPCModule
+    // and the JVM unit tests), so the dependency is declared here rather
+    // than borrowed from another library's dependency graph.
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+
+    // Nullability/threading annotations referenced by app sources.
+    implementation("androidx.annotation:annotation:1.8.1")
+
     val workVersion = "2.10.0"
 
-    // (Java only)
     implementation("androidx.work:work-runtime:$workVersion")
 
-    // Kotlin + coroutines
-    implementation("androidx.work:work-runtime-ktx:$workVersion")
-
-    // optional - RxJava2 support
-    implementation("androidx.work:work-rxjava2:$workVersion")
-
-    // optional - Test helpers
-    androidTestImplementation("androidx.work:work-testing:$workVersion")
+    // BackgroundSyncWorker consumes the ListenableFuture WorkManager
+    // returns; declare the class's provider instead of borrowing it from
+    // work-runtime's dependency graph.
+    implementation("com.google.guava:listenablefuture:1.0")
 
     // optional - Multiprocess support
     implementation("androidx.work:work-multiprocess:$workVersion")
@@ -363,23 +367,24 @@ dependencies {
     // google truth testing framework
     androidTestImplementation("com.google.truth:truth:1.1.3")
 
-    // JSON parsing
+    // JSON parsing: the Kotlin module plus the core/databind classes the
+    // sources use directly (ObjectMapper, JsonNode, and friends).
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.3")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.18.3")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
 
     // JVM unit tests for pure logic (no device or emulator)
     testImplementation("junit:junit:4.13.2")
 
-    // JUnit test runners
+    // JUnit test runners; the instrumented sources use the JUnit 4 API and
+    // the androidx.test runner/rules directly.
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
-
-    // Kotlin extensions for androidx.test.ext.junit
-    androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
+    androidTestImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test:rules:1.7.0")
+    androidTestImplementation("androidx.test:runner:1.7.0")
 
     // uniffi needs this
     implementation("net.java.dev.jna:jna:5.18.1@aar")
-
-    // back navigation implementation
-    implementation("androidx.activity:activity:1.10.1")
 
     // encrypted file storage
     implementation("androidx.security:security-crypto:1.0.0")

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -20,6 +20,18 @@ buildscript {
 
 plugins {
     id("com.facebook.react.rootproject")
+    // Kotlin's answer to `cargo shear`: fails the build on declared
+    // dependencies nothing compiles against. Advice beyond unused
+    // dependencies (scopes, transitives) stays warning-only.
+    id("com.autonomousapps.dependency-analysis") version "3.17.0"
+}
+
+dependencyAnalysis {
+    issues {
+        all {
+            onUnusedDependencies { severity("fail") }
+        }
+    }
 }
 
 allprojects {

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -4,6 +4,14 @@ plugins { id("com.facebook.react.settings")
 }
 extensions.configure<com.facebook.react.ReactSettingsExtension> { autolinkLibrariesFromCommand() }
 
+// The React Native settings plugin exports Guava 31 into the settings
+// classloader, below the floor the Dependency Analysis plugin requires;
+// declaring a newer Guava here shadows it for the whole build.
+buildscript {
+    repositories { mavenCentral() }
+    dependencies { classpath("com.google.guava:guava:33.4.0-jre") }
+}
+
 rootProject.name = "Zingo"
 include(":app")
 includeBuild("../node_modules/@react-native/gradle-plugin")


### PR DESCRIPTION
A [Dependency Analysis Gradle Plugin](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) audit of the app module found seven declarations nothing compiles against, and five classes of direct use served only transitively. This PR applies both halves of the advice and then makes the unused-dependency check permanent — the Kotlin analog of the `rust-shear` job, continuing the `shear_unused_dependencies` effort on the Rust side.

**Commit 1 — the pruning.** Removed as unused: `androidx.swiperefreshlayout`, `androidx.activity` (no reference in sources, manifest, or resources), `work-runtime-ktx` and `work-rxjava2` (plain `work-runtime` stays; `BackgroundSyncWorker` uses it), `work-testing`, and `junit-ktx`. The `material` dependency becomes `debugRuntimeOnly` instead of being removed: Detox `getAttributes()` reaches it purely by reflection at runtime, which is exactly why compile analysis reports it unused. Declared as direct dependencies, because app sources use them by name yet previously borrowed them from other libraries' graphs: `kotlinx-coroutines-core` (also for the JVM test source set), `jackson-core` and `jackson-databind`, `androidx.annotation`, `com.google.guava:listenablefuture` (the `ListenableFuture` that `BackgroundSyncWorker` consumes), and `junit` plus the `androidx.test` runner and rules for the instrumented sources.

**Commit 2 — the enforcement.** A new `android-dependency-analysis` CI job runs `./gradlew buildHealth` on every PR, failing only on unused dependencies (scope and transitive advice stays warning-only). The job stages the checked-in uniffi bindings into the generated-source path so it never needs the Rust NDK build, and the settings script shadows the Guava 31 the React Native settings plugin exports (below the analysis plugin's floor).

**Verification.** All variants compile, `:app:testBetaDebugUnitTest` passes, and `buildHealth` is green on the pruned set — while the enforcement demonstrably fires: during development it correctly failed on two over-declared androidTest jackson entries.

**Interaction with #1187.** The privacy-path branch adds notifee, whose Guava breaks compilation independently (see the root-cause comment there); that fix travels separately. When these merge, the `listenablefuture` declaration added here remains harmless — Guava supersedes it as the class provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)