### PR TITLE
ci: unpin simulator arch so build-for-testing runs on the Intel pool

### DIFF
--- a/.github/workflows/ios-integration-test.yaml
+++ b/.github/workflows/ios-integration-test.yaml
@@ -74,12 +74,16 @@ jobs:
         run: |
           set -euxo pipefail
           mkdir -p build/reports build/DerivedData
+          # The destination pins no arch: it resolves arm64 on Apple-silicon
+          # runners and x86_64 on the Intel larger-runner pool; the
+          # xcframework's simulator slice is a fat arm64+x86_64 binary
+          # either way.
           xcodebuild build-for-testing \
             -workspace Zingo.xcworkspace \
             -scheme Zingo \
             -sdk iphonesimulator \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5,arch=arm64' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
             -derivedDataPath "build/DerivedData" \
             -resultBundlePath "build/reports/Zingo-BuildForTesting.xcresult" \
             -quiet


### PR DESCRIPTION
Completes the larger-runner rollout from #1194, which merged before this one-line follow-up landed on its branch. `build-for-testing` pins `-destination '...,arch=arm64'`, which matched the Apple-silicon simulators on GitHub's standard `macos-15` runners but matches nothing on the Intel `zingo-ios-build-12` pool, so the job fails deterministically with `xcodebuild: Unable to find a destination` (3m12s to fail on dev's merge-commit run). Dropping the arch key lets xcodebuild resolve the runner's native simulator architecture on either hardware; the xcframework's simulator slice is a fat arm64+x86_64 binary by design, and the detox configuration already pins no arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)