### PR TITLE
ci: run the bucket test filter as a single line

### DIFF
--- a/.github/workflows/android-ubuntu-integration-test-ci.yaml
+++ b/.github/workflows/android-ubuntu-integration-test-ci.yaml
@@ -343,12 +343,10 @@ jobs:
           # KEEP_EMULATORS: the per-test runner script must not shut the
           # emulator down between the bucket's tests — this action boots
           # it once for the whole bucket and tears it down afterwards.
-          script: |
-            tests=""
-            for t in ${{ matrix.bucket.tests }}; do
-              tests="$tests android_integration::${{ env.NEXTEST-ABI }}::$t"
-            done
-            KEEP_EMULATORS=1 cargo nextest run $tests --features "ci" --verbose --release
+          # One line only: the emulator-runner action executes each line
+          # of `script` as its own `sh -c`, so multi-line shell constructs
+          # never parse.
+          script: KEEP_EMULATORS=1 cargo nextest run $(for t in ${{ matrix.bucket.tests }}; do printf 'android_integration::${{ env.NEXTEST-ABI }}::%s ' "$t"; done) --features "ci" --verbose --release
           working-directory: ./rust
         env:
           TEST_BINARIES_DIR: ${{ env.TEST_BINARIES_DIR }}


### PR DESCRIPTION
PR #1168's first run of the bucketed integration matrix (#1201) failed in all three buckets with `sh: 1: Syntax error: end of file unexpected (expecting "done")`: `reactivecircus/android-emulator-runner` executes each line of its `script` input as a separate `sh -c`, so the multi-line for-loop assembling the nextest filters never parsed. The filter list is now a single-line command substitution, verified locally to expand to the intended `cargo nextest run android_integration::<abi>::<test> ...` invocation. A comment in the workflow records the one-line constraint so it does not regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)