### PR TITLE
ci: run iOS per-PR as a trailing advisory stage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,29 @@ jobs:
       abi: ${{ matrix.config.abi }}
       api-level: ${{ matrix.config['api-level'] }}
       target: ${{ matrix.config.target }}
+
+  # iOS runs per-PR as a trailing, advisory stage: it starts only after
+  # every blocking check has passed, so the fast path's verdict is never
+  # delayed by the macOS-runner queue and a red fast path skips iOS
+  # entirely. Advisory mode records iOS failures without failing the PR;
+  # ci-nightly remains the enforced iOS gate.
+  ios-build:
+    uses: ./.github/workflows/ios-build.yaml
+    needs:
+      - jest-test
+      - rust-shear
+      - js-depcheck
+      - android-dependency-analysis
+      - create-cache-key
+      - android-ubuntu-integration-test-ci
+    with:
+      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
+      advisory: true
+
+  ios-integration-test:
+    uses: ./.github/workflows/ios-integration-test.yaml
+    needs: [create-cache-key, ios-build]
+    secrets: inherit
+    with:
+      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
+      advisory: true

--- a/.github/workflows/ios-build.yaml
+++ b/.github/workflows/ios-build.yaml
@@ -6,6 +6,13 @@ on:
       cache-key:
         required: true
         type: string
+      advisory:
+        # Advisory mode: job failures are recorded but do not fail the
+        # caller, for runs where iOS is informational (per-PR CI) rather
+        # than a gate (nightly).
+        required: false
+        default: false
+        type: boolean
 
 env:
   CACHE-KEY: ${{ inputs.cache-key }}
@@ -14,6 +21,7 @@ env:
 jobs:
   ios-check-build-cache:
     name: Check build cache
+    continue-on-error: ${{ inputs.advisory }}
     runs-on: macos-15
     outputs:
       ios-cache-found: ${{ steps.ios-set-cache-found.outputs.ios-cache-found }}
@@ -45,6 +53,7 @@ jobs:
     name: Build iOS Rust xcframework
     needs: ios-check-build-cache
     if: ${{ needs.ios-check-build-cache.outputs.ios-cache-found != 'true' }}
+    continue-on-error: ${{ inputs.advisory }}
     runs-on: zingo-ios-build-12
     env:
       RUSTUP_HOME: ${{ github.workspace }}/.rustup
@@ -148,6 +157,7 @@ jobs:
   cache-native-ios-uniffi:
     name: Cache iOS xcframework
     needs: ios-build
+    continue-on-error: ${{ inputs.advisory }}
     runs-on: macos-15
     steps:
       - name: Set envs for zingolib CI

--- a/.github/workflows/ios-integration-test.yaml
+++ b/.github/workflows/ios-integration-test.yaml
@@ -6,6 +6,13 @@ on:
       cache-key:
         required: true
         type: string
+      advisory:
+        # Advisory mode: job failures are recorded but do not fail the
+        # caller, for runs where iOS is informational (per-PR CI) rather
+        # than a gate (nightly).
+        required: false
+        default: false
+        type: boolean
 
 env:
   CACHE-KEY: ${{ inputs.cache-key }}
@@ -13,6 +20,7 @@ env:
 
 jobs:
   build-for-testing:
+    continue-on-error: ${{ inputs.advisory }}
     # Stock runners, deliberately: the huge macos-15 fleet queues in seconds,
     # while the max-4 zingo-ios-build-12 pool is left to the xcframework
     # build alone. The xcodebuild destination pins no arch (see the


### PR DESCRIPTION
Restores iOS to per-PR CI with two constraints that preserve the fast path won in #1201:

- **After everything else**: `ios-build` `needs` every blocking check (jest, shear, depcheck, dependency-analysis, and the Android integration matrix), so the macOS-runner queue is entered only once the PR already has its verdict — and a red fast path skips iOS entirely instead of feeding the queue a doomed run.
- **Non-blocking**: both iOS reusable workflows gain an `advisory` input (default `false`) that applies `continue-on-error` to their jobs. Per-PR CI passes `advisory: true`, so iOS failures are recorded as annotations on the run without turning the PR red. `ci-nightly` passes nothing and stays the enforced iOS gate. (The input lives inside the reusable workflows because `continue-on-error` is not a supported keyword on caller jobs.)

One behavior to be aware of: with `continue-on-error`, a failed iOS job renders as green-with-annotation in the checks UI rather than red — the failure is visible in the run log and annotations, not the check list. That is the GitHub-native meaning of "non-blocking"; if a visibly-red-but-unrequired check is preferred instead, the alternative is dropping `continue-on-error` and relying on branch-protection required-checks configuration, which lives outside the repo.

All three YAML files validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)