### PR TITLE
ci: survive cache eviction in the Android integration build

### DIFF
--- a/.github/workflows/android-ubuntu-integration-test-ci.yaml
+++ b/.github/workflows/android-ubuntu-integration-test-ci.yaml
@@ -78,8 +78,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-write-only: true
-          cache-read-only: false
+          # Only the default branch seeds Gradle caches; PR refs write ~1 GiB
+          # per job into the 10 GiB repo quota, and the resulting LRU
+          # eviction has raced (and lost) same-run cache handoffs.
+          cache-write-only: ${{ github.ref == 'refs/heads/dev' }}
+          cache-read-only: ${{ github.ref != 'refs/heads/dev' }}
 
       - name: Check AVD cache
         uses: actions/cache/restore@v6
@@ -145,21 +148,49 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-read-only: false
+          # See the avd-cache job: only dev writes Gradle caches.
+          cache-read-only: ${{ github.ref != 'refs/heads/dev' }}
 
+      # The Actions cache is evictable under the repo quota's LRU policy —
+      # an entry saved by this run's cache-native job has been evicted
+      # minutes later under churn. The uploaded artifacts from this run's
+      # native build are durable, so each restore falls back to its
+      # artifact, and only the final presence check can fail the job.
       - name: Native rust cache
+        id: native-cache
         uses: actions/cache/restore@v6
         with:
           path: android/app/src/main/jniLibs/${{ env.ABI }}
           key: native-android-uniffi-${{ env.ABI }}-${{ env.CACHE-KEY }}
-          fail-on-cache-miss: true
+
+      - name: Native rust artifact fallback
+        if: ${{ steps.native-cache.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: native-android-uniffi-${{ env.ABI }}-${{ env.CACHE-KEY }}
+          path: android/app/src/main/jniLibs/${{ env.ABI }}
 
       - name: Kotlin uniffi cache
+        id: kotlin-cache
         uses: actions/cache/restore@v6
         with:
           path: android/app/build/generated/source/uniffi/release/java/uniffi/zingo
           key: kotlin-android-uniffi-${{ env.ABI }}-${{ env.CACHE-KEY }}
-          fail-on-cache-miss: true
+
+      - name: Kotlin uniffi artifact fallback
+        if: ${{ steps.kotlin-cache.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: kotlin-android-uniffi-${{ env.ABI }}-${{ env.CACHE-KEY }}
+          path: android/app/build/generated/source/uniffi/release/java/uniffi/zingo
+
+      - name: Verify native and uniffi inputs present
+        run: |
+          set -eu
+          test -f "android/app/src/main/jniLibs/${{ env.ABI }}/libuniffi_zingo.so"
+          test -f "android/app/build/generated/source/uniffi/release/java/uniffi/zingo/zingo.kt"
 
       - name: Remove unnecessary directories to free up space
         run: |


### PR DESCRIPTION
Root cause and fix for the `Native rust cache` failure on #1168's run ([job 89064697438](https://github.com/zingolabs/zingo-mobile/actions/runs/29961402125/job/89064697438)): the repo's Actions cache sits at its quota (9.44 of 10 GiB), so LRU eviction is routine — and it deleted the `native-android-uniffi-x86_64-…` entry **eighteen minutes after this same run saved it** (save logged 22:09:15, restore missed 22:27:59, byte-identical keys), before the downstream build could restore it. `fail-on-cache-miss: true` turned the eviction race into a job failure.

Two changes:

1. **PR refs stop writing Gradle caches.** The build and avd-cache jobs write only on `dev` (the default branch, whose caches every ref can read); the emulator-test jobs were already read-only, and `android-release` already follows this pattern. This removes ~3 GiB of churn per fresh PR ref — the pressure that drives eviction.
2. **The native-rust and kotlin-uniffi restores fall back to artifacts.** This run's native build already uploads both as artifacts, which are run-scoped and not evictable. The restores drop `fail-on-cache-miss`; a fallback `download-artifact` step covers a miss, and an explicit presence check for `libuniffi_zingo.so` / `zingo.kt` becomes the single, clearly-named failure point.

Validation: `actionlint` reports no new findings; `git diff --check` clean.

Related admin action (not possible from the repo): raising the Actions cache size limit above 10 GiB in org/repo settings would add headroom; this PR removes the churn regardless. The failed #1168 jobs are being re-run separately — the rebuilt cache plus quieter traffic should let them pass even before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)