### PR TITLE
ci: relieve the iOS runner-pool queueing

### DIFF
--- a/.github/workflows/ios-build.yaml
+++ b/.github/workflows/ios-build.yaml
@@ -59,6 +59,21 @@ jobs:
         with:
           repository: ${{ env.REPO-OWNER }}/zingo-mobile
 
+      # CARGO_HOME is workspace-relative (see env above), so these paths cover
+      # the registry, git checkouts, and the release artifacts for all three
+      # iOS targets. Keyed on the lockfile; the prefix fallback keeps stale
+      # caches useful after a zingolib rev bump.
+      - name: Cargo cache (registry, git, iOS targets)
+        uses: actions/cache@v6
+        with:
+          path: |
+            .cargo/registry
+            .cargo/git
+            rust/target
+          key: ios-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ios-cargo-
+
       - name: Cargo update for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}
         run: |

--- a/.github/workflows/ios-integration-test.yaml
+++ b/.github/workflows/ios-integration-test.yaml
@@ -13,7 +13,11 @@ env:
 
 jobs:
   build-for-testing:
-    runs-on: zingo-ios-build-12
+    # Stock runners, deliberately: the huge macos-15 fleet queues in seconds,
+    # while the max-4 zingo-ios-build-12 pool is left to the xcframework
+    # build alone. The xcodebuild destination pins no arch (see the
+    # build-for-testing step), so Apple-silicon stock runners are fine.
+    runs-on: macos-15
     steps:
       - name: Xcode 16.4
         uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
The first green run on the new runner pools (29968686825) showed the Android pipeline down to roughly 35 minutes with negligible queueing, while the two iOS jobs waited 40 and 94 minutes for the two Intel larger-runner slots — nearly the entire 2h53m wall clock was macOS queue time, aggravated by overlapping runs contending for one small pool.

This PR relieves that from both ends. The build-for-testing job moves to the stock macos-15 fleet, which queued in seconds all day and is safe for this job since the xcodebuild destination pins no architecture and the xcframework's simulator slice is a fat arm64+x86_64 binary. The xcframework build keeps the 12-core Intel pool to itself and gains a cargo cache (registry, git checkouts, and the release target directory, keyed on the lockfile with a prefix fallback), converting its cold 18-minute cargo build into an incremental rebuild on the cache-miss runs where the job actually executes.

The pool's maximum concurrency was separately raised from 2 to 4 in the org runner settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)