### PR TITLE
ci: route heavy build jobs to provisioned larger runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# Custom runner labels for actionlint's runner-label check. These are the
+# organization's provisioned GitHub-hosted larger-runner pools (org
+# Settings -> Actions -> Runners); a larger runner's configured name is its
+# runs-on label.
+self-hosted-runner:
+  labels:
+    - zingo-android-native-16
+    - zingo-android-gradle-16
+    - zingo-ios-build-12

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Build native rust & kotlin uniffi
     needs: android-check-build-cache
     if: ${{ needs.android-check-build-cache.outputs.native-cache-found != 'true' || needs.android-check-build-cache.outputs.kotlin-cache-found != 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: zingo-android-native-16
     container:
       image: zingodevops/android_builder:018
     env:

--- a/.github/workflows/android-ubuntu-integration-test-ci.yaml
+++ b/.github/workflows/android-ubuntu-integration-test-ci.yaml
@@ -115,7 +115,7 @@ jobs:
 
   android-ubuntu-build:
     name: Android Ubuntu Build
-    runs-on: ubuntu-24.04
+    runs-on: zingo-android-gradle-16
     env:
       RUSTFLAGS: -D warnings
       CACHE-KEY: ${{ inputs.cache-key }}

--- a/.github/workflows/ios-build.yaml
+++ b/.github/workflows/ios-build.yaml
@@ -45,7 +45,7 @@ jobs:
     name: Build iOS Rust xcframework
     needs: ios-check-build-cache
     if: ${{ needs.ios-check-build-cache.outputs.ios-cache-found != 'true' }}
-    runs-on: macos-15
+    runs-on: zingo-ios-build-12
     env:
       RUSTUP_HOME: ${{ github.workspace }}/.rustup
       CARGO_HOME:  ${{ github.workspace }}/.cargo

--- a/.github/workflows/ios-integration-test.yaml
+++ b/.github/workflows/ios-integration-test.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-for-testing:
-    runs-on: macos-15
+    runs-on: zingo-ios-build-12
     steps:
       - name: Xcode 16.4
         uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
Implements the larger-runner routing plan: exactly four `runs-on` changes move the expensive build jobs onto the three provisioned GitHub-hosted larger-runner pools, while cache probes, cache uploads, validation checks, AVD cache jobs, and the 18-job emulator-test fan-out stay on free standard runners.

| Job | Runner |
| --- | --- |
| `Build native rust & kotlin uniffi` (4-ABI matrix, cache-miss only) | `zingo-android-native-16` |
| `Android Ubuntu Build` (both configurations) | `zingo-android-gradle-16` |
| `Build iOS Rust xcframework` (cache-miss only) | `zingo-ios-build-12` |
| `build-for-testing` | `zingo-ios-build-12` |

A new `.github/actionlint.yaml` declares the three custom labels for actionlint's runner-label check. Validation: `git diff --check` clean; `actionlint` (v1.7.12) reports no new findings against this change — the remaining shellcheck findings are pre-existing and count-identical to base `fa2d9ae6`. No cache-key format, artifact contract, or job-dependency change; rollback is the four one-line label reverts.

**Reviewer preflight (needs org admin — not verifiable with repo credentials):**
1. The three runner names exactly match the labels above (org Settings → Actions → Runners).
2. Their runner group grants `zingolabs/zingo-mobile` access (this repo is public — selected-repositories groups must allow it explicitly).
3. Maximum concurrency: 4 native / 2 Gradle / 1 iOS.
4. The Actions spending limit permits larger-runner execution.

If a label mismatches, the affected job will sit at "Waiting for a runner" on this PR — that is the empirical form of check 1. Acceptance per the plan: on this PR's runs, the four jobs above request their new labels, everything else keeps its original label, and a superseding push cancels the prior run (PR #1193 behavior, unchanged).

**Separate follow-up, not in this PR (requires admin console):** making iOS non-blocking is a rules/branch-protection change — remove `ios-build / Check build cache`, `ios-build / Build iOS Rust xcframework`, `ios-build / Cache iOS xcframework`, and `ios-integration-test / build-for-testing` from the required-status-check list for `dev` and other protected targets, leaving the checks enabled and visible. Android required checks stay required. Per the plan, no `continue-on-error` was added to iOS jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)