### PR TITLE
ci: start integration buckets at launch behind an artifact gate, fail-all on PR

### DIFF
--- a/.github/workflows/android-apk-build.yaml
+++ b/.github/workflows/android-apk-build.yaml
@@ -14,6 +14,14 @@ on:
       abi:
         required: true
         type: string
+      # Fail-all (see CONTEXT.md): when true, a failure here cancels the
+      # whole run. PR CI opts in; ci-nightly does not. The PR integration
+      # buckets also watch this job through the ci-gate artifact gate, so
+      # they abort even if the cancellation races.
+      fail-all:
+        required: false
+        type: boolean
+        default: false
 
 env:
   REPO-OWNER: ${{ github.repository_owner }}
@@ -144,3 +152,14 @@ jobs:
           path: |
             android/app/build/outputs
           retention-days: 3
+
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });

--- a/.github/workflows/android-build.yaml
+++ b/.github/workflows/android-build.yaml
@@ -9,6 +9,12 @@ on:
       arch:
         required: true
         type: string
+      # Fail-all (see CONTEXT.md): when true, a failure in any job here
+      # cancels the whole run. PR CI opts in; ci-nightly does not.
+      fail-all:
+        required: false
+        type: boolean
+        default: false
 
 env:
   CACHE-KEY: ${{ inputs.cache-key }}
@@ -55,6 +61,17 @@ jobs:
       - name: Set cache-found
         id: kotlin-set-cache-found
         run: echo "kotlin-cache-found=${{ steps.kotlin-check-build-cache.outputs.cache-hit }}" >> $GITHUB_OUTPUT
+
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
 
   android-build:
     name: Build native rust & kotlin uniffi
@@ -205,6 +222,17 @@ jobs:
           path: rust/target/${{ env.TARGET }}/release/libuniffi_zingo.so
           retention-days: 3
 
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+
   cache-native-android-uniffi:
     name: Cache native rust
     needs: android-build
@@ -242,3 +270,14 @@ jobs:
         with:
           path: android/app/build/generated/source/uniffi/release/java/uniffi/zingo
           key: kotlin-android-uniffi-${{ env.ARCH }}-${{ env.CACHE-KEY }}
+
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });

--- a/.github/workflows/android-dependency-analysis.yaml
+++ b/.github/workflows/android-dependency-analysis.yaml
@@ -2,6 +2,13 @@ name: Android dependency analysis
 
 on:
   workflow_call:
+    inputs:
+      # Fail-all (see CONTEXT.md): when true, a failure here cancels the
+      # whole run. PR CI opts in; ci-nightly does not.
+      fail-all:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   android-dependency-analysis:
@@ -44,3 +51,14 @@ jobs:
       - name: Dependency analysis
         working-directory: ./android
         run: ./gradlew buildHealth
+
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });

--- a/.github/workflows/android-ubuntu-integration-test-ci.yaml
+++ b/.github/workflows/android-ubuntu-integration-test-ci.yaml
@@ -18,6 +18,13 @@ on:
       target:
         required: true
         type: string
+      # Fail-all (see CONTEXT.md): when true, the first failure here
+      # cancels the whole run, and the bucket matrix fails fast. PR CI
+      # opts in; ci-nightly keeps the complete-signal default.
+      fail-all:
+        required: false
+        type: boolean
+        default: false
 
 env:
   REPO-OWNER: ${{ github.repository_owner }}
@@ -116,16 +123,33 @@ jobs:
             ~/.android/adb*
           key: avd-${{ env.ABI }}-api-${{ env.API-LEVEL }}-integ
 
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+
   # The app and androidTest APKs are assembled once per ABI by the
   # android-apk-build workflow at the caller level; this workflow only
-  # consumes its android-build-outputs artifact.
+  # consumes its android-build-outputs artifact. PR CI calls this
+  # workflow WITHOUT a needs-edge on the APK build: the buckets start at
+  # workflow launch, run every APK-independent step (setup, harness
+  # prebuild, regtest binaries), and then hold at the ci-gate artifact
+  # gate until the APK artifact lands — overlapping ~10 minutes of setup
+  # with the build path. ci-nightly keeps its needs-edge, so there the
+  # gate opens instantly.
   android-ubuntu-integration-test-ci:
     name: Android Ubuntu Integration test
     needs:
       - android-ubuntu-integration-test-ci-avd-cache
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      fail-fast: ${{ inputs.fail-all }}
       # Buckets of three tests share one job, so the runner setup and
       # emulator boot amortize across the bucket instead of being paid
       # once per test.
@@ -263,12 +287,6 @@ jobs:
       - name: Yarn install
         run: yarn
 
-      - name: Download Android build outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: android-build-outputs-${{ env.ABI }}-${{ env.CACHE-KEY }}
-          path: android/app/build/outputs
-
       # Resolve the zingolib commit the same way android-build does: the
       # GITHUB_SHA under zingolib CI, otherwise the pinned rev in
       # rust/Cargo.toml. The ci-build image tag is content-addressed from
@@ -331,6 +349,31 @@ jobs:
           TEST_BINARIES_DIR="$(pwd)/rust/test_binaries/bins"
           echo "TEST_BINARIES_DIR=$TEST_BINARIES_DIR" >> "$GITHUB_ENV"
 
+      # Compile the nextest harness while the APK build is still running;
+      # the emulator step then reuses the warm target directory.
+      - name: Prebuild test harness
+        working-directory: ./rust
+        run: cargo nextest run --no-run --features ci --release
+
+      # Everything above needs nothing from the APK build. Hold here
+      # until its artifact lands; abort promptly if it can never land.
+      - name: Wait for the APK artifact (ci-gate)
+        working-directory: ./rust
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cargo run -p workbench --bin ci-gate -- \
+            --artifact "android-build-outputs-${{ env.ABI }}-${{ env.CACHE-KEY }}" \
+            --upstream "Android APK build" \
+            --timeout-secs 2700 \
+            --poll-secs 20
+
+      - name: Download Android build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: android-build-outputs-${{ env.ABI }}-${{ env.CACHE-KEY }}
+          path: android/app/build/outputs
+
       - name: Run Android Integration Test
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -358,3 +401,14 @@ jobs:
           name: test-android-integration-reports-${{ env.ABI }}-${{ matrix.bucket.name }}-${{ env.TIMESTAMP }}
           path: android/app/build/outputs/integration_test_reports
           retention-days: 7
+
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,20 +13,39 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# actions: write lets the fail-all steps in the blocking jobs cancel this
+# run, and lets ci-gate read the run's artifact and job listings. Fork
+# PRs get a read-only token regardless; there the cancel step fails
+# harmlessly inside an already-failing job.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
+  # Every blocking check opts into fail-all: its first failure cancels
+  # the whole run (see CONTEXT.md). Nightly leaves fail-all off to keep
+  # the complete picture.
   jest-test:
     uses: ./.github/workflows/jest-test.yaml
     secrets: inherit
+    with:
+      fail-all: true
 
   rust-shear:
     uses: ./.github/workflows/rust-shear.yaml
+    with:
+      fail-all: true
 
   js-depcheck:
     uses: ./.github/workflows/js-depcheck.yaml
+    with:
+      fail-all: true
 
   android-dependency-analysis:
     uses: ./.github/workflows/android-dependency-analysis.yaml
     secrets: inherit
+    with:
+      fail-all: true
 
   create-timestamp:
     uses: ./.github/workflows/create-timestamp.yaml
@@ -46,6 +65,7 @@ jobs:
     with:
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
       arch: ${{ matrix.arch }}
+      fail-all: true
 
   android-apk-build:
     uses: ./.github/workflows/android-apk-build.yaml
@@ -53,14 +73,20 @@ jobs:
     with:
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
       abi: x86_64
+      fail-all: true
 
+  # Deliberately NO needs-edge on android-apk-build: the buckets start
+  # at workflow launch, front-load all APK-independent setup, and hold
+  # at the ci-gate artifact gate until the APK artifact lands (or abort
+  # when the APK build concludes without success). This overlaps ~10
+  # minutes of bucket setup with the build path.
   android-ubuntu-integration-test-ci:
     strategy:
       matrix:
         config:
           - { abi: x86_64, api-level: 34, target: default }
     uses: ./.github/workflows/android-ubuntu-integration-test-ci.yaml
-    needs: [create-timestamp, create-cache-key, android-apk-build]
+    needs: [create-timestamp, create-cache-key]
     secrets: inherit
     with:
       timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
@@ -68,6 +94,7 @@ jobs:
       abi: ${{ matrix.config.abi }}
       api-level: ${{ matrix.config['api-level'] }}
       target: ${{ matrix.config.target }}
+      fail-all: true
 
   # iOS runs per-PR as a trailing, advisory stage: it starts only after
   # every blocking check has passed, so the fast path's verdict is never

--- a/.github/workflows/jest-test.yaml
+++ b/.github/workflows/jest-test.yaml
@@ -2,6 +2,13 @@ name: Jest test
 
 on:
   workflow_call:
+    inputs:
+      # Fail-all (see CONTEXT.md): when true, a failure here cancels the
+      # whole run. PR CI opts in; ci-nightly does not.
+      fail-all:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   jest-test:
@@ -31,4 +38,15 @@ jobs:
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
+
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
 

--- a/.github/workflows/js-depcheck.yaml
+++ b/.github/workflows/js-depcheck.yaml
@@ -2,6 +2,13 @@ name: JS unused dependencies
 
 on:
   workflow_call:
+    inputs:
+      # Fail-all (see CONTEXT.md): when true, a failure here cancels the
+      # whole run. PR CI opts in; ci-nightly does not.
+      fail-all:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   js-depcheck:
@@ -23,3 +30,14 @@ jobs:
       # Known false positives are recorded, with reasons, in .depcheckrc.yml.
       - name: Check for unused dependencies
         run: yarn depcheck
+
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });

--- a/.github/workflows/rust-shear.yaml
+++ b/.github/workflows/rust-shear.yaml
@@ -2,6 +2,13 @@ name: Rust unused dependencies
 
 on:
   workflow_call:
+    inputs:
+      # Fail-all (see CONTEXT.md): when true, a failure here cancels the
+      # whole run. PR CI opts in; ci-nightly does not.
+      fail-all:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   rust-shear:
@@ -20,3 +27,14 @@ jobs:
       - name: Check for unused dependencies
         working-directory: ./rust
         run: cargo shear
+
+      - name: Cancel the run on failure (fail-all)
+        if: ${{ failure() && inputs.fail-all }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,35 @@
+# Context
+
+A glossary of the ubiquitous language of this repository. Terms are added
+as they are resolved in design discussions; each entry states what the
+term means here, and, where useful, what it does not mean.
+
+## CI
+
+**Blocking check** — a PR CI job whose failure fails the pull request.
+Jest, rust-shear, js-depcheck, android-dependency-analysis, the Android
+build chain, and the Android integration buckets are blocking checks.
+
+**Advisory stage** — a PR CI job that records its result without
+affecting the pull request verdict. The per-PR iOS pipeline is an
+advisory stage; ci-nightly remains the enforced iOS gate.
+
+**Verdict path** — the longest chain of blocking checks; its wall-clock
+length is the time from push to PR verdict. Advisory stages are never on
+the verdict path.
+
+**Bucket** — a group of Android integration tests that share one CI job,
+so runner setup and emulator boot amortize across the group instead of
+being paid once per test.
+
+**Fail-all** — the policy that the first failure of any blocking check
+cancels the entire run at once, rather than letting the surviving checks
+run to completion for diagnostic completeness. Under fail-all, one red
+run reports the first failure found, not necessarily every failure
+present.
+
+**Artifact gate** — a step inside a job that waits for a named artifact
+from an upstream job in the same run, instead of a `needs:` edge between
+the jobs. It lets a job front-load work that does not depend on the
+artifact, and it must abort promptly with a clear message when the
+upstream job that produces the artifact concludes without success.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4557,6 +4557,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "workbench"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["lib", "android", "ios", "zingomobile_utils"]
+members = ["lib", "android", "ios", "zingomobile_utils", "workbench"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/rust/android/tests/integration_tests.rs
+++ b/rust/android/tests/integration_tests.rs
@@ -325,23 +325,21 @@ async fn execute_sapling_balance_from_seed(abi: &str) {
 }
 
 async fn execute_parse_address_for_tex(abi: &str) {
+    // Address parsing only needs a reachable server with nonzero height,
+    // so the cheap scenario suffices; the multi-pool funded scenario
+    // costs ~150s more of regtest setup per test.
     #[cfg(not(feature = "regchest"))]
-    let local_net =
-        scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
+    let local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(not(feature = "regchest"))]
     let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
     #[cfg(feature = "regchest")]
     let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        UNIX_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-    };
+    let docker =
+        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
+            Ok(d) => d,
+            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
+        };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) = zingomobile_utils::android_integration_test(
@@ -370,23 +368,21 @@ async fn execute_parse_address_for_tex(abi: &str) {
 }
 
 async fn execute_parse_address_invalid(abi: &str) {
+    // Address parsing only needs a reachable server with nonzero height,
+    // so the cheap scenario suffices; the multi-pool funded scenario
+    // costs ~150s more of regtest setup per test.
     #[cfg(not(feature = "regchest"))]
-    let local_net =
-        scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
+    let local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(not(feature = "regchest"))]
     let activation_heights = Some(validator_activation_heights(local_net.validator()).await);
     #[cfg(feature = "regchest")]
     let activation_heights: Option<String> = None;
     #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        UNIX_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-    };
+    let docker =
+        match regchest_utils::launch(UNIX_SOCKET, Some("funded_orchard_mobileclient")).await {
+            Ok(d) => d,
+            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
+        };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) = zingomobile_utils::android_integration_test(

--- a/rust/ios/tests/integration_tests.rs
+++ b/rust/ios/tests/integration_tests.rs
@@ -11,14 +11,13 @@ const MAC_SOCKET: Option<&str> = Some("unix:///Users/runner/.colima/default/dock
 
 async fn execute_version_from_seed() {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let docker = match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await
+    {
+        Ok(d) => d,
+        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
+    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -42,14 +41,13 @@ async fn execute_version_from_seed() {
 
 async fn execute_addresses_from_ufvk() {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let docker = match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await
+    {
+        Ok(d) => d,
+        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
+    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -73,14 +71,13 @@ async fn execute_addresses_from_ufvk() {
 
 async fn execute_addresses_from_seed() {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let docker = match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await
+    {
+        Ok(d) => d,
+        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
+    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -104,14 +101,13 @@ async fn execute_addresses_from_seed() {
 
 async fn execute_sync_from_seed() {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let docker = match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await
+    {
+        Ok(d) => d,
+        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
+    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -135,14 +131,13 @@ async fn execute_sync_from_seed() {
 
 async fn execute_send_from_orchard() {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_mobileclient(1_000_000).await;
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(feature = "regchest")]
-    let docker =
-        match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await {
-            Ok(d) => d,
-            Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
-        };
+    let docker = match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await
+    {
+        Ok(d) => d,
+        Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
+    };
 
     #[cfg(not(feature = "ci"))]
     let (exit_code, output, error) =
@@ -166,8 +161,7 @@ async fn execute_send_from_orchard() {
 
 async fn execute_currentprice_and_value_transfers_from_seed() {
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_with_3_txs_mobileclient(1_000_000).await;
+    let _local_net = scenarios::funded_orchard_with_3_txs_mobileclient(1_000_000).await;
     #[cfg(feature = "regchest")]
     let docker =
         match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_with_3_txs_mobileclient"))
@@ -235,15 +229,13 @@ async fn execute_sapling_balance_from_seed() {
 }
 
 async fn execute_parse_address_for_tex() {
+    // Address parsing only needs a reachable server with nonzero height,
+    // so the cheap scenario suffices; the multi-pool funded scenario
+    // costs ~150s more of regtest setup per test.
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        MAC_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
+    let docker = match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await
     {
         Ok(d) => d,
         Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),
@@ -270,15 +262,13 @@ async fn execute_parse_address_for_tex() {
 }
 
 async fn execute_parse_address_invalid() {
+    // Address parsing only needs a reachable server with nonzero height,
+    // so the cheap scenario suffices; the multi-pool funded scenario
+    // costs ~150s more of regtest setup per test.
     #[cfg(not(feature = "regchest"))]
-    let _local_net =
-        scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(1_000_000).await;
+    let _local_net = scenarios::funded_orchard_mobileclient(1_000_000).await;
     #[cfg(feature = "regchest")]
-    let docker = match regchest_utils::launch(
-        MAC_SOCKET,
-        Some("funded_orchard_sapling_transparent_shielded_mobileclient"),
-    )
-    .await
+    let docker = match regchest_utils::launch(MAC_SOCKET, Some("funded_orchard_mobileclient")).await
     {
         Ok(d) => d,
         Err(e) => panic!("Failed to launch regchest docker container: {:?}", e),

--- a/rust/workbench/Cargo.toml
+++ b/rust/workbench/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "workbench"
+version = "0.1.0"
+edition = "2021"
+description = "Developer and CI tooling for zingo-mobile."
+publish = false
+
+[dependencies]
+serde_json = { workspace = true }
+
+[[bin]]
+name = "ci-gate"
+path = "src/main.rs"

--- a/rust/workbench/src/main.rs
+++ b/rust/workbench/src/main.rs
@@ -1,0 +1,300 @@
+#![forbid(unsafe_code)]
+
+//! ci-gate: an artifact gate for GitHub Actions jobs.
+//!
+//! Blocks until a named artifact exists in the current workflow run, then
+//! exits 0. Aborts with exit 1 as soon as every upstream job matching the
+//! given name pattern has completed without success (the artifact can no
+//! longer appear), or when the deadline passes. This lets a job start at
+//! workflow launch and front-load work that does not depend on the
+//! artifact, instead of serializing behind the producer with a `needs:`
+//! edge. See CONTEXT.md ("Artifact gate").
+//!
+//! Transport is the `gh` CLI (present on all GitHub-hosted runners,
+//! authenticated via GH_TOKEN); the decision logic is pure and unit
+//! tested. Both API reads request one page of 100 entries, which is far
+//! above the job and artifact count of any run of this repository.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, PartialEq, Eq)]
+enum GateState {
+    /// The wanted artifact exists; the gate opens.
+    Ready,
+    /// A job matching the upstream pattern completed without success, so
+    /// the artifact can never appear. Note that any matching job anywhere
+    /// in the run triggers this; under the fail-all policy the run is
+    /// being cancelled anyway.
+    UpstreamGone { job: String, conclusion: String },
+    /// Nothing decisive yet; poll again.
+    Waiting,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct UpstreamJob {
+    name: String,
+    completed: bool,
+    conclusion: String,
+}
+
+fn assess(artifact_names: &[String], upstream: &[UpstreamJob], wanted: &str) -> GateState {
+    if artifact_names.iter().any(|name| name == wanted) {
+        return GateState::Ready;
+    }
+    for job in upstream {
+        if job.completed && job.conclusion != "success" {
+            return GateState::UpstreamGone {
+                job: job.name.clone(),
+                conclusion: job.conclusion.clone(),
+            };
+        }
+    }
+    GateState::Waiting
+}
+
+fn parse_artifact_names(body: &serde_json::Value) -> Vec<String> {
+    body["artifacts"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|artifact| artifact["name"].as_str())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn parse_upstream_jobs(body: &serde_json::Value, pattern: &str) -> Vec<UpstreamJob> {
+    body["jobs"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|job| {
+            job["name"]
+                .as_str()
+                .is_some_and(|name| name.contains(pattern))
+        })
+        .map(|job| UpstreamJob {
+            name: job["name"].as_str().unwrap_or_default().to_owned(),
+            completed: job["status"].as_str() == Some("completed"),
+            conclusion: job["conclusion"].as_str().unwrap_or_default().to_owned(),
+        })
+        .collect()
+}
+
+/// Fetches one API page via `gh api`. Returns None on any transport or
+/// parse failure so a transient API error reads as "keep waiting".
+fn fetch(path: &str) -> Option<serde_json::Value> {
+    let output = Command::new("gh").args(["api", path]).output().ok()?;
+    if !output.status.success() {
+        eprintln!(
+            "ci-gate: gh api {path} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        return None;
+    }
+    serde_json::from_slice(&output.stdout).ok()
+}
+
+struct Config {
+    artifact: String,
+    upstream: String,
+    timeout: Duration,
+    poll: Duration,
+    repo: String,
+    run_id: String,
+}
+
+fn parse_args() -> Result<Config, String> {
+    let mut artifact = None;
+    let mut upstream = None;
+    let mut timeout_secs: u64 = 2700;
+    let mut poll_secs: u64 = 20;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(flag) = args.next() {
+        let mut value = |flag: &str| {
+            args.next()
+                .ok_or_else(|| format!("missing value for {flag}"))
+        };
+        match flag.as_str() {
+            "--artifact" => artifact = Some(value("--artifact")?),
+            "--upstream" => upstream = Some(value("--upstream")?),
+            "--timeout-secs" => {
+                timeout_secs = value("--timeout-secs")?
+                    .parse()
+                    .map_err(|e| format!("--timeout-secs: {e}"))?
+            }
+            "--poll-secs" => {
+                poll_secs = value("--poll-secs")?
+                    .parse()
+                    .map_err(|e| format!("--poll-secs: {e}"))?
+            }
+            other => return Err(format!("unknown flag: {other}")),
+        }
+    }
+
+    let env = |name: &str| std::env::var(name).map_err(|_| format!("{name} is not set"));
+    Ok(Config {
+        artifact: artifact.ok_or("--artifact is required")?,
+        upstream: upstream.ok_or("--upstream is required")?,
+        timeout: Duration::from_secs(timeout_secs),
+        poll: Duration::from_secs(poll_secs),
+        repo: env("GITHUB_REPOSITORY")?,
+        run_id: env("GITHUB_RUN_ID")?,
+    })
+}
+
+fn main() {
+    let config = match parse_args() {
+        Ok(config) => config,
+        Err(message) => {
+            eprintln!("ci-gate: {message}");
+            std::process::exit(2);
+        }
+    };
+
+    let artifacts_path = format!(
+        "repos/{}/actions/runs/{}/artifacts?per_page=100",
+        config.repo, config.run_id
+    );
+    let jobs_path = format!(
+        "repos/{}/actions/runs/{}/jobs?per_page=100",
+        config.repo, config.run_id
+    );
+
+    let deadline = Instant::now() + config.timeout;
+    println!(
+        "ci-gate: waiting up to {}s for artifact \"{}\" (producer: jobs matching \"{}\")",
+        config.timeout.as_secs(),
+        config.artifact,
+        config.upstream
+    );
+
+    while Instant::now() < deadline {
+        let artifact_names = fetch(&artifacts_path)
+            .map(|body| parse_artifact_names(&body))
+            .unwrap_or_default();
+        let upstream_jobs = fetch(&jobs_path)
+            .map(|body| parse_upstream_jobs(&body, &config.upstream))
+            .unwrap_or_default();
+
+        match assess(&artifact_names, &upstream_jobs, &config.artifact) {
+            GateState::Ready => {
+                println!("ci-gate: artifact \"{}\" is ready", config.artifact);
+                return;
+            }
+            GateState::UpstreamGone { job, conclusion } => {
+                eprintln!(
+                    "ci-gate: upstream job \"{job}\" concluded \"{conclusion}\"; \
+                     artifact \"{}\" will never appear",
+                    config.artifact
+                );
+                std::process::exit(1);
+            }
+            GateState::Waiting => std::thread::sleep(config.poll),
+        }
+    }
+
+    eprintln!(
+        "ci-gate: deadline exceeded waiting for artifact \"{}\"",
+        config.artifact
+    );
+    std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(name: &str, completed: bool, conclusion: &str) -> UpstreamJob {
+        UpstreamJob {
+            name: name.to_owned(),
+            completed,
+            conclusion: conclusion.to_owned(),
+        }
+    }
+
+    #[test]
+    fn artifact_present_opens_the_gate() {
+        let artifacts = vec!["android-build-outputs-x86_64-abc".to_owned()];
+        let upstream = vec![job("Android APK build", true, "success")];
+        assert_eq!(
+            assess(&artifacts, &upstream, "android-build-outputs-x86_64-abc"),
+            GateState::Ready
+        );
+    }
+
+    #[test]
+    fn artifact_wins_even_if_a_matching_job_failed() {
+        // In a matrix, another leg's producer may fail after ours already
+        // uploaded; the artifact's existence is the decisive fact.
+        let artifacts = vec!["wanted".to_owned()];
+        let upstream = vec![job("Android APK build", true, "failure")];
+        assert_eq!(assess(&artifacts, &upstream, "wanted"), GateState::Ready);
+    }
+
+    #[test]
+    fn failed_upstream_aborts() {
+        let upstream = vec![job("Android APK build", true, "failure")];
+        assert_eq!(
+            assess(&[], &upstream, "wanted"),
+            GateState::UpstreamGone {
+                job: "Android APK build".to_owned(),
+                conclusion: "failure".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn skipped_upstream_aborts() {
+        // A skipped producer (its own dependency failed) also means the
+        // artifact can never appear.
+        let upstream = vec![job("Android APK build", true, "skipped")];
+        assert!(matches!(
+            assess(&[], &upstream, "wanted"),
+            GateState::UpstreamGone { .. }
+        ));
+    }
+
+    #[test]
+    fn running_upstream_keeps_waiting() {
+        let upstream = vec![job("Android APK build", false, "")];
+        assert_eq!(assess(&[], &upstream, "wanted"), GateState::Waiting);
+    }
+
+    #[test]
+    fn absent_upstream_keeps_waiting() {
+        // The jobs listing can lag behind scheduling; absence is not
+        // evidence of failure.
+        assert_eq!(assess(&[], &[], "wanted"), GateState::Waiting);
+    }
+
+    #[test]
+    fn parses_artifact_names() {
+        let body: serde_json::Value = serde_json::json!({
+            "artifacts": [{ "name": "a" }, { "name": "b" }]
+        });
+        assert_eq!(parse_artifact_names(&body), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn parses_and_filters_jobs_by_pattern() {
+        let body: serde_json::Value = serde_json::json!({
+            "jobs": [
+                { "name": "android-apk-build / Android APK build",
+                  "status": "completed", "conclusion": "success" },
+                { "name": "jest-test / Jest test",
+                  "status": "in_progress", "conclusion": null }
+            ]
+        });
+        let jobs = parse_upstream_jobs(&body, "Android APK build");
+        assert_eq!(
+            jobs,
+            vec![job(
+                "android-apk-build / Android APK build",
+                true,
+                "success"
+            )]
+        );
+    }
+}


### PR DESCRIPTION
PR CI serialized roughly ten minutes of integration-bucket setup behind the APK build that needed nothing from it, and the ledger-and-parsing bucket spent about 150 seconds per parse test on a multi-pool funded scenario those tests never consume. Measured on the last runs of #1168, the verdict path was 38 minutes cold and 32 warm; after this change the expected path is roughly 24 and 19.

The integration buckets now start at workflow launch with no `needs:` edge on the APK build. They front-load all APK-independent setup, prebuild the nextest harness, and hold at a `ci-gate` artifact gate until the APK artifact lands. The gate is the first binary in the new `rust/workbench` crate, the home for CI tooling per our scripting conventions; it aborts promptly when the producing job concludes without success, and its decision logic is pure and unit tested. The AVD-cache job starts at launch as well.

Every blocking check opts into a fail-all policy on PR CI: the first failure cancels the entire run through a terminal `github-script` step, so one red check stops spending runners on a verdict that is already decided. The policy is carried by a `fail-all` input that defaults to false, so ci-nightly keeps its complete-signal behavior untouched, including the bucket matrix's `fail-fast: false`. iOS remains a trailing advisory stage, unchanged.

The two `parse_address` integration tests move from `funded_orchard_sapling_transparent_shielded_mobileclient` to `funded_orchard_mobileclient` in both the Android and iOS test crates. They only initialize from seed against the server and parse a hard-coded string, so the heavyweight scenario bought them nothing but setup time; `sapling_balance_from_seed` keeps it because it genuinely asserts on sapling funds. A new `CONTEXT.md` records the vocabulary these changes introduce: blocking check, advisory stage, verdict path, bucket, fail-all, and artifact gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)