### PR TITLE
ci: cut the PR pipeline to the fast path

### DIFF
--- a/.github/workflows/android-apk-build.yaml
+++ b/.github/workflows/android-apk-build.yaml
@@ -1,0 +1,117 @@
+name: Android APK build
+
+# Assembles the app and androidTest APKs once per ABI, downstream of the
+# native android-build. Extracted from the integration-test workflow so the
+# ~14-minute Gradle assembly runs once per ABI instead of once per test
+# matrix configuration.
+
+on:
+  workflow_call:
+    inputs:
+      cache-key:
+        required: true
+        type: string
+      abi:
+        required: true
+        type: string
+
+env:
+  REPO-OWNER: ${{ github.repository_owner }}
+  ABI: ${{ inputs.abi }}
+
+jobs:
+  android-apk-build:
+    name: Android APK build
+    runs-on: zingo-android-gradle-16
+    env:
+      RUSTFLAGS: -D warnings
+      CACHE-KEY: ${{ inputs.cache-key }}
+
+    steps:
+      - name: Set envs for zingolib CI
+        if: ${{ contains(github.repository, 'zingolib') }}
+        run: echo "REPO-OWNER=zingolabs" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ env.REPO-OWNER }}/zingo-mobile
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Gradle setup cache (read/write)
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
+
+      - name: Native rust cache
+        uses: actions/cache/restore@v6
+        with:
+          path: android/app/src/main/jniLibs/${{ env.ABI }}
+          key: native-android-uniffi-${{ env.ABI }}-${{ env.CACHE-KEY }}
+          fail-on-cache-miss: true
+
+      - name: Kotlin uniffi cache
+        uses: actions/cache/restore@v6
+        with:
+          path: android/app/build/generated/source/uniffi/release/java/uniffi/zingo
+          key: kotlin-android-uniffi-${{ env.ABI }}-${{ env.CACHE-KEY }}
+          fail-on-cache-miss: true
+
+      - name: Remove unnecessary directories to free up space
+        run: |
+          set -eux
+          echo "Disk space before cleanup:"
+          df -h
+
+          sudo apt-get update
+
+          sudo apt-get remove -y '^dotnet-.*' || true
+          sudo apt-get remove -y 'php.*' || true
+          sudo apt-get remove -y '^mongodb-.*' || true
+          sudo apt-get remove -y '^mysql-.*' || true
+          sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri || true
+          sudo apt-get autoremove -y || true
+          sudo apt-get clean || true
+
+          sudo rm -rf /usr/local/graalvm/
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet /etc/mysql /etc/php /etc/apt/sources.list.d
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+
+          podman image prune --all --force || true
+          podman system prune --all --force || true
+
+          echo "Disk space after cleanup:"
+          df -h
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.18.0
+          cache: yarn
+
+      - name: Yarn install
+        run: yarn
+
+      - name: Run Build
+        working-directory: android
+        run: ./gradlew assembleProdRelease assembleProdReleaseAndroidTest -DtestBuildType=release -PsplitApk=true
+
+      - name: Upload Android build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-build-outputs-${{ env.ABI }}-${{ env.CACHE-KEY }}
+          path: |
+            android/app/build/outputs
+          retention-days: 3

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -133,6 +133,7 @@ jobs:
         with:
           name: kotlin-android-uniffi-${{ env.ARCH }}-${{ env.CACHE-KEY }}
           path: android/app/build/generated/source/uniffi/release/java/uniffi/zingo/zingo.kt
+          retention-days: 3
 
       - name: Set envs for x86_64
         if: ${{ env.ARCH == 'x86_64' }}
@@ -202,6 +203,7 @@ jobs:
         with:
           name: native-android-uniffi-${{ env.ARCH }}-${{ env.CACHE-KEY }}
           path: rust/target/${{ env.TARGET }}/release/libuniffi_zingo.so
+          retention-days: 3
 
   cache-native-android-uniffi:
     name: Cache native rust

--- a/.github/workflows/android-ubuntu-integration-test-ci.yaml
+++ b/.github/workflows/android-ubuntu-integration-test-ci.yaml
@@ -113,121 +113,27 @@ jobs:
             ~/.android/adb*
           key: avd-${{ env.ABI }}-api-${{ env.API-LEVEL }}-integ
 
-  android-ubuntu-build:
-    name: Android Ubuntu Build
-    runs-on: zingo-android-gradle-16
-    env:
-      RUSTFLAGS: -D warnings
-      CACHE-KEY: ${{ inputs.cache-key }}
-
-    steps:
-      - name: Set envs for zingolib CI
-        if: ${{ contains(github.repository, 'zingolib') }}
-        run: echo "REPO-OWNER=zingolabs" >> $GITHUB_ENV
-
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          repository: ${{ env.REPO-OWNER }}/zingo-mobile
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Gradle setup cache (read/write)
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          gradle-version: wrapper
-          cache-read-only: false
-
-      - name: Native rust cache
-        uses: actions/cache/restore@v6
-        with:
-          path: android/app/src/main/jniLibs/${{ env.ABI }}
-          key: native-android-uniffi-${{ env.ABI }}-${{ env.CACHE-KEY }}
-          fail-on-cache-miss: true
-
-      - name: Kotlin uniffi cache
-        uses: actions/cache/restore@v6
-        with:
-          path: android/app/build/generated/source/uniffi/release/java/uniffi/zingo
-          key: kotlin-android-uniffi-${{ env.ABI }}-${{ env.CACHE-KEY }}
-          fail-on-cache-miss: true
-
-      - name: Remove unnecessary directories to free up space
-        run: |
-          set -eux
-          echo "Disk space before cleanup:"
-          df -h
-
-          sudo apt-get update
-
-          sudo apt-get remove -y '^dotnet-.*' || true
-          sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y '^mongodb-.*' || true
-          sudo apt-get remove -y '^mysql-.*' || true
-          sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri || true
-          sudo apt-get autoremove -y || true
-          sudo apt-get clean || true
-
-          sudo rm -rf /usr/local/graalvm/
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/local/share/chromium
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android/sdk/ndk
-          sudo rm -rf /usr/share/dotnet /etc/mysql /etc/php /etc/apt/sources.list.d
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-
-          podman image prune --all --force || true
-          podman system prune --all --force || true
-
-          echo "Disk space after cleanup:"
-          df -h
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.18.0
-          cache: yarn
-
-      - name: Yarn install
-        run: yarn
-
-      - name: Run Build
-        working-directory: android
-        run: ./gradlew assembleProdRelease assembleProdReleaseAndroidTest -DtestBuildType=release -PsplitApk=true
-
-      - name: Upload Android build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: android-build-outputs-${{ env.ABI }}-${{ env.CACHE-KEY }}
-          path: |
-            android/app/build/outputs
-
+  # The app and androidTest APKs are assembled once per ABI by the
+  # android-apk-build workflow at the caller level; this workflow only
+  # consumes its android-build-outputs artifact.
   android-ubuntu-integration-test-ci:
     name: Android Ubuntu Integration test
-    needs: 
+    needs:
       - android-ubuntu-integration-test-ci-avd-cache
-      - android-ubuntu-build
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      # Buckets of three tests share one job, so the runner setup and
+      # emulator boot amortize across the bucket instead of being paid
+      # once per test.
       matrix:
-        test: [
-          "execute_version_from_seed",
-          "execute_addresses_from_ufvk",
-          "execute_addresses_from_seed",
-          "execute_sync_from_seed",
-          "execute_send_from_orchard",
-          "execute_currentprice_and_value_transfers_from_seed",
-          "execute_sapling_balance_from_seed",
-          "execute_parse_address_for_tex",
-          "execute_parse_address_invalid"
-        ]
+        bucket:
+          - name: accounts
+            tests: execute_version_from_seed execute_addresses_from_ufvk execute_addresses_from_seed
+          - name: chain
+            tests: execute_sync_from_seed execute_send_from_orchard execute_currentprice_and_value_transfers_from_seed
+          - name: ledger-and-parsing
+            tests: execute_sapling_balance_from_seed execute_parse_address_for_tex execute_parse_address_invalid
     env:
       RUSTFLAGS: -D warnings
       CACHE-KEY: ${{ inputs.cache-key }}
@@ -431,7 +337,15 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
           disable-animations: true
-          script: cargo nextest run android_integration::${{ env.NEXTEST-ABI }}::${{ matrix.test }} --features "ci" --verbose --release
+          # KEEP_EMULATORS: the per-test runner script must not shut the
+          # emulator down between the bucket's tests — this action boots
+          # it once for the whole bucket and tears it down afterwards.
+          script: |
+            tests=""
+            for t in ${{ matrix.bucket.tests }}; do
+              tests="$tests android_integration::${{ env.NEXTEST-ABI }}::$t"
+            done
+            KEEP_EMULATORS=1 cargo nextest run $tests --features "ci" --verbose --release
           working-directory: ./rust
         env:
           TEST_BINARIES_DIR: ${{ env.TEST_BINARIES_DIR }}
@@ -440,5 +354,6 @@ jobs:
         if: ${{ always() && !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: test-android-integration-reports-${{ env.ABI }}-${{ matrix.test }}-${{ env.TIMESTAMP }}
+          name: test-android-integration-reports-${{ env.ABI }}-${{ matrix.bucket.name }}-${{ env.TIMESTAMP }}
           path: android/app/build/outputs/integration_test_reports
+          retention-days: 7

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -27,6 +27,17 @@ jobs:
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
       arch: ${{ matrix.arch }}
 
+  android-apk-build:
+    strategy:
+      matrix:
+        abi: [ x86_64, x86 ]
+      fail-fast: false
+    uses: ./.github/workflows/android-apk-build.yaml
+    needs: [create-cache-key, android-build]
+    with:
+      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
+      abi: ${{ matrix.abi }}
+
   android-ubuntu-integration-test-ci:
     strategy:
       matrix:
@@ -35,7 +46,7 @@ jobs:
           - { abi: x86, api-level: 29, target: default }
       fail-fast: false
     uses: ./.github/workflows/android-ubuntu-integration-test-ci.yaml
-    needs: [create-timestamp, create-cache-key, android-build]
+    needs: [create-timestamp, create-cache-key, android-apk-build]
     secrets: inherit
     with:
       timestamp: ${{ needs.create-timestamp.outputs.timestamp }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,24 +34,33 @@ jobs:
   create-cache-key:
     uses: ./.github/workflows/create-cache-key.yaml
 
+  # PR CI covers the primary target only (x86_64 / API 34). The full ABI
+  # matrix, the x86 / API 29 lane, and the whole iOS pipeline — whose
+  # macOS-runner queue dominated PR wall-clock — run on ci-nightly.
   android-build:
     strategy:
       matrix:
-        arch: [ x86_64, x86, arm64-v8a, armeabi-v7a ]
+        arch: [ x86_64 ]
     uses: ./.github/workflows/android-build.yaml
     needs: create-cache-key
     with:
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
       arch: ${{ matrix.arch }}
 
+  android-apk-build:
+    uses: ./.github/workflows/android-apk-build.yaml
+    needs: [create-cache-key, android-build]
+    with:
+      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
+      abi: x86_64
+
   android-ubuntu-integration-test-ci:
     strategy:
       matrix:
         config:
           - { abi: x86_64, api-level: 34, target: default }
-          - { abi: x86, api-level: 29, target: default }
     uses: ./.github/workflows/android-ubuntu-integration-test-ci.yaml
-    needs: [create-timestamp, create-cache-key, android-build]
+    needs: [create-timestamp, create-cache-key, android-apk-build]
     secrets: inherit
     with:
       timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
@@ -59,16 +68,3 @@ jobs:
       abi: ${{ matrix.config.abi }}
       api-level: ${{ matrix.config['api-level'] }}
       target: ${{ matrix.config.target }}
-
-  ios-build:
-    uses: ./.github/workflows/ios-build.yaml
-    needs: create-cache-key
-    with:
-      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
-
-  ios-integration-test:
-    uses: ./.github/workflows/ios-integration-test.yaml
-    needs: [create-cache-key, ios-build]
-    secrets: inherit
-    with:
-      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}

--- a/.github/workflows/ios-build.yaml
+++ b/.github/workflows/ios-build.yaml
@@ -128,6 +128,7 @@ jobs:
           path: |
             ios/Zingolib.xcframework
             ios/zingo.swift
+          retention-days: 3
 
   cache-native-ios-uniffi:
     name: Cache iOS xcframework

--- a/.github/workflows/ios-integration-test.yaml
+++ b/.github/workflows/ios-integration-test.yaml
@@ -88,6 +88,7 @@ jobs:
         with:
           name: xctestrun-and-products
           path: ios/build/DerivedData/Build/Products
+          retention-days: 3
 
       - name: Upload IOS build reports (.xcresult)
         if: ${{ always() && !cancelled() }}

--- a/scripts/ci/android_integration_tests_ci.sh
+++ b/scripts/ci/android_integration_tests_ci.sh
@@ -66,10 +66,17 @@ fi
 
 cd android
 
-# Create integration test report directory
-test_report_dir="app/build/outputs/integration_test_reports/${abi}"
+# Create integration test report directory. Keyed by test name as well as
+# ABI so tests sharing one emulator session (bucketed CI jobs) do not
+# overwrite each other's reports.
+test_report_dir="app/build/outputs/integration_test_reports/${abi}/${test_name}"
 rm -rf "${test_report_dir}"
 mkdir -p "${test_report_dir}"
+
+# A clean slate for this test's app state: the emulator may be carrying a
+# previous test's wallet data when several tests share one session.
+adb -s emulator-5554 uninstall org.ZingoLabs.Zingo &> /dev/null || true
+adb -s emulator-5554 uninstall org.ZingoLabs.Zingo.test &> /dev/null || true
 
 echo -e "\nInstalling Test APK..."
 i=0
@@ -140,17 +147,24 @@ fi
 
 echo -e "\nTest reports saved: android/${test_report_dir}"
     
+# When several tests share one emulator session (bucketed CI jobs), the
+# session's owner — the workflow's emulator runner — does the teardown;
+# KEEP_EMULATORS tells this per-test script to leave the emulator alive.
 if [[ $(cat "${test_report_dir}/test_results.txt" | grep INSTRUMENTATION_CODE | cut -d' ' -f2) -ne -1 || \
         $(cat "${test_report_dir}/test_results.txt" | grep 'FAILURES!!!') ]]; then
     echo -e "\nIntegration tests FAILED"
 
-    # Kill all emulators
-    ../scripts/kill_emulators.sh
+    if [ -z "${KEEP_EMULATORS:-}" ]; then
+        # Kill all emulators
+        ../scripts/kill_emulators.sh
+    fi
 
     exit 1
 fi
 
 echo -e "\nIntegration tests PASSED"
 
-# Kill all emulators
-../scripts/kill_emulators.sh
+if [ -z "${KEEP_EMULATORS:-}" ]; then
+    # Kill all emulators
+    ../scripts/kill_emulators.sh
+fi


### PR DESCRIPTION
Implements the five optimizations from the CI audit of run 29968686825 (PR #1168), where the Android checks finished in 37 minutes but macOS-runner queues (40m + 94m) stretched the run past three hours.

1. **iOS moves to nightly.** `ci.yaml` drops `ios-build`/`ios-integration-test`; `ci-nightly.yaml` already runs both. PR wall-clock is no longer hostage to the macOS queue.
2. **The two-stage Android build collapses.** The ~14-minute Gradle APK assembly is extracted from the integration workflow into a new `android-apk-build` reusable workflow, called once per ABI at the caller level instead of once per matrix configuration.
3. **The test matrix is bucketed.** Three buckets of three tests (`accounts`, `chain`, `ledger-and-parsing`) instead of nine single-test jobs — one runner and one emulator boot per bucket. The per-test script gains `KEEP_EMULATORS` (the workflow's emulator runner owns teardown), per-test report directories, and an uninstall-first step so tests sharing a session neither clobber reports nor inherit wallet state.
4. **x86/API-29 demotes to nightly**, and the PR `android-build` matrix drops the arm targets nothing in PR CI consumes.
5. **Artifacts trim**: build artifacts expire in 3 days, test reports in 7 (was the 90-day default) — this covers the 631MB `xctestrun` bundle, the xcframework, and the per-ABI build outputs.

Expected PR CI shape after this: fast checks (≤12m) in parallel with native build (~6m) → APK build (~14m) → three test buckets (~20m each, parallel) — roughly **40 minutes end to end** with no macOS dependency. Nightly keeps the full matrix: all four ABIs, both emulator lanes, and the complete iOS pipeline.

All seven touched YAML files validate; the script passes `bash -n`. The proof of the bucketed emulator sharing is this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)