### PR TITLE
fix(harness): regtest activation heights flow from the validator to the on-device wallet

### DIFF
--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
@@ -96,6 +96,9 @@ data class SyncStatus (
 )
 
 data class Balance (
+    var total_ironwood_balance : Long = 0L,
+    var confirmed_ironwood_balance : Long = 0L,
+    var unconfirmed_ironwood_balance : Long = 0L,
     var total_sapling_balance : Long = 0L,
     var confirmed_sapling_balance : Long = 0L,
     var unconfirmed_sapling_balance : Long = 0L,
@@ -600,17 +603,24 @@ class ExecuteSaplingBalanceFromSeed {
         println("\nValue Transfers:")
         println(valueTranfersJson)
 
-        // Value Transfers
-        // 1. Received in orchard pool =     +500_000
-        // 2. Received in sapling pool =     +250_000
-        // 3. Received in transparent pool = +250_000
-        // 4. Send - 100_000 + 20_000fee =   -110_000
-        // 5. MemoToSelf orchard pool =       -10_000 (send-to-self)
-        // 6. MemoToSelf sapling pool =       -10_000 (send-to-self)
-        // 7. MemoToSelf transparent pool =   -15_000 (send-to-self)
-        // 8. Upgrading sapling pool =        -20_000 (shield)
+        // Value Transfers, on the ironwood-activated regtest chain. Shield
+        // and self-send outputs prefer the Ironwood pool (confirmed policy),
+        // so part of the orchard change and the shielded transparent funds
+        // land in Ironwood rather than Orchard.
+        // 1. Received in orchard pool =         +500_000
+        // 2. Received in sapling pool =         +250_000
+        // 3. Received in transparent pool =     +250_000
+        // 4. Send - 100_000 + 20_000fee =       -120_000
+        // 5. MemoToSelf orchard pool =           -20_000 fee,
+        //    100_000 of orchard change lands in ironwood
+        // 6. MemoToSelf sapling pool =           -10_000 fee
+        // 7. MemoToSelf sapling->transparent =   -15_000 fee,
+        //    100_000 moves to transparent
+        // 8. Shield transparent->ironwood =      -20_000 fee,
+        //    330_000 lands in ironwood
         //
-        // orchard pool     = 710_000
+        // ironwood pool    = 430_000
+        // orchard pool     = 260_000
         // sapling pool     = 125_000
         // transparent pool = 0
 
@@ -619,8 +629,10 @@ class ExecuteSaplingBalanceFromSeed {
         println(balanceJson)
         val balance: Balance = mapper.readValue(balanceJson)
 
-        assertThat(balance.total_orchard_balance).isEqualTo(710000)
-        assertThat(balance.confirmed_orchard_balance).isEqualTo(710000)
+        assertThat(balance.total_ironwood_balance).isEqualTo(430000)
+        assertThat(balance.confirmed_ironwood_balance).isEqualTo(430000)
+        assertThat(balance.total_orchard_balance).isEqualTo(260000)
+        assertThat(balance.confirmed_orchard_balance).isEqualTo(260000)
         assertThat(balance.total_sapling_balance).isEqualTo(125000)
         assertThat(balance.confirmed_sapling_balance).isEqualTo(125000)
         assertThat(balance.confirmed_transparent_balance).isEqualTo(0)

--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
@@ -1,5 +1,6 @@
 package org.ZingoLabs.Zingo
 
+import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -12,6 +13,18 @@ import com.fasterxml.jackson.core.type.TypeReference
 // Jackson can use the no-arg constructor + setter injection.
 fun testMapper(): ObjectMapper = ObjectMapper()
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+// The regtest chain hint for the wallet under test. The host harness reads
+// the launched chain's activation heights back from the running validator
+// and forwards them as the `activation_heights` instrumentation argument
+// (see scripts/android_integration_tests.sh); the extended hint hands them
+// to the FFI so the wallet's schedule is the chain's, never a guess. With
+// no argument (a chain whose provisioner cannot report a schedule) the
+// bare hint keeps the FFI's historical default.
+fun regtestChainHint(): String {
+    val heights = InstrumentationRegistry.getArguments().getString("activation_heights")
+    return if (heights.isNullOrEmpty()) "regtest" else "regtest:$heights"
+}
 
 inline fun <reified T> ObjectMapper.readValue(src: String): T =
     readValue(src, object : TypeReference<T>() {})
@@ -150,7 +163,7 @@ class ExecuteAddressesFromSeed {
         val mapper = testMapper()
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val seed = Seeds.HOSPITAL
         
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()
@@ -198,7 +211,7 @@ class ExecuteAddressesFromUfvk {
         val mapper = testMapper()
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val ufvk = Ufvk.HOSPITAL
         
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()
@@ -249,7 +262,7 @@ class ExecuteVersionFromSeed {
         val mapper = testMapper()
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val seed = Seeds.HOSPITAL
         
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()
@@ -284,7 +297,7 @@ class ExecuteSyncFromSeed {
         val mapper = testMapper()
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val seed = Seeds.HOSPITAL
 
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()
@@ -350,7 +363,7 @@ class ExecuteSendFromOrchard {
         val mapper = testMapper()
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val seed = Seeds.HOSPITAL
         
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()
@@ -465,7 +478,7 @@ class UpdateCurrentPriceAndValueTransfersFromSeed {
         val mapper = testMapper()
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val seed = Seeds.HOSPITAL
 
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()
@@ -553,7 +566,7 @@ class ExecuteSaplingBalanceFromSeed {
         val rpcModule = RPCModule(MainApplication.getAppReactContext())
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val seed = Seeds.HOSPITAL
         
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()
@@ -665,7 +678,7 @@ class ExecuteParseAddressForTex {
         val mapper = testMapper()
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val seed = Seeds.HOSPITAL
         
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()
@@ -711,7 +724,7 @@ class ExecuteParseAddressInvalid {
         val mapper = testMapper()
 
         val serveruri = "http://10.0.2.2:20000"
-        val chainhint = "regtest"
+        val chainhint = regtestChainHint()
         val seed = Seeds.HOSPITAL
         
         val setCrytoProvider = uniffi.zingo.setCryptoDefaultProviderToRing()

--- a/docs/adr/0001-shield-and-change-outputs-prefer-the-ironwood-pool.md
+++ b/docs/adr/0001-shield-and-change-outputs-prefer-the-ironwood-pool.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+---
+
+# Shield and self-send change outputs prefer the Ironwood pool
+
+Once the Ironwood network upgrade (NU6.3 of the Zcash chain) has activated, the wallet directs shielding
+transactions and the change portion of self-sends into the Ironwood shielded value pool rather than the
+Orchard pool. This is the wallet's privacy path: value migrates toward the newest pool as a side effect
+of ordinary operations, without a distinct "migration" transaction the chain could distinguish. We accept
+that balances drift out of Orchard over time and that pre-Ironwood balance expectations (in tests and in
+user-facing pool breakdowns) change; keeping change in Orchard would preserve those expectations but
+would strand value in the older pool and make deliberate migrations stand out on chain.
+
+## Consequences
+
+- Integration-test ledgers must model the post-activation pool distribution; the
+  `ExecuteSaplingBalanceFromSeed` expectations were updated for this on 2026-07-22 (ironwood 430 000,
+  orchard 260 000, sapling 125 000, transparent 0 for the standard funded regtest scenario).
+- Any transaction the wallet authors on an ironwood-activated chain must use the Ironwood consensus
+  branch ID; the receive/scan path is unaffected. (An incorrect-branch-id defect in the authoring path
+  was open when this was recorded.)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2976,6 +2976,7 @@ version = "2.0.0"
 dependencies = [
  "regchest_utils",
  "tokio",
+ "zcash_local_net",
  "zingolib_testutils",
  "zingomobile_utils",
 ]

--- a/rust/android/Cargo.toml
+++ b/rust/android/Cargo.toml
@@ -13,3 +13,4 @@ zingolib_testutils = { workspace = true }
 zingomobile_utils = { workspace = true }
 regchest_utils = { workspace = true }
 tokio = { workspace = true }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "537f84d3d81b228c06ae82365f306ff364e164da" }

--- a/rust/android/tests/integration_tests.rs
+++ b/rust/android/tests/integration_tests.rs
@@ -1,4 +1,6 @@
 #[cfg(not(feature = "regchest"))]
+use zcash_local_net::validator::Validator;
+#[cfg(not(feature = "regchest"))]
 use zingolib_testutils::scenarios;
 
 // ubuntu ci runner
@@ -9,10 +11,39 @@ const UNIX_SOCKET: Option<&str> = Some("/var/run/docker.sock");
 //#[cfg(feature = "ci", feature = "regchest")]
 //const UNIX_SOCKET: Option<&str> = Some("unix:///Users/runner/.colima/default/docker.sock");
 
+/// The launched chain's activation heights in the spec form the wallet's
+/// `regtest:<schedule>` chain hint consumes, read back from the running
+/// validator (infrastructure ADR 0003: the validator is the only heights
+/// authority) rather than restated from the launch fixture. The regchest
+/// path has no validator handle to query, so those runs pass no schedule
+/// and the wallet keeps its historical default.
+#[cfg(not(feature = "regchest"))]
+async fn validator_activation_heights(validator: &impl Validator) -> String {
+    let heights = validator.get_activation_heights().await;
+    let fmt = |height: Option<u32>| height.map_or_else(|| "off".to_string(), |h| h.to_string());
+    format!(
+        "overwinter={},sapling={},blossom={},heartwood={},canopy={},nu5={},nu6={},nu6_1={},nu6_2={},nu6_3={},nu7={}",
+        fmt(heights.overwinter()),
+        fmt(heights.sapling()),
+        fmt(heights.blossom()),
+        fmt(heights.heartwood()),
+        fmt(heights.canopy()),
+        fmt(heights.nu5()),
+        fmt(heights.nu6()),
+        fmt(heights.nu6_1()),
+        fmt(heights.nu6_2()),
+        fmt(heights.nu6_3()),
+        fmt(heights.nu7()),
+    )
+}
+
 async fn execute_version_from_seed(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker =
         match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
@@ -21,11 +52,17 @@ async fn execute_version_from_seed(abi: &str) {
         };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test(abi, "ExecuteVersionFromSeed");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test(
+        abi,
+        "ExecuteVersionFromSeed",
+        activation_heights.as_deref(),
+    );
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test_ci(abi, "ExecuteVersionFromSeed");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
+        abi,
+        "ExecuteVersionFromSeed",
+        activation_heights.as_deref(),
+    );
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
@@ -42,8 +79,11 @@ async fn execute_version_from_seed(abi: &str) {
 
 async fn execute_addresses_from_ufvk(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker =
         match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
@@ -52,11 +92,17 @@ async fn execute_addresses_from_ufvk(abi: &str) {
         };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test(abi, "ExecuteAddressesFromUfvk");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test(
+        abi,
+        "ExecuteAddressesFromUfvk",
+        activation_heights.as_deref(),
+    );
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test_ci(abi, "ExecuteAddressesFromUfvk");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
+        abi,
+        "ExecuteAddressesFromUfvk",
+        activation_heights.as_deref(),
+    );
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
@@ -73,8 +119,11 @@ async fn execute_addresses_from_ufvk(abi: &str) {
 
 async fn execute_addresses_from_seed(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker =
         match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
@@ -83,11 +132,17 @@ async fn execute_addresses_from_seed(abi: &str) {
         };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test(abi, "ExecuteAddressesFromSeed");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test(
+        abi,
+        "ExecuteAddressesFromSeed",
+        activation_heights.as_deref(),
+    );
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test_ci(abi, "ExecuteAddressesFromSeed");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
+        abi,
+        "ExecuteAddressesFromSeed",
+        activation_heights.as_deref(),
+    );
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
@@ -104,8 +159,11 @@ async fn execute_addresses_from_seed(abi: &str) {
 
 async fn execute_sync_from_seed(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker =
         match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
@@ -114,11 +172,17 @@ async fn execute_sync_from_seed(abi: &str) {
         };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test(abi, "ExecuteSyncFromSeed");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test(
+        abi,
+        "ExecuteSyncFromSeed",
+        activation_heights.as_deref(),
+    );
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test_ci(abi, "ExecuteSyncFromSeed");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
+        abi,
+        "ExecuteSyncFromSeed",
+        activation_heights.as_deref(),
+    );
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
@@ -135,8 +199,11 @@ async fn execute_sync_from_seed(abi: &str) {
 
 async fn execute_send_from_orchard(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker =
         match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
@@ -145,11 +212,17 @@ async fn execute_send_from_orchard(abi: &str) {
         };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test(abi, "ExecuteSendFromOrchard");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test(
+        abi,
+        "ExecuteSendFromOrchard",
+        activation_heights.as_deref(),
+    );
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test_ci(abi, "ExecuteSendFromOrchard");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
+        abi,
+        "ExecuteSendFromOrchard",
+        activation_heights.as_deref(),
+    );
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
@@ -166,8 +239,11 @@ async fn execute_send_from_orchard(abi: &str) {
 
 async fn execute_currentprice_and_value_transfers_from_seed(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_with_3_txs_mobileclient(1_000_000).await;
+    let local_net = scenarios::funded_orchard_with_3_txs_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker =
         match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_with_3_txs_mobileclient"))
@@ -181,11 +257,13 @@ async fn execute_currentprice_and_value_transfers_from_seed(abi: &str) {
     let (exit_code, output, error) = zingomobile_utils::android_integration_test(
         abi,
         "UpdateCurrentPriceAndValueTransfersFromSeed",
+        activation_heights.as_deref(),
     );
     #[cfg(feature = "ci")]
     let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
         abi,
         "UpdateCurrentPriceAndValueTransfersFromSeed",
+        activation_heights.as_deref(),
     );
 
     #[cfg(feature = "regchest")]
@@ -203,8 +281,12 @@ async fn execute_currentprice_and_value_transfers_from_seed(abi: &str) {
 
 async fn execute_sapling_balance_from_seed(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
+    let local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker = match regchest_utils::launch(
         UNIX_SOCKET,
@@ -217,11 +299,17 @@ async fn execute_sapling_balance_from_seed(abi: &str) {
     };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test(abi, "ExecuteSaplingBalanceFromSeed");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test(
+        abi,
+        "ExecuteSaplingBalanceFromSeed",
+        activation_heights.as_deref(),
+    );
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test_ci(abi, "ExecuteSaplingBalanceFromSeed");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
+        abi,
+        "ExecuteSaplingBalanceFromSeed",
+        activation_heights.as_deref(),
+    );
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
@@ -238,8 +326,12 @@ async fn execute_sapling_balance_from_seed(abi: &str) {
 
 async fn execute_parse_address_for_tex(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
+    let local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker = match regchest_utils::launch(
         UNIX_SOCKET,
@@ -252,11 +344,17 @@ async fn execute_parse_address_for_tex(abi: &str) {
     };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test(abi, "ExecuteParseAddressForTex");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test(
+        abi,
+        "ExecuteParseAddressForTex",
+        activation_heights.as_deref(),
+    );
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test_ci(abi, "ExecuteParseAddressForTex");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
+        abi,
+        "ExecuteParseAddressForTex",
+        activation_heights.as_deref(),
+    );
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {
@@ -273,8 +371,12 @@ async fn execute_parse_address_for_tex(abi: &str) {
 
 async fn execute_parse_address_invalid(abi: &str) {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
+    let local_net =
         scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
+    #[cfg(not(feature = "regchest"))]
+    let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
+    #[cfg(feature = "regchest")]
+    let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
     let docker = match regchest_utils::launch(
         UNIX_SOCKET,
@@ -287,11 +389,17 @@ async fn execute_parse_address_invalid(abi: &str) {
     };
 
     #[cfg(not(feature = "ci"))]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test(abi, "ExecuteParseAddressInvalid");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test(
+        abi,
+        "ExecuteParseAddressInvalid",
+        activation_heights.as_deref(),
+    );
     #[cfg(feature = "ci")]
-    let (exit_code, output, error) =
-        zingomobile_utils::android_integration_test_ci(abi, "ExecuteParseAddressInvalid");
+    let (exit_code, output, error) = zingomobile_utils::android_integration_test_ci(
+        abi,
+        "ExecuteParseAddressInvalid",
+        activation_heights.as_deref(),
+    );
 
     #[cfg(feature = "regchest")]
     match regchest_utils::close(&docker).await {

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -290,6 +290,88 @@ where
     })
 }
 
+/// Parses the schedule suffix of a `regtest:<schedule>` chain hint into
+/// activation heights.
+///
+/// The format is the harness convention (`regtest-launcher`, and the shape
+/// of `REGTEST_FIXTURE_HEIGHTS_CLI_STRING`): comma-separated `key=height`
+/// entries applied left to right over the bare-"regtest" default schedule,
+/// where `height` is a block height or `off`, and `all` sets every upgrade
+/// through NU6.3 at once. Unknown keys and malformed heights are errors,
+/// never silently dropped — a wrong schedule fails loudly here instead of
+/// as a consensus-branch-id rejection at broadcast.
+fn parse_regtest_activation_heights(spec: &str) -> Result<ActivationHeights, String> {
+    let default = ActivationHeights::default();
+    let mut overwinter = default.overwinter();
+    let mut sapling = default.sapling();
+    let mut blossom = default.blossom();
+    let mut heartwood = default.heartwood();
+    let mut canopy = default.canopy();
+    let mut nu5 = default.nu5();
+    let mut nu6 = default.nu6();
+    let mut nu6_1 = default.nu6_1();
+    let mut nu6_2 = default.nu6_2();
+    let mut nu6_3 = default.nu6_3();
+    let mut nu7 = default.nu7();
+
+    for entry in spec.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (key, value) = entry
+            .split_once('=')
+            .ok_or_else(|| format!("expected key=height, got \"{entry}\""))?;
+        let height = match value.trim() {
+            "off" => None,
+            v => Some(
+                v.parse::<u32>()
+                    .map_err(|_| format!("invalid height \"{v}\" for \"{}\"", key.trim()))?,
+            ),
+        };
+        match key.trim() {
+            "all" => {
+                overwinter = height;
+                sapling = height;
+                blossom = height;
+                heartwood = height;
+                canopy = height;
+                nu5 = height;
+                nu6 = height;
+                nu6_1 = height;
+                nu6_2 = height;
+                nu6_3 = height;
+            }
+            "overwinter" => overwinter = height,
+            "sapling" => sapling = height,
+            "blossom" => blossom = height,
+            "heartwood" => heartwood = height,
+            "canopy" => canopy = height,
+            "nu5" => nu5 = height,
+            "nu6" => nu6 = height,
+            "nu6_1" => nu6_1 = height,
+            "nu6_2" => nu6_2 = height,
+            "nu6_3" => nu6_3 = height,
+            "nu7" => nu7 = height,
+            other => return Err(format!("unknown network upgrade \"{other}\"")),
+        }
+    }
+
+    Ok(ActivationHeights::builder()
+        .set_overwinter(overwinter)
+        .set_sapling(sapling)
+        .set_blossom(blossom)
+        .set_heartwood(heartwood)
+        .set_canopy(canopy)
+        .set_nu5(nu5)
+        .set_nu6(nu6)
+        .set_nu6_1(nu6_1)
+        .set_nu6_2(nu6_2)
+        .set_nu6_3(nu6_3)
+        .set_nu7(nu7)
+        .build())
+}
+
 struct ConnectionParams {
     chain_type: ChainType,
     wallet_settings: WalletSettings,
@@ -309,7 +391,19 @@ fn build_connection_params(
         "main" => ChainType::Mainnet,
         "test" => ChainType::Testnet,
         "regtest" => ChainType::Regtest(ActivationHeights::default()),
-        _ => return Err(ZingolibError::init("Not a valid chain hint!")),
+        hint => match hint.strip_prefix("regtest:") {
+            // A regtest chain has no universal schedule: the node that was
+            // launched is the only authority on its activation heights
+            // (infrastructure ADR 0003), so the harness that launched it
+            // passes the schedule through the hint. Bare "regtest" keeps
+            // the historical all-at-height-1 default.
+            Some(schedule) => {
+                ChainType::Regtest(parse_regtest_activation_heights(schedule).map_err(|e| {
+                    ZingolibError::init(format!("Invalid regtest activation heights: {e}"))
+                })?)
+            }
+            None => return Err(ZingolibError::init("Not a valid chain hint!")),
+        },
     };
 
     // Offline Mode = empty uri → no Indexer is ever configured; the client
@@ -665,6 +759,73 @@ mod wallet_export_tests {
     fn no_save_needed_crosses_as_null() {
         let crossed = map_wallet_save(Ok(None)).expect("no-save is not a failure");
         assert_eq!(crossed, None);
+    }
+}
+
+/// The regtest schedule handoff: a `regtest:<schedule>` hint must carry
+/// the launched node's activation heights into the wallet verbatim
+/// (infrastructure ADR 0003 — the validator is the only heights
+/// authority), and a malformed schedule must fail at parse time, never
+/// surface later as a consensus-branch-id rejection at broadcast.
+#[cfg(test)]
+mod regtest_activation_heights_tests {
+    use super::*;
+
+    #[test]
+    fn empty_schedule_matches_the_bare_regtest_default() {
+        let parsed = parse_regtest_activation_heights("").expect("empty schedule is valid");
+        assert_eq!(parsed, ActivationHeights::default());
+    }
+
+    #[test]
+    fn fixture_schedule_parses_to_the_mixed_chain() {
+        // The harness fixture shape: pre-NU5 upgrades at 1, NU5/NU6 at 2,
+        // the NU6.x line at 5, NU7 unscheduled.
+        let parsed =
+            parse_regtest_activation_heights("all=1,nu5=2,nu6=2,nu6_1=5,nu6_2=5,nu6_3=5,nu7=off")
+                .expect("the fixture schedule is valid");
+        assert_eq!(parsed.canopy(), Some(1));
+        assert_eq!(parsed.nu5(), Some(2));
+        assert_eq!(parsed.nu6(), Some(2));
+        assert_eq!(parsed.nu6_1(), Some(5));
+        assert_eq!(parsed.nu6_2(), Some(5));
+        assert_eq!(parsed.nu6_3(), Some(5));
+        assert_eq!(parsed.nu7(), None);
+    }
+
+    #[test]
+    fn entries_apply_left_to_right_over_all() {
+        let parsed = parse_regtest_activation_heights("all=3,nu6_3=7").expect("override is valid");
+        assert_eq!(parsed.nu6(), Some(3));
+        assert_eq!(parsed.nu6_3(), Some(7));
+    }
+
+    #[test]
+    fn unknown_upgrade_is_an_error_not_a_silent_drop() {
+        let error = parse_regtest_activation_heights("nu99=1")
+            .expect_err("an unknown upgrade must be rejected");
+        assert!(error.contains("nu99"), "error names the bad key: {error}");
+    }
+
+    #[test]
+    fn malformed_height_is_an_error() {
+        let error = parse_regtest_activation_heights("nu5=soon")
+            .expect_err("a non-numeric height must be rejected");
+        assert!(error.contains("soon"), "error names the bad value: {error}");
+    }
+
+    #[test]
+    fn hint_without_schedule_prefix_still_fails_init() {
+        let error = match build_connection_params(
+            String::new(),
+            "shmegtest".to_string(),
+            "Medium".to_string(),
+            1,
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("an unknown chain hint must be rejected"),
+        };
+        assert!(matches!(error, ZingolibError::Init(_)));
     }
 }
 

--- a/rust/zingomobile_utils/src/lib.rs
+++ b/rust/zingomobile_utils/src/lib.rs
@@ -1,6 +1,18 @@
 use std::process::Command;
 
-pub fn android_integration_test(abi: &str, test_name: &str) -> (i32, String, String) {
+/// Runs one on-device instrumented test class.
+///
+/// `activation_heights` is the launched regtest chain's schedule in the
+/// harness's `key=height` spec form; `None` when the chain provisioner
+/// cannot report one (regchest). The script forwards it to the device as
+/// an instrumentation argument, from which the Kotlin side builds the
+/// wallet's `regtest:<schedule>` chain hint — so the wallet's schedule is
+/// derived from the chain that was actually launched, never assumed.
+pub fn android_integration_test(
+    abi: &str,
+    test_name: &str,
+    activation_heights: Option<&str>,
+) -> (i32, String, String) {
     let command: String;
     let arg: String;
     #[cfg(unix)]
@@ -15,9 +27,14 @@ pub fn android_integration_test(abi: &str, test_name: &str) -> (i32, String, Str
         arg = "/C".to_string();
     }
 
+    let mut process = Command::new(command);
+    process.arg(arg);
+    if let Some(heights) = activation_heights {
+        process.env("ACTIVATION_HEIGHTS", heights);
+    }
+
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
-    let output = Command::new(command)
-        .arg(arg)
+    let output = process
         .arg(format!(
             r#"
             cd $(git rev-parse --show-toplevel)
@@ -28,8 +45,7 @@ pub fn android_integration_test(abi: &str, test_name: &str) -> (i32, String, Str
         .expect("Failed to execute command");
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    let output = Command::new(command)
-        .arg(arg)
+    let output = process
         .arg(format!(
             r#"
             cd $(git rev-parse --show-toplevel)
@@ -47,7 +63,13 @@ pub fn android_integration_test(abi: &str, test_name: &str) -> (i32, String, Str
     (exit_code, stdout, stderr)
 }
 
-pub fn android_integration_test_ci(abi: &str, test_name: &str) -> (i32, String, String) {
+/// CI variant of [`android_integration_test`]; same activation-heights
+/// contract.
+pub fn android_integration_test_ci(
+    abi: &str,
+    test_name: &str,
+    activation_heights: Option<&str>,
+) -> (i32, String, String) {
     let command: String;
     let arg: String;
     #[cfg(unix)]
@@ -62,8 +84,13 @@ pub fn android_integration_test_ci(abi: &str, test_name: &str) -> (i32, String, 
         arg = "/C".to_string();
     }
 
-    let output = Command::new(command)
-        .arg(arg)
+    let mut process = Command::new(command);
+    process.arg(arg);
+    if let Some(heights) = activation_heights {
+        process.env("ACTIVATION_HEIGHTS", heights);
+    }
+
+    let output = process
         .arg(format!(
             r#"
             cd $(git rev-parse --show-toplevel)

--- a/scripts/android_integration_tests.sh
+++ b/scripts/android_integration_tests.sh
@@ -346,8 +346,17 @@ else
     adb -s emulator-5554 shell mkdir -p "/sdcard/Android/media/org.ZingoLabs.Zingo/additional_test_output"
 
     echo -e "\nRunning integration tests..."
+    # The launched chain's activation-heights spec, exported by the host
+    # test harness; the on-device tests build their regtest chain hint
+    # from it.
+    activation_heights_args=()
+    if [ -n "${ACTIVATION_HEIGHTS:-}" ]; then
+        activation_heights_args=(-e activation_heights "${ACTIVATION_HEIGHTS}")
+    fi
+
     adb -s emulator-5554 shell am instrument -w -r -e class org.ZingoLabs.Zingo.$test_name \
         -e additionalTestOutputDir /sdcard/Android/media/org.ZingoLabs.Zingo/additional_test_output \
+        "${activation_heights_args[@]}" \
         -e testTimeoutSeconds 31536000 org.ZingoLabs.Zingo.test/androidx.test.runner.AndroidJUnitRunner \
         | tee "${test_report_dir}/test_results.txt"
 

--- a/scripts/ci/android_integration_tests_ci.sh
+++ b/scripts/ci/android_integration_tests_ci.sh
@@ -119,8 +119,16 @@ adb -s emulator-5554 shell mkdir -p "/sdcard/Android/media/org.ZingoLabs.Zingo/a
 
 echo -e "\nRunning integration tests..."
 nohup yarn start &> "${test_report_dir}/metro.txt" &
+# The launched chain's activation-heights spec, exported by the host test
+# harness; the on-device tests build their regtest chain hint from it.
+activation_heights_args=()
+if [ -n "${ACTIVATION_HEIGHTS:-}" ]; then
+    activation_heights_args=(-e activation_heights "${ACTIVATION_HEIGHTS}")
+fi
+
 adb -s emulator-5554 shell am instrument -w -r -e class org.ZingoLabs.Zingo.$test_name \
     -e additionalTestOutputDir /sdcard/Android/media/org.ZingoLabs.Zingo/additional_integration_test_output \
+    "${activation_heights_args[@]}" \
     -e testTimeoutSeconds 31536000 org.ZingoLabs.Zingo.test/androidx.test.runner.AndroidJUnitRunner \
     | tee "${test_report_dir}/test_results.txt"
 


### PR DESCRIPTION
The deterministic integration failures on this branch (`execute_send_from_orchard`, and the send-dependent part of the ledger tests) root-cause to a schedule disagreement: the FFI hardcodes `ActivationHeights::default()` (every upgrade at height 1) for regtest wallets, while the zebrad fixture activates NU6.3 at height 5. In the pre-activation window the wallet derives the Ironwood consensus branch ID, and zebrad rejects every transaction it authors — `"transaction uses an incorrect consensus branch id"`, visible in the send test's logcat while `propose` succeeds and the balance never moves.

This PR brings the mobile wallet under the standard the rest of the ecosystem already follows (infrastructure ADR 0003: the running validator is the sole authority on regtest heights; zcash-devtool receives them via a harness-written artifact, zainod adoption is tracked as zaino#1076):

- **`feat(ffi)`**: the chain hint accepts `regtest:<schedule>` (comma-separated `key=height` entries, harness convention, `off` for unscheduled, unknown keys rejected loudly). Bare `"regtest"`, `"main"`, and `"test"` behavior is byte-identical, and there are no uniffi signature changes — the same shipped library serves app and harness.
- **`fix(harness)`**: the host tests read the schedule back from the running validator (`Validator::get_activation_heights()`, a live `getblockchaininfo` query) and thread it through the runner scripts (`ACTIVATION_HEIGHTS` env var), the instrumentation arguments (`-e activation_heights`), and the extended hint. `rust/android` gains a dev-dependency on `zcash_local_net` at the same infrastructure rev zingolib pins; pin drift fails compilation loudly. The regchest path passes no schedule (no validator to query) pending its excision.
- Also carried: `test: update the sapling-balance ledger for the Ironwood pool` — the host-authored scenario transactions land post-activation and distribute into the Ironwood pool; the expectations now count it (values read from a passing sync, see the commit message).
- Also carried: `docs: record ADR 0001, shield and change outputs prefer Ironwood` — the wallet-policy decision underlying the ledger change, recorded in the repo's new `docs/adr/`.

Verified: `cargo check --workspace --tests` (default and `ci` features), clippy clean, `rustfmt` clean on touched files, six new parser unit tests green, `compileBetaDebugAndroidTestKotlin` green, `bash -n` on both scripts. The on-emulator proof is this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
