### PR TITLE
feat!: excise zcashd by removing the regchest test backend

### DIFF
--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -109,7 +109,7 @@ jobs:
 
           cd rust
           rustup default stable
-          cargo update -p zingolib -p regchest_utils --aggressive
+          cargo update -p zingolib --aggressive
 
       - name: Cargo default stable
         run: |

--- a/.github/workflows/ios-build.yaml
+++ b/.github/workflows/ios-build.yaml
@@ -82,7 +82,7 @@ jobs:
 
           cd rust
           rustup default stable
-          cargo update -p zingolib -p regchest_utils --aggressive
+          cargo update -p zingolib --aggressive
 
       - name: Cargo default stable
         run: |

--- a/.github/workflows/ios-integration-test.yaml
+++ b/.github/workflows/ios-integration-test.yaml
@@ -155,38 +155,8 @@ jobs:
   #       with:
   #         repository: ${{ env.REPO-OWNER }}/zingo-mobile
 
-  #     - name: Install docker
-  #       run: |
-  #         set -euxo pipefail
-
-  #         brew install qemu
-  #         brew install docker
-
-  #         brew developer on
-
-  #         brew tap-new local/old-lima || true
-  #         brew extract --version=0.22.0 lima local/old-lima || true
-  #         brew install --build-from-source local/old-lima/lima@0.22.0
-  #         brew pin lima@0.22.0
-
-  #         # Replace limactl with the no-HVF build (if you really need this patch)
-  #         LIMACTL_PATH="$(brew --prefix lima@0.22.0)/bin/limactl"
-  #         sudo curl -L -o "${LIMACTL_PATH}" https://github.com/mikekazakov/lima-nohvf/raw/master/limactl
-  #         sudo chmod +x "${LIMACTL_PATH}"
-
-  #         sudo curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.7.3/colima-Darwin-arm64
-  #         sudo chmod +x /usr/local/bin/colima
-
-  #         /usr/local/bin/colima version || true
-  #         limactl version || true
-
-  #         brew developer off
-
-  #         colima start --network-address --arch arm64 --vm-type=qemu
-
   #     - name: Grant permissions
   #       run: |
-  #         sudo chmod 777 ~/.colima/default/docker.sock
   #         sudo chmod 777 ./scripts/ci/ios_integration_tests_ci.sh
 
   #     - name: Rust toolchain
@@ -200,9 +170,6 @@ jobs:
   #       with:
   #         tool: nextest
 
-  #     - name: Pull docker image
-  #       run: docker pull zingodevops/regchest:013
-      
   #     - name: Install nvm with node 22.18.0
   #       run: |
   #         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
@@ -232,7 +199,7 @@ jobs:
 
   #     - name: Run IOS integration tests
   #       working-directory: ./rust
-  #       run: cargo nextest run ios_integration::universal::${{ matrix.test }} --features "ci regchest" --verbose --release
+  #       run: cargo nextest run ios_integration::universal::${{ matrix.test }} --features "ci" --verbose --release
 
   #     - name: Upload IOS test reports (.xcresult)
   #       if: ${{ always() && !cancelled() }}

--- a/README.md
+++ b/README.md
@@ -41,17 +41,14 @@ flavor architecture: see [docs/release_quickstart.md](./docs/release_quickstart.
 
 ## Testing
 ### Prerequisites
-Integration tests and end-to-end tests require a regtest server. On linux hosts, these may be run
-locally by installing the lightwalletd, zcashd and zcash-cli binaries
-(https://github.com/zingolabs/zingolib#regtest). From the `rust/android/regtest/bin/` directory run: <br />
-`ln -s path/to/lightwalletd/binary path/to/zcashd/binary path/to/zcash-cli/binary ./` <br />
-From the `rust/android/lightwalletd_bin` directory run: <br />
-`ln -s path/to/lightwalletd/binary ./`
+Integration tests and end-to-end tests require a regtest network. The test harness
+(`zingolib_testutils` scenarios, built on `zcash_local_net`) launches native `zebrad`
+(validator) and `lightwalletd` (indexer) processes for each test, so both binaries must
+be installed and discoverable via `$PATH`, or placed in the directory named by the
+`TEST_BINARIES_DIR` environment variable. This works on both Linux and macOS hosts.
 
-Alternatively, integration tests and end-to-end tests can be run on non-linux hosts with Regchest
-(https://github.com/zingolabs/zingo-regchest). Regchest manages the zcash/lightwalletd regtest
-network in a docker container. Before running tests, pull the latest Regchest image from docker: <br />
-`docker pull zingodevops/regchest:013`
+Additionally, from the `rust/android/lightwalletd_bin` directory run: <br />
+`ln -s path/to/lightwalletd/binary ./`
 
 ### Yarn Tests
 1. From the root directory, run: <br />
@@ -85,13 +82,10 @@ commands.
    Specify to run a specific ABI and test: <br />
    `cargo nextest run android_integration::x86_64::test_name`
 
-To run tests with Regchest, add the `--features regchest` flag, for example: <br />
-`cargo nextest run android_integration --features regchest`
-
 For more information on running integration tests on non-default AVDs, run: <br />
 `./scripts/android_integration_tests.sh -h` <br />
 Without the cargo test runner these emulated android devices will not be able to connect to a
-lightwalletd/zcashd regtest network. Therefore, only tests in the "Offline Testsuite" may be tested.
+regtest network. Therefore, only tests in the "Offline Testsuite" may be tested.
 
 ### End-to-End Tests (Rust nextest, Android)
 Drives the Android app from Rust against a regtest network. Lives in

--- a/docs/adr/0001-excise-zcashd-and-regchest.md
+++ b/docs/adr/0001-excise-zcashd-and-regchest.md
@@ -1,0 +1,35 @@
+# Excise zcashd by removing the regchest test backend
+
+zcashd is dead, and the only functional zcashd path left in this repository was
+the `regchest` cargo feature: an alternative arm in each integration and e2e
+test that launched the `zingodevops/regchest` docker container, whose image
+ships `zcashd`, `zcash-cli`, and `lightwalletd` and has no zebrad mode. We
+removed the regchest integration entirely — the `regchest_utils` dependency,
+the `regchest` features on the `rustandroid` and `rustios` crates, the gated
+arms in the test suites, and the workflow and README references. Every test
+now provisions its network exclusively through the default arm:
+`zingolib_testutils` scenarios driving `zcash_local_net` to launch a native
+zebrad validator and lightwalletd indexer, which is what gating CI already ran.
+
+## Considered options
+
+Porting regchest to zebrad + zainod was rejected because it amounts to
+rebuilding regchest: its orchestration would be rewritten around
+`zcash_local_net`, and every cached chain scenario would need regeneration
+because zcashd chain state is meaningless to zebrad. Keeping the feature flag
+dormant until such a rebuild was rejected because it ships a permanently
+broken flag. The services regchest uniquely provided (a macOS-friendly
+whole-network container and pre-baked funded chain state) have living
+equivalents in the zaino repository's patterns (a containerized test runner
+and `zcash_local_net` chain caches) that can be adopted as separate, additive
+work if a need appears.
+
+## Consequences
+
+The tests lose their only alternative network backend until the darkside
+harness (built on the auzum197/lightwallet-tools crates) inherits the vacated
+feature-gated seam. Darkside fabricates and verifies nothing, so
+real-validator coverage remains the zebrad default arm's job; on macOS hosts
+zebrad is a Zebra Tier 3 platform (build-it-yourself, no upstream guarantee),
+and if it ever regresses there, darkside fidelity is certified against zebrad
+on Linux runners rather than by resurrecting a zcashd container.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:beta:release:split": "cd android && ./gradlew assembleBetaRelease -PsplitApk=true && cd ..",
     "build:beta:debug": "cd android && ./gradlew assembleBetaDebug && cd ..",
     "build:beta:debug:split": "cd android && ./gradlew assembleBetaDebug -PsplitApk=true && cd ..",
-    "cargo:update": "cd rust && cargo update -p zingolib -p regchest_utils --aggressive && cd ..",
+    "cargo:update": "cd rust && cargo update -p zingolib --aggressive && cd ..",
     "cargo:clean": "cd rust && cargo clean && cd ..",
     "cargo:check": "cd rust && cargo check && cd ..",
     "rust:android": "node rust/android/build_android.mjs",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -435,50 +435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bollard"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41711ad46fda47cd701f6908e59d1bd6b9a2b7464c0d0aeab95c6d37096ff8a"
-dependencies = [
- "base64",
- "bollard-stubs",
- "bytes",
- "futures-core",
- "futures-util",
- "hex",
- "http",
- "http-body-util",
- "hyper",
- "hyper-named-pipe",
- "hyper-util",
- "hyperlocal",
- "log",
- "pin-project-lite",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_repr",
- "serde_urlencoded",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
- "tower-service",
- "url",
- "winapi",
-]
-
-[[package]]
-name = "bollard-stubs"
-version = "1.45.0-rc.26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7c5415e3a6bc6d3e99eff6268e488fd4ee25e7b28c10f08fa6760bd9de16e4"
-dependencies = [
- "serde",
- "serde_repr",
- "serde_with",
-]
-
-[[package]]
 name = "borsh"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,7 +626,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -886,7 +841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -968,12 +922,6 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1620,21 +1568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-named-pipe"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
-dependencies = [
- "hex",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
- "winapi",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,21 +1616,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "hyperlocal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
-dependencies = [
- "hex",
- "http-body-util",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1844,7 +1762,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -1855,8 +1772,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2786,35 +2701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "regchest_utils"
-version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingo-regchest?branch=dev#4ae67cc9f347077504245dc0082d192db95ac467"
-dependencies = [
- "bollard",
- "futures",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,7 +2909,6 @@ dependencies = [
  "env_logger",
  "json",
  "pepper-sync",
- "regchest_utils",
  "rustls 0.23.41",
  "tokio",
  "zingolib",
@@ -3053,7 +2938,6 @@ dependencies = [
  "env_logger",
  "json",
  "pepper-sync",
- "regchest_utils",
  "rustls 0.23.41",
  "tokio",
  "zingolib",
@@ -3185,30 +3069,6 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_spec",
  "zip32",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3354,17 +3214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,24 +3232,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "time",
 ]
 
 [[package]]
@@ -4415,22 +4246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4438,12 +4253,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,6 @@ pepper-sync = { git = "https://github.com/zingolabs/zingolib", branch = "feature
 zingolib_testutils = { git = "https://github.com/zingolabs/zingolib", branch = "feature/swap-op-return", features = [
     "test_lwd_zebrad",
 ] }
-regchest_utils = { git = "https://github.com/zingolabs/zingo-regchest", branch = "dev" }
 zingomobile_utils = { path = "zingomobile_utils" }
 
 zcash_address = "0.12.0"

--- a/rust/android/Cargo.toml
+++ b/rust/android/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 
 [features]
 ci = []
-regchest = []
 
 [dev-dependencies]
 zingolib = { workspace = true , features = [
@@ -15,7 +14,6 @@ zingolib = { workspace = true , features = [
 pepper-sync = { workspace = true }
 zingolib_testutils = { workspace = true }
 zingomobile_utils = { workspace = true }
-regchest_utils = { workspace = true }
 json = { workspace = true }
 env_logger = { workspace = true }
 tokio = { workspace = true }

--- a/rust/android/tests/e2e_tests.rs
+++ b/rust/android/tests/e2e_tests.rs
@@ -1,36 +1,13 @@
-#[cfg(not(feature = "regchest"))]
 use zingolib_testutils::scenarios;
 
-// ubuntu ci runner
-#[cfg(all(feature = "ci", feature = "regchest"))]
-const UNIX_SOCKET: Option<&str> = Some("/var/run/docker.sock");
-
-// macos ci runner
-//#[cfg(feature = "ci", feature = "regchest")]
-//const UNIX_SOCKET: Option<&str> = Some("`/Users/runner/.colima/default/docker.sock`");
-
 async fn tex_send_address(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) = zingomobile_utils::android_e2e_test(abi, "tex_send_address");
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_e2e_test_ci(abi, "tex_send_address");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -40,26 +17,12 @@ async fn tex_send_address(abi: &str) {
 }
 
 async fn shielding(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_transparent_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_transparent_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_transparent_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) = zingomobile_utils::android_e2e_test(abi, "shielding");
     #[cfg(feature = "ci")]
     let (exit_code, output, error) = zingomobile_utils::android_e2e_test_ci(abi, "shielding");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -69,15 +32,7 @@ async fn shielding(abi: &str) {
 }
 
 async fn parse_invalid_address(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -85,12 +40,6 @@ async fn parse_invalid_address(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_e2e_test_ci(abi, "parse_invalid_address");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -100,15 +49,7 @@ async fn parse_invalid_address(abi: &str) {
 }
 
 async fn reload_while_tx_pending(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -116,12 +57,6 @@ async fn reload_while_tx_pending(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_e2e_test_ci(abi, "reload_while_tx_pending");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -146,15 +81,7 @@ async fn change_custom_server(abi: &str) {
 }
 
 async fn change_custom_regtest_server(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -162,12 +89,6 @@ async fn change_custom_regtest_server(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_e2e_test_ci(abi, "change_custom_regtest_server");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -233,26 +154,12 @@ async fn screen_awake(abi: &str) {
 }
 
 async fn send(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) = zingomobile_utils::android_e2e_test(abi, "send");
     #[cfg(feature = "ci")]
     let (exit_code, output, error) = zingomobile_utils::android_e2e_test_ci(abi, "send");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -357,7 +264,6 @@ mod e2e {
         async fn transaction_history() {
             crate::transaction_history(ABI).await;
         }
-
     }
 
     mod x86_64 {
@@ -427,7 +333,6 @@ mod e2e {
         async fn transaction_history() {
             crate::transaction_history(ABI).await;
         }
-
     }
 
     mod arm32 {
@@ -497,7 +402,6 @@ mod e2e {
         async fn transaction_history() {
             crate::transaction_history(ABI).await;
         }
-
     }
 
     mod arm64 {
@@ -567,6 +471,5 @@ mod e2e {
         async fn transaction_history() {
             crate::transaction_history(ABI).await;
         }
-
     }
 }

--- a/rust/android/tests/integration_tests.rs
+++ b/rust/android/tests/integration_tests.rs
@@ -1,24 +1,7 @@
-#[cfg(not(feature = "regchest"))]
 use zingolib_testutils::scenarios;
 
-// ubuntu ci runner
-#[cfg(all(feature = "ci", feature = "regchest"))]
-const UNIX_SOCKET: Option<&str> = Some("/var/run/docker.sock");
-
-// macos ci runner
-//#[cfg(feature = "ci", feature = "regchest")]
-//const UNIX_SOCKET: Option<&str> = Some("unix:///Users/runner/.colima/default/docker.sock");
-
 async fn execute_version_from_seed(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -26,12 +9,6 @@ async fn execute_version_from_seed(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_integration_test_ci(abi, "ExecuteVersionFromSeed");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -41,15 +18,7 @@ async fn execute_version_from_seed(abi: &str) {
 }
 
 async fn execute_addresses_from_ufvk(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -57,12 +26,6 @@ async fn execute_addresses_from_ufvk(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_integration_test_ci(abi, "ExecuteAddressesFromUfvk");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -72,15 +35,7 @@ async fn execute_addresses_from_ufvk(abi: &str) {
 }
 
 async fn execute_addresses_from_seed(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -88,12 +43,6 @@ async fn execute_addresses_from_seed(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_integration_test_ci(abi, "ExecuteAddressesFromSeed");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -103,15 +52,7 @@ async fn execute_addresses_from_seed(abi: &str) {
 }
 
 async fn execute_sync_from_seed(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -119,12 +60,6 @@ async fn execute_sync_from_seed(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_integration_test_ci(abi, "ExecuteSyncFromSeed");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -134,15 +69,7 @@ async fn execute_sync_from_seed(abi: &str) {
 }
 
 async fn execute_send_from_orchard(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -150,12 +77,6 @@ async fn execute_send_from_orchard(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_integration_test_ci(abi, "ExecuteSendFromOrchard");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -165,17 +86,7 @@ async fn execute_send_from_orchard(abi: &str) {
 }
 
 async fn execute_currentprice_and_value_transfers_from_seed(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_with_3_txs_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_with_3_txs_mobileclient"))
-            .await
-        {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_with_3_txs_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) = zingomobile_utils::android_integration_test(
@@ -188,12 +99,6 @@ async fn execute_currentprice_and_value_transfers_from_seed(abi: &str) {
         "UpdateCurrentPriceAndValueTransfersFromSeed",
     );
 
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
-
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
     println!("Error: {}", error);
@@ -202,19 +107,8 @@ async fn execute_currentprice_and_value_transfers_from_seed(abi: &str) {
 }
 
 async fn execute_sapling_balance_from_seed(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
     let _local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        UNIX_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -222,12 +116,6 @@ async fn execute_sapling_balance_from_seed(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_integration_test_ci(abi, "ExecuteSaplingBalanceFromSeed");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -237,19 +125,8 @@ async fn execute_sapling_balance_from_seed(abi: &str) {
 }
 
 async fn execute_parse_address_for_tex(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
     let _local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        UNIX_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -257,12 +134,6 @@ async fn execute_parse_address_for_tex(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_integration_test_ci(abi, "ExecuteParseAddressForTex");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -272,19 +143,8 @@ async fn execute_parse_address_for_tex(abi: &str) {
 }
 
 async fn execute_parse_address_invalid(abi: &str) {
-    #[cfg(not(feature = "regchest"))]
     let _local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        UNIX_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -292,12 +152,6 @@ async fn execute_parse_address_invalid(abi: &str) {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::android_integration_test_ci(abi, "ExecuteParseAddressInvalid");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);

--- a/rust/ios/Cargo.toml
+++ b/rust/ios/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 
 [features]
 ci = []
-regchest = []
 
 [dev-dependencies]
 zingolib = { workspace = true , features = [
@@ -15,7 +14,6 @@ zingolib = { workspace = true , features = [
 pepper-sync = { workspace = true }
 zingolib_testutils = { workspace = true }
 zingomobile_utils = { workspace = true }
-regchest_utils = { workspace = true }
 json = { workspace = true }
 env_logger = { workspace = true }
 tokio = { workspace = true }

--- a/rust/ios/tests/integration_tests.rs
+++ b/rust/ios/tests/integration_tests.rs
@@ -1,24 +1,7 @@
-#[cfg(not(feature = "regchest"))]
 use zingolib_testutils::scenarios;
 
-// ubuntu ci runner
-//#[cfg(all(feature = "ci", feature = "regchest"))]
-//const MAC_SOCKET: Option<&str> = Some("/var/run/docker.sock");
-
-// macos ci runner
-#[cfg(all(feature = "ci", feature = "regchest"))]
-const MAC_SOCKET: Option<&str> = Some("unix:///Users/runner/.colima/default/docker.sock");
-
 async fn execute_version_from_seed() {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -26,12 +9,6 @@ async fn execute_version_from_seed() {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::ios_integration_test_ci("ZingoTests/ExecuteVersionFromSeed");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -41,15 +18,7 @@ async fn execute_version_from_seed() {
 }
 
 async fn execute_addresses_from_ufvk() {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -57,12 +26,6 @@ async fn execute_addresses_from_ufvk() {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::ios_integration_test_ci("ZingoTests/ExecuteAddressesFromUfvk");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -72,15 +35,7 @@ async fn execute_addresses_from_ufvk() {
 }
 
 async fn execute_addresses_from_seed() {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -88,12 +43,6 @@ async fn execute_addresses_from_seed() {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::ios_integration_test_ci("ZingoTests/ExecuteAddressesFromSeed");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -103,15 +52,7 @@ async fn execute_addresses_from_seed() {
 }
 
 async fn execute_sync_from_seed() {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -119,12 +60,6 @@ async fn execute_sync_from_seed() {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::ios_integration_test_ci("ZingoTests/ExecuteSyncFromSeed");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -134,15 +69,7 @@ async fn execute_sync_from_seed() {
 }
 
 async fn execute_send_from_orchard() {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -150,12 +77,6 @@ async fn execute_send_from_orchard() {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::ios_integration_test_ci("ZingoTests/ExecuteSendFromOrchard");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -165,17 +86,7 @@ async fn execute_send_from_orchard() {
 }
 
 async fn execute_currentprice_and_value_transfers_from_seed() {
-    #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_with_3_txs_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_with_3_txs_mobileclient"))
-            .await
-        {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let _local_net = scenarios::funded_orchard_with_3_txs_mobileclient(1_000_000).await;
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) = zingomobile_utils::ios_integration_test(
@@ -186,12 +97,6 @@ async fn execute_currentprice_and_value_transfers_from_seed() {
         "ZingoTests/UpdateCurrentPriceAndValueTransfersFromSeed",
     );
 
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
-
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
     println!("Error: {}", error);
@@ -200,19 +105,8 @@ async fn execute_currentprice_and_value_transfers_from_seed() {
 }
 
 async fn execute_sapling_balance_from_seed() {
-    #[cfg(not(feature = "regchest"))]
     let _local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        MAC_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -220,12 +114,6 @@ async fn execute_sapling_balance_from_seed() {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::ios_integration_test_ci("ZingoTests/ExecuteSaplingBalanceFromSeed");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -235,19 +123,8 @@ async fn execute_sapling_balance_from_seed() {
 }
 
 async fn execute_parse_address_for_tex() {
-    #[cfg(not(feature = "regchest"))]
     let _local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        MAC_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -255,12 +132,6 @@ async fn execute_parse_address_for_tex() {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::ios_integration_test_ci("ZingoTests/ExecuteParseAddressForTex");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);
@@ -270,19 +141,8 @@ async fn execute_parse_address_for_tex() {
 }
 
 async fn execute_parse_address_invalid() {
-    #[cfg(not(feature = "regchest"))]
     let _local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
-    #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        MAC_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -290,12 +150,6 @@ async fn execute_parse_address_invalid() {
     #[cfg(feature = "ci")]
     let (exit_code, output, error) =
         zingomobile_utils::ios_integration_test_ci("ZingoTests/ExecuteParseAddressInvalid");
-
-    #[cfg(feature = "regchest")]
-    match regchest_utils::close(&docker).await {
-        Ok(_) => (),
-        Err(e) => panic!("Failed to close regchest docker container: {:?}", e),
-    }
 
     println!("Exit Code: {}", exit_code);
     println!("Output: {}", output);


### PR DESCRIPTION
zcashd is dead, and the last functional zcashd path in this repository was the `regchest` cargo feature: an alternative arm in each integration and e2e test that launched the `zingodevops/regchest` docker container, whose image ships `zcashd`, `zcash-cli`, and `lightwalletd` and has no zebrad mode. This pull request removes that integration entirely.

Every test now provisions its network exclusively through the formerly-default arm: `zingolib_testutils` scenarios driving `zcash_local_net` to launch a native zebrad validator and lightwalletd indexer. This is a 1:1 replacement of the zcashd-backed test paths with zebrad-backed ones — no test bodies changed, and it is the path the gating Android integration CI already ran (`--features "ci"`, never `regchest`).

Concretely, the change removes the `regchest_utils` dependency from the workspace and both mobile crates, deletes the `regchest` feature from `rustandroid` and `rustios`, strips the regchest-gated launch and teardown blocks from all three test suites, drops the regchest and colima/docker scaffolding from the commented-out iOS integration workflow, unpins `regchest_utils` from the build workflows and the `cargo:update` yarn script, and rewrites the README testing prerequisites to describe the real harness (native `zebrad` and `lightwalletd` resolved via `$PATH` or `TEST_BINARIES_DIR`, working on Linux and macOS). The old instructions pointed at a `rust/android/regtest/bin/` directory that did not exist.

The new `docs/adr/0001-excise-zcashd-and-regchest.md` records the decision, the rejected alternatives (porting regchest to zebrad, which amounts to rebuilding it; or shipping a dormant broken flag), and the consequence: the darkside harness later inherits the vacated feature-gated backend seam, while real-validator coverage remains the zebrad default arm's job.

Verified with `cargo check --tests`, `cargo clippy --tests`, and `cargo fmt` on both crates; a repository-wide sweep finds no remaining references to zcashd, zcash-cli, or regchest outside the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
