### PR TITLE
ci: cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,13 @@ on:
     branches: [main, dev, stable]
   workflow_dispatch:
 
+# A new push to a PR supersedes the in-flight run, so cancel it and free its
+# runners; cancelling the caller run also cancels every reusable-workflow job
+# it fanned out. Mainline pushes are never cancelled.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   jest-test:
     uses: ./.github/workflows/jest-test.yaml


### PR DESCRIPTION
CI currently has no `concurrency` configuration anywhere in `.github/workflows/`, so a new push to a PR leaves the previous head's run executing to completion — PR #1187 accumulated five complete runs in one day, each occupying two ubuntu runners and a macOS runner for up to ~25 minutes. The only cancellation happening today is matrix `fail-fast` within a single run, which does not address supersession.

This adds one concurrency block to `ci.yaml`: runs group by PR number (ref for mainline pushes), and `cancel-in-progress` applies only to `pull_request` events, so pushes to `main`/`dev`/`stable` always finish. Cancelling the caller run cancels every reusable-workflow job it fanned out, so the single block covers the whole fan-out. The cron workflows (`ci-nightly`, `maestro-nightly`) are untouched.

Scope note: for `pull_request` events GitHub evaluates the workflow from the PR's merge preview, so this takes effect for PRs whose base branch contains it — immediately for PRs against `dev`, and for feature bases (e.g. `feat/ironwood`) once they next merge `dev` forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)