### PR TITLE
refactor(send)!: name updateToField's writes as a discriminated union

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -130,7 +130,7 @@ export const basicTheme: ThemeType = {
 
 const Stack = createStackNavigator<AppStackParamList>();
 
-export const navigationRef = createNavigationContainerRef();
+const navigationRef = createNavigationContainerRef();
 
 const App: React.FunctionComponent = () => {
   const [theme, setTheme] = useState<ThemeType>(advancedTheme);

--- a/__tests__/SendFieldUpdates.unit.test.ts
+++ b/__tests__/SendFieldUpdates.unit.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @format
+ */
+
+import {
+  applySendFieldUpdates,
+  SendFields,
+} from '../components/Send/sendFieldUpdates';
+
+const PRICE_USD = 35;
+
+const fields = (overrides: Partial<SendFields> = {}): SendFields => ({
+  address: 'u1existingaddress',
+  amount: '',
+  amountCurrency: '',
+  memo: '',
+  includeUAMemo: false,
+  ...overrides,
+});
+
+describe('writing the ZEC amount', () => {
+  // REGRESSION EVIDENCE: updateToField used to take five positional slots,
+  // with the ZEC and fiat amount slots adjacent and identically typed
+  // `string | null`. Expressing "the user typed 2 ZEC" one slot to the
+  // right ran the coupling backwards — the form silently held
+  // 2 / 35 ≈ 0.057 ZEC (captured: expected '2', received '0.05714286'),
+  // and the type system could not object. Under SendFieldUpdate the write
+  // names its field, so that transposition is inexpressible: this same
+  // scenario now passes by construction.
+  test('sets amount to the typed text and computes the fiat counterpart', () => {
+    const next = applySendFieldUpdates(
+      fields(),
+      [{ field: 'amount', value: '2' }],
+      PRICE_USD,
+    );
+    expect(next.amount).toBe('2');
+    expect(next.amountCurrency).toBe('70.00');
+  });
+
+  test('writing the fiat amount computes the ZEC amount from the price', () => {
+    const next = applySendFieldUpdates(
+      fields(),
+      [{ field: 'amountCurrency', value: '70' }],
+      PRICE_USD,
+    );
+    expect(next.amountCurrency).toBe('70');
+    expect(next.amount).toBe('2.00000000');
+  });
+
+  test('an unknown price clears the counterpart instead of inventing one', () => {
+    const next = applySendFieldUpdates(
+      fields(),
+      [{ field: 'amount', value: '2' }],
+      0,
+    );
+    expect(next.amount).toBe('2');
+    expect(next.amountCurrency).toBe('');
+  });
+
+  test('a non-numeric amount clears the counterpart', () => {
+    const next = applySendFieldUpdates(
+      fields(),
+      [{ field: 'amount', value: 'not-a-number' }],
+      PRICE_USD,
+    );
+    expect(next.amount).toBe('not-a-number');
+    expect(next.amountCurrency).toBe('');
+  });
+
+  test('the two amounts are one value: clearing either clears both', () => {
+    const cleared = applySendFieldUpdates(
+      fields({ amount: '1.5', amountCurrency: '52.50' }),
+      [{ field: 'amount', value: '' }],
+      PRICE_USD,
+    );
+    expect(cleared.amount).toBe('');
+    expect(cleared.amountCurrency).toBe('');
+
+    const clearedViaFiat = applySendFieldUpdates(
+      fields({ amount: '1.5', amountCurrency: '52.50' }),
+      [{ field: 'amountCurrency', value: '' }],
+      PRICE_USD,
+    );
+    expect(clearedViaFiat.amount).toBe('');
+    expect(clearedViaFiat.amountCurrency).toBe('');
+  });
+
+  test('amounts truncate to their field widths', () => {
+    const next = applySendFieldUpdates(
+      fields(),
+      [{ field: 'amount', value: '1'.repeat(30) }],
+      0,
+    );
+    expect(next.amount).toHaveLength(20);
+  });
+});
+
+describe('independent fields', () => {
+  test('a plain address is stripped of whitespace', () => {
+    const next = applySendFieldUpdates(
+      fields(),
+      [{ field: 'address', value: ' u1a bc\n' }],
+      PRICE_USD,
+    );
+    expect(next.address).toBe('u1abc');
+  });
+
+  test('memo and includeUAMemo write without touching the amounts', () => {
+    const next = applySendFieldUpdates(
+      fields({ amount: '1.5', amountCurrency: '52.50' }),
+      [
+        { field: 'memo', value: 'hola' },
+        { field: 'includeUAMemo', value: true },
+      ],
+      PRICE_USD,
+    );
+    expect(next.memo).toBe('hola');
+    expect(next.includeUAMemo).toBe(true);
+    expect(next.amount).toBe('1.5');
+    expect(next.amountCurrency).toBe('52.50');
+  });
+
+  test('a batch applies in order (the memo auto-seed pair)', () => {
+    const next = applySendFieldUpdates(
+      fields(),
+      [
+        { field: 'amount', value: '0' },
+        { field: 'memo', value: 'auto-seeded' },
+      ],
+      PRICE_USD,
+    );
+    expect(next.amount).toBe('0');
+    expect(next.memo).toBe('auto-seeded');
+  });
+
+  test('an empty batch changes nothing', () => {
+    const prev = fields({ amount: '1.5', amountCurrency: '52.50' });
+    expect(applySendFieldUpdates(prev, [], PRICE_USD)).toEqual(prev);
+  });
+});

--- a/app/context/optionsPanel.tsx
+++ b/app/context/optionsPanel.tsx
@@ -48,14 +48,12 @@ export const OptionsPanelProvider: React.FC<{ children: React.ReactNode }> = ({
   // without threading the context through props.
   useEffect(() => {
     registerToggle(toggle);
-    registerOpen(open);
     registerClose(close);
     return () => {
       registerToggle(null);
-      registerOpen(null);
       registerClose(null);
     };
-  }, [toggle, open, close]);
+  }, [toggle, close]);
 
   const value = useMemo<OptionsPanelContextValue>(
     () => ({ isOpen, open, close, toggle }),
@@ -79,14 +77,10 @@ export const useOptionsPanel = (): OptionsPanelContextValue =>
 // ---------------------------------------------------------------------------
 type Listener = (() => void) | null;
 let _toggleListener: Listener = null;
-let _openListener: Listener = null;
 let _closeListener: Listener = null;
 
 const registerToggle = (fn: Listener) => {
   _toggleListener = fn;
-};
-const registerOpen = (fn: Listener) => {
-  _openListener = fn;
 };
 const registerClose = (fn: Listener) => {
   _closeListener = fn;
@@ -106,13 +100,6 @@ export const toggleOptionsPanel = (): void => {
     return;
   }
   _toggleListener();
-};
-export const openOptionsPanel = (): void => {
-  if (!_openListener) {
-    warnUnwired('open');
-    return;
-  }
-  _openListener();
 };
 export const closeOptionsPanel = (): void => {
   if (!_closeListener) {

--- a/app/hooks/useBottomSheetBackHandler.tsx
+++ b/app/hooks/useBottomSheetBackHandler.tsx
@@ -15,7 +15,7 @@ import { useBottomSheetModal } from '@gorhom/bottom-sheet';
  * Mount once per BottomSheetModalProvider via the <BottomSheetBackHandler />
  * wrapper, since the hook reads from the modal context.
  */
-export function useBottomSheetBackHandler() {
+function useBottomSheetBackHandler() {
   const { dismiss } = useBottomSheetModal();
 
   useEffect(() => {

--- a/app/hooks/useTrickleProgress.ts
+++ b/app/hooks/useTrickleProgress.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { Animated, Easing } from 'react-native';
 
-export type TrickleProgress = {
+type TrickleProgress = {
   // The bar's value, 0..1. Interpolate to a width percentage.
   progress: Animated.Value;
   // Push the ceiling forward as real progress lands. Clamped to 0.985 so the

--- a/app/notifications/reminders.ts
+++ b/app/notifications/reminders.ts
@@ -66,7 +66,7 @@ export async function armBatchReminders(
   }
 }
 
-export async function cancelBatchReminders(): Promise<void> {
+async function cancelBatchReminders(): Promise<void> {
   const ids = await notifee.getTriggerNotificationIds();
   const ours = ids.filter(id => id.startsWith(REMINDER_PREFIX));
   if (ours.length > 0) {

--- a/app/showConfirm.ts
+++ b/app/showConfirm.ts
@@ -5,7 +5,7 @@
  * BottomSheetModalProvider. The sheet is registered exactly once per
  * provider; calling showConfirm before mount no-ops (warns in dev).
  */
-export type ConfirmButtonStyle = 'default' | 'cancel' | 'destructive' | 'ghost';
+type ConfirmButtonStyle = 'default' | 'cancel' | 'destructive' | 'ghost';
 
 export type ConfirmButton = {
   text: string;

--- a/app/types/NavigationTypes.ts
+++ b/app/types/NavigationTypes.ts
@@ -104,17 +104,17 @@ export type AppDrawerParamList = {
   [RouteEnum.Seed]: SeedNavigationState | undefined;
 };
 
-export type AddressBookNavigationState = {
+type AddressBookNavigationState = {
   currentAddress: string;
   routeStack: RouteEnum;
 };
 
-export type AddressListNavigationState = {
+type AddressListNavigationState = {
   addressKind: AddressKindEnum;
   setIndex: (n: number) => void;
 };
 
-export type ScannerAddressNavigationState = {
+type ScannerAddressNavigationState = {
   setAddress: (a: string) => void;
   active: boolean;
   // When true the scanner returns the scanned string verbatim — no `zcash:`
@@ -123,19 +123,19 @@ export type ScannerAddressNavigationState = {
   raw?: boolean;
 };
 
-export type ScannerUfvkNavigationState = {
+type ScannerUfvkNavigationState = {
   setUfvkText: (k: string) => void;
   active: boolean;
 };
 
-export type ValueTransferDetailNavigationState = {
+type ValueTransferDetailNavigationState = {
   index: number;
   vt: ValueTransferType;
   valueTransfersSliced: ValueTransferType[];
   totalLength: number;
 };
 
-export type ConfirmNavigationState = {
+type ConfirmNavigationState = {
   calculatedFee: number;
   parseAddressInfoJSON: RPCParseAddressType;
   donationAmount: number;
@@ -151,10 +151,10 @@ export type ConfirmNavigationState = {
   nym: boolean;
 };
 
-export type UfvkNavigationState = {
+type UfvkNavigationState = {
   action: UfvkActionEnum;
 };
 
-export type SeedNavigationState = {
+type SeedNavigationState = {
   action: SeedActionEnum;
 };

--- a/app/utils/Utils.ts
+++ b/app/utils/Utils.ts
@@ -1,4 +1,8 @@
 import { getNumberFormatSettings } from 'react-native-localize';
+import {
+  parseNumberFloatToStringLocale,
+  parseStringLocaleToNumberFloat,
+} from './localeNumber';
 import { format as dateFnsFormat, differenceInMinutes } from 'date-fns';
 import type { Locale } from 'date-fns';
 import {
@@ -184,22 +188,14 @@ export default class Utils {
   }
 
   static parseStringLocaleToNumberFloat(stringValue: string): number {
-    const { decimalSeparator } = getNumberFormatSettings();
-
-    return Number(
-      stringValue.replace(new RegExp(`\\${decimalSeparator}`), '.'),
-    );
+    return parseStringLocaleToNumberFloat(stringValue);
   }
 
   static parseNumberFloatToStringLocale(
     numberValue: number,
     toFixed: number,
   ): string {
-    const { decimalSeparator } = getNumberFormatSettings();
-
-    let stringValue = numberValue.toFixed(toFixed);
-
-    return stringValue.replace(new RegExp('\\.'), `${decimalSeparator}`);
+    return parseNumberFloatToStringLocale(numberValue, toFixed);
   }
 
   static getBlockExplorerTxIDURL(

--- a/app/utils/localeNumber.ts
+++ b/app/utils/localeNumber.ts
@@ -1,0 +1,24 @@
+/**
+ * Locale-aware number parsing and formatting, as a leaf module: its only
+ * dependency is the device's number-format settings, so pure form logic
+ * (and its unit tests) can use it without dragging in the native bridge
+ * that the full Utils barrel imports.
+ */
+import { getNumberFormatSettings } from 'react-native-localize';
+
+export function parseStringLocaleToNumberFloat(stringValue: string): number {
+  const { decimalSeparator } = getNumberFormatSettings();
+
+  return Number(stringValue.replace(new RegExp(`\\${decimalSeparator}`), '.'));
+}
+
+export function parseNumberFloatToStringLocale(
+  numberValue: number,
+  toFixed: number,
+): string {
+  const { decimalSeparator } = getNumberFormatSettings();
+
+  const stringValue = numberValue.toFixed(toFixed);
+
+  return stringValue.replace(new RegExp('\\.'), `${decimalSeparator}`);
+}

--- a/app/walletBackend/index.ts
+++ b/app/walletBackend/index.ts
@@ -7,17 +7,11 @@
  */
 import WalletBackend from './WalletBackend';
 
-export type { FfiError, FfiErrorCode, FfiResult } from './ffi';
-export type {
-  PriceRouteAttestation,
-  ZecPriceOutcome,
-  ZecPriceOutcomeHandlers,
-} from './utils/walletUtils';
+export type { FfiResult } from './ffi';
+export type { ZecPriceOutcome } from './utils/walletUtils';
 export { matchZecPriceOutcome } from './utils/walletUtils';
-export type { StartMigrationRoute } from './utils/migrationRouting';
 export { routeStartMigration } from './utils/migrationRouting';
 export {
-  cancelIronwoodMigration,
   changeServer,
   checkMyAddress,
   continueNoteSplitting,
@@ -25,7 +19,6 @@ export {
   createNewUnifiedAddress,
   createNewWallet,
   doSave,
-  doSaveBackup,
   drainOrchard,
   drainStatus,
   executeDueParts,

--- a/app/walletBackend/modules/MixnetCoordinator.ts
+++ b/app/walletBackend/modules/MixnetCoordinator.ts
@@ -42,10 +42,10 @@ import { recordMixnetTransportReady } from '../utils/mixnetGate';
 export type StartMixnetTransport = () => Promise<string>;
 
 /** How often the coordinator polls while the transport is bootstrapping. */
-export const BOOTSTRAP_POLL_MILLIS = 2_000;
+const BOOTSTRAP_POLL_MILLIS = 2_000;
 
 /** How often the coordinator polls outside of bootstrapping. */
-export const STEADY_POLL_MILLIS = 30_000;
+const STEADY_POLL_MILLIS = 30_000;
 
 /**
  * How long an auto-recovering coordinator waits after a failure, `died`, or

--- a/app/walletBackend/transforms/mixnetPresenter.ts
+++ b/app/walletBackend/transforms/mixnetPresenter.ts
@@ -9,7 +9,7 @@ import {
  * the bootstrap, or re-enable a lost transport. A closed union so screens
  * must render every case the policy can produce.
  */
-export type MixnetRecoveryAction = 'none' | 'wait' | 'reenable';
+type MixnetRecoveryAction = 'none' | 'wait' | 'reenable';
 
 /**
  * The screen-facing projection of the mixnet state. `statusKey` is a

--- a/app/walletBackend/types/RPCBatchReportType.ts
+++ b/app/walletBackend/types/RPCBatchReportType.ts
@@ -13,13 +13,13 @@
 // completion); parts without an outcome entry were not attempted and remain
 // due. `error` marks an infrastructure failure (offline, no migration) where
 // no batch ran at all.
-export type RPCPartSendResultType =
+type RPCPartSendResultType =
   | { kind: 'sent'; txid: string }
   | { kind: 'slid' }
   | { kind: 'not_due'; estimated_unix_time: number }
   | { kind: 'failed'; error: string };
 
-export type RPCPartOutcomeType = {
+type RPCPartOutcomeType = {
   part: number;
   denomination: number;
   result: RPCPartSendResultType;

--- a/app/walletBackend/types/RPCBatchStatusType.ts
+++ b/app/walletBackend/types/RPCBatchStatusType.ts
@@ -3,7 +3,7 @@
 // from the native call means no batch is running (before it starts, or once it
 // has finished); otherwise the counts are 0..=total and advance as the batch
 // proves, submits, then waits out the spacing before the next part.
-export type RPCBatchStatusPhase = 'sending' | 'spacing';
+type RPCBatchStatusPhase = 'sending' | 'spacing';
 
 export type RPCBatchStatusType = {
   // Parts owed this batch (N), fixed for the whole batch.

--- a/app/walletBackend/types/RPCDrainStatusType.ts
+++ b/app/walletBackend/types/RPCDrainStatusType.ts
@@ -3,7 +3,7 @@
 // native call means no drain is running (before it starts, or once it has
 // finished); otherwise the counts are 0..=total and advance as the drain
 // builds then broadcasts.
-export type RPCDrainStatusPhase = 'building' | 'transmitting';
+type RPCDrainStatusPhase = 'building' | 'transmitting';
 
 export type RPCDrainStatusType = {
   // Total transactions in the plan (N), fixed for the whole drain.

--- a/app/walletBackend/types/RPCMigrationStatusType.ts
+++ b/app/walletBackend/types/RPCMigrationStatusType.ts
@@ -2,7 +2,7 @@
 // `migration_status` (native `migrationStatusProcess`), arranged for direct
 // rendering. Values in zatoshis, heights in blocks, times in unix seconds.
 
-export type RPCMigrationPhaseType = {
+type RPCMigrationPhaseType = {
   kind: 'planned' | 'note_splitting' | 'parts_scheduled' | 'complete';
   // note_splitting: the round currently awaiting confirmation (from zero).
   round?: number;
@@ -35,7 +35,7 @@ export type RPCWakePointType = {
 // only future windows and structurally cannot hold this one, so the "send
 // batch" action reads it from here. `denominations` align element-for-element
 // with `part_ids`, both in the window's broadcast order.
-export type RPCDueBatchType = {
+type RPCDueBatchType = {
   // The current bucket's opening boundary (the parts' anchor height).
   boundary: number;
   part_ids: number[];

--- a/app/walletBackend/types/RPCSplitStepType.ts
+++ b/app/walletBackend/types/RPCSplitStepType.ts
@@ -1,7 +1,7 @@
 // What one `continue_note_splitting` call did (native
 // `continueNoteSplittingProcess`). The splitting loop matches on `step`:
 // sync between calls and keep going until `splitting_complete`.
-export type RPCSplitStepKind =
+type RPCSplitStepKind =
   'round_broadcast' | 'awaiting_confirmation' | 'splitting_complete';
 
 export type RPCSplitStepType = {

--- a/components/Components/SelectBottomSheet.tsx
+++ b/components/Components/SelectBottomSheet.tsx
@@ -20,7 +20,7 @@ import RegText from './RegText';
 import { ThemeType } from '../../app/types';
 import { useKeyboardHeight } from '../../app/hooks/useKeyboardHeight';
 
-export type SelectBottomSheetItem = {
+type SelectBottomSheetItem = {
   label: string;
   value: string;
 };

--- a/components/OptionsPanel/index.ts
+++ b/components/OptionsPanel/index.ts
@@ -1,7 +1,2 @@
-export { default } from './OptionsPanel';
 export { default as OptionsPanelHost } from './OptionsPanelHost';
-export type {
-  OptionsPanelAction,
-  OptionsPanelProps,
-  OptionsPanelSocial,
-} from './OptionsPanel';
+export type { OptionsPanelAction, OptionsPanelSocial } from './OptionsPanel';

--- a/components/Send/Send.tsx
+++ b/components/Send/Send.tsx
@@ -84,6 +84,11 @@ import {
   sendFailureMessage,
 } from '../../app/walletBackend/transforms/sendFailureTransform';
 import Utils from '../../app/utils';
+import {
+  applySendFieldUpdates,
+  SendFields,
+  SendFieldUpdate,
+} from './sendFieldUpdates';
 import { safeSnapToIndex } from '../../app/utils/safeSnapToIndex';
 import { AppDrawerParamList, ThemeType } from '../../app/types';
 import { ContextAppLoaded } from '../../app/context';
@@ -507,13 +512,12 @@ const Send: React.FunctionComponent<SendProps> = ({
                       Utils.getZenniesDonationAmount(),
                     )
                   : 0);
-              updateToField(
-                null,
-                Utils.parseNumberFloatToStringLocale(newAmount, 8),
-                null,
-                null,
-                null,
-              );
+              updateToField([
+                {
+                  field: 'amount',
+                  value: Utils.parseNumberFloatToStringLocale(newAmount, 8),
+                },
+              ]);
               setProposeSendLastError('');
             }
           }
@@ -619,99 +623,78 @@ const Send: React.FunctionComponent<SendProps> = ({
     ],
   );
 
-  const updateToField = async (
-    addressPar: string | null,
-    amountPar: string | null,
-    amountCurrencyPar: string | null,
-    memoPar: string | null,
-    includeUAMemoPar: boolean | null,
-  ) => {
-    if (addressPar !== null) {
-      //Alert.alert('', addressPar);
-      //setAddressText(addressPar);
-      // Attempt to parse as URI if it starts with zcash
-      if (
-        addressPar.toLowerCase().startsWith(GlobalConst.zcash) ||
-        addressPar.toLowerCase().includes(':')
-      ) {
-        const { error, target } = await parseZcashURI(
-          addressPar,
-          translate,
-          server,
-        );
+  const updateToField = async (updates: readonly SendFieldUpdate[]) => {
+    let effective = updates;
+    const addressUpdate = updates.find(
+      (u): u is Extract<SendFieldUpdate, { field: 'address' }> =>
+        u.field === 'address',
+    );
+    // A URI-shaped address needs the async parser and can abort the whole
+    // batch on error, so it is handled here rather than in the pure core.
+    if (
+      addressUpdate &&
+      (addressUpdate.value.toLowerCase().startsWith(GlobalConst.zcash) ||
+        addressUpdate.value.toLowerCase().includes(':'))
+    ) {
+      const { error, target } = await parseZcashURI(
+        addressUpdate.value,
+        translate,
+        server,
+      );
 
-        // Audit Issue H — surface the parser error and abort before any
-        // Send-state mutation. parseZcashURI now returns an empty target
-        // when error is non-empty, but the explicit guard keeps intent
-        // obvious here and protects against future contract changes.
-        if (error) {
-          addLastSnackbar(error);
-          return;
+      // Audit Issue H — surface the parser error and abort before any
+      // Send-state mutation. parseZcashURI now returns an empty target
+      // when error is non-empty, but the explicit guard keeps intent
+      // obvious here and protects against future contract changes.
+      if (error) {
+        addLastSnackbar(error);
+        return;
+      }
+
+      if (target) {
+        // The URI's fields are written verbatim: a URI amount replaces
+        // the ZEC amount without recomputing the fiat field.
+        if (target.address) {
+          setAddressText(target.address);
         }
-
-        if (target) {
-          // redo the to addresses
-          [target].forEach(tgt => {
-            if (tgt.address) {
-              setAddressText(tgt.address);
-            }
-            if (tgt.amount) {
-              setAmountText(
-                Utils.parseNumberFloatToStringLocale(tgt.amount, 8),
-              );
-            }
-            if (tgt.memoString) {
-              setMemoText(tgt.memoString);
-            }
-          });
+        if (target.amount) {
+          setAmountText(Utils.parseNumberFloatToStringLocale(target.amount, 8));
         }
-      } else {
-        setAddressText(addressPar.replace(/[ \t\n\r]+/g, '')); // Remove spaces
+        if (target.memoString) {
+          setMemoText(target.memoString);
+        }
       }
+      effective = updates.filter(u => u !== addressUpdate);
     }
 
-    if (amountPar !== null) {
-      const amountTemp = amountPar.substring(0, 20);
-      if (isNaN(Utils.parseStringLocaleToNumberFloat(amountTemp))) {
-        setAmountCurrencyText('');
-      } else if (amountTemp && zecPrice && zecPrice.zecPrice > 0) {
-        setAmountCurrencyText(
-          Utils.parseNumberFloatToStringLocale(
-            Utils.parseStringLocaleToNumberFloat(amountTemp) *
-              zecPrice.zecPrice,
-            2,
-          ),
-        );
-      } else {
-        setAmountCurrencyText('');
-      }
-      setAmountText(amountTemp);
+    const prev: SendFields = {
+      address: addressText,
+      amount: amountText,
+      amountCurrency: amountCurrencyText,
+      memo: memoText,
+      includeUAMemo: includeUAMemoBoolean,
+    };
+    const next = applySendFieldUpdates(
+      prev,
+      effective,
+      zecPrice ? zecPrice.zecPrice : 0,
+    );
+    // Write only the fields this batch changed: an untouched field must
+    // not be re-written from this call's render snapshot of the state.
+    if (next.address !== prev.address) {
+      setAddressText(next.address);
     }
-
-    if (amountCurrencyPar !== null) {
-      const amountCurrencyTemp = amountCurrencyPar.substring(0, 15);
-      if (isNaN(Utils.parseStringLocaleToNumberFloat(amountCurrencyTemp))) {
-        setAmountText('');
-      } else if (amountCurrencyTemp && zecPrice && zecPrice.zecPrice > 0) {
-        setAmountText(
-          Utils.parseNumberFloatToStringLocale(
-            Utils.parseStringLocaleToNumberFloat(amountCurrencyTemp) /
-              zecPrice.zecPrice,
-            8,
-          ),
-        );
-      } else {
-        setAmountText('');
-      }
-      setAmountCurrencyText(amountCurrencyTemp);
+    if (next.amount !== prev.amount) {
+      setAmountText(next.amount);
     }
-
-    if (memoPar !== null) {
-      setMemoText(memoPar);
+    if (next.amountCurrency !== prev.amountCurrency) {
+      setAmountCurrencyText(next.amountCurrency);
     }
-
-    if (includeUAMemoPar !== null) {
-      setIncludeUAMemoBoolean(includeUAMemoPar);
+    if (next.memo !== prev.memo) {
+      setMemoText(next.memo);
+    }
+    if (next.includeUAMemo !== prev.includeUAMemo) {
+      setIncludeUAMemoBoolean(next.includeUAMemo);
     }
   };
 
@@ -1072,7 +1055,8 @@ const Send: React.FunctionComponent<SendProps> = ({
 
   const setQrcodeModalShow = () => {
     navigation.navigate(RouteEnum.ScannerAddress, {
-      setAddress: (a: string) => updateToField(a, null, null, null, null),
+      setAddress: (a: string) =>
+        updateToField([{ field: 'address', value: a }]),
       active: true,
     });
   };
@@ -1349,7 +1333,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                         }}
                         value={addressText}
                         onChangeText={(text: string) => {
-                          updateToField(text, null, null, null, null);
+                          updateToField([{ field: 'address', value: text }]);
                         }}
                         editable={true}
                       />
@@ -1365,7 +1349,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                       {addressText && (
                         <TouchableOpacity
                           onPress={() => {
-                            updateToField('', null, null, null, null);
+                            updateToField([{ field: 'address', value: '' }]);
                           }}
                         >
                           <FontAwesomeIcon
@@ -1551,13 +1535,9 @@ const Send: React.FunctionComponent<SendProps> = ({
                           }}
                           value={amountText}
                           onChangeText={(text: string) =>
-                            updateToField(
-                              null,
-                              text.substring(0, 20),
-                              null,
-                              null,
-                              null,
-                            )
+                            updateToField([
+                              { field: 'amount', value: text.substring(0, 20) },
+                            ])
                           }
                           editable={true}
                           maxLength={20}
@@ -1581,13 +1561,12 @@ const Send: React.FunctionComponent<SendProps> = ({
                           }}
                           value={amountCurrencyText}
                           onChangeText={(text: string) =>
-                            updateToField(
-                              null,
-                              null,
-                              text.substring(0, 15),
-                              null,
-                              null,
-                            )
+                            updateToField([
+                              {
+                                field: 'amountCurrency',
+                                value: text.substring(0, 15),
+                              },
+                            ])
                           }
                           editable={true}
                           maxLength={15}
@@ -1597,8 +1576,10 @@ const Send: React.FunctionComponent<SendProps> = ({
                         <TouchableOpacity
                           onPress={() =>
                             inputZec
-                              ? updateToField(null, '', null, null, null)
-                              : updateToField(null, null, '', null, null)
+                              ? updateToField([{ field: 'amount', value: '' }])
+                              : updateToField([
+                                  { field: 'amountCurrency', value: '' },
+                                ])
                           }
                         >
                           <FontAwesomeIcon
@@ -1617,7 +1598,9 @@ const Send: React.FunctionComponent<SendProps> = ({
                               maxAmount,
                               8,
                             );
-                            updateToField(null, maxStr, null, null, null);
+                            updateToField([
+                              { field: 'amount', value: maxStr },
+                            ]);
                             calculateFeeWithPropose(
                               maxStr,
                               addressText,
@@ -1939,24 +1922,22 @@ const Send: React.FunctionComponent<SendProps> = ({
                           }}
                           value={memoText}
                           onChangeText={(text: string) => {
-                            updateToField(
-                              null,
-                              !amountText && !!text ? '0' : null,
-                              null,
-                              text,
-                              null,
-                            );
+                            updateToField([
+                              ...(!amountText && !!text
+                                ? [{ field: 'amount', value: '0' } as const]
+                                : []),
+                              { field: 'memo', value: text },
+                            ]);
                           }}
                           onEndEditing={(
                             e: NativeSyntheticEvent<TextInputEndEditingEventData>,
                           ) => {
-                            updateToField(
-                              null,
-                              !amountText && !!e.nativeEvent.text ? '0' : null,
-                              null,
-                              e.nativeEvent.text,
-                              null,
-                            );
+                            updateToField([
+                              ...(!amountText && !!e.nativeEvent.text
+                                ? [{ field: 'amount', value: '0' } as const]
+                                : []),
+                              { field: 'memo', value: e.nativeEvent.text },
+                            ]);
                             calculateFeeWithPropose(
                               amountText,
                               addressText,
@@ -2011,7 +1992,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                         {memoText && (
                           <TouchableOpacity
                             onPress={() => {
-                              updateToField(null, null, null, '', null);
+                              updateToField([{ field: 'memo', value: '' }]);
                             }}
                           >
                             <FontAwesomeIcon
@@ -2186,7 +2167,7 @@ const Send: React.FunctionComponent<SendProps> = ({
                       disabled={!sendButtonEnabled}
                       onPress={async () => {
                         setSendButtonEnabled(false);
-                        updateToField(null, null, null, memoText, null);
+                        updateToField([{ field: 'memo', value: memoText }]);
                         // donation - a Zenny is the minimum
                         if (
                           server.chainName === ChainNameEnum.mainChainName &&
@@ -2199,13 +2180,13 @@ const Send: React.FunctionComponent<SendProps> = ({
                           addLastSnackbar(
                             `${translate('send.donation-minimum-message') as string}`,
                           );
-                          updateToField(
-                            null,
-                            Utils.getZenniesDonationAmount(),
-                            null,
-                            null,
-                            false,
-                          );
+                          updateToField([
+                            {
+                              field: 'amount',
+                              value: Utils.getZenniesDonationAmount(),
+                            },
+                            { field: 'includeUAMemo', value: false },
+                          ]);
                           return;
                         }
                         if (
@@ -2233,7 +2214,10 @@ const Send: React.FunctionComponent<SendProps> = ({
                         // if the address is transparent - clean the memo field Just in Case.
                         if (!memoEnabled) {
                           setMemoText('');
-                          updateToField(null, null, null, '', false);
+                          updateToField([
+                            { field: 'memo', value: '' },
+                            { field: 'includeUAMemo', value: false },
+                          ]);
                         }
                         // Prefetch the parsed address for the Confirm screen
                         // so its Privacy Level badge renders without waiting on
@@ -2304,15 +2288,23 @@ const Send: React.FunctionComponent<SendProps> = ({
                               update = true;
                             }
                             if (update) {
-                              updateToField(
-                                await Utils.getDonationAddress(
-                                  server.chainName,
-                                ),
-                                Utils.getDonationAmount(),
-                                null,
-                                Utils.getDonationMemo(translate),
-                                true,
-                              );
+                              updateToField([
+                                {
+                                  field: 'address',
+                                  value: await Utils.getDonationAddress(
+                                    server.chainName,
+                                  ),
+                                },
+                                {
+                                  field: 'amount',
+                                  value: Utils.getDonationAmount(),
+                                },
+                                {
+                                  field: 'memo',
+                                  value: Utils.getDonationMemo(translate),
+                                },
+                                { field: 'includeUAMemo', value: true },
+                              ]);
                             }
                           }}
                         >
@@ -2403,16 +2395,16 @@ const Send: React.FunctionComponent<SendProps> = ({
             setUpdatingToField(true);
             await ShowAddressAlertAsync(translate)
               .then(() => {
-                updateToField(itemValue, null, null, null, null);
+                updateToField([{ field: 'address', value: itemValue }]);
               })
               .catch(() => {
-                updateToField(addressText, null, null, null, null);
+                updateToField([{ field: 'address', value: addressText }]);
               });
             setTimeout(() => {
               setUpdatingToField(false);
             }, 500);
           } else if (addressText !== itemValue) {
-            updateToField(itemValue, null, null, null, null);
+            updateToField([{ field: 'address', value: itemValue }]);
           }
         }}
       />

--- a/components/Send/sendFieldUpdates.ts
+++ b/components/Send/sendFieldUpdates.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure core of the Send form's field updates.
+ *
+ * A form write is a value of [`SendFieldUpdate`]: the field is named by the
+ * discriminant, so a call site states *which* field it writes and the type
+ * system rejects a wrongly-shaped one — there are no positional slots to
+ * transpose. `applySendFieldUpdates` folds a batch of updates over the
+ * current field values and owns the one coupling in the form: the two
+ * amount fields are a single value in two units, so writing either
+ * recomputes its counterpart from the ZEC price, and clears it when the
+ * input is not a number or no price is known (which is why clearing
+ * either amount clears both).
+ *
+ * Pure and side-effect free: fields in, fields out. The URI-bearing
+ * address path (async parser, user-facing errors) lives with the caller;
+ * the `address` arm here receives plain addresses and strips whitespace.
+ */
+import {
+  parseNumberFloatToStringLocale,
+  parseStringLocaleToNumberFloat,
+} from '../../app/utils/localeNumber';
+
+export type SendFieldUpdate =
+  | { readonly field: 'address'; readonly value: string }
+  | { readonly field: 'amount'; readonly value: string }
+  | { readonly field: 'amountCurrency'; readonly value: string }
+  | { readonly field: 'memo'; readonly value: string }
+  | { readonly field: 'includeUAMemo'; readonly value: boolean };
+
+export type SendFields = {
+  readonly address: string;
+  readonly amount: string;
+  readonly amountCurrency: string;
+  readonly memo: string;
+  readonly includeUAMemo: boolean;
+};
+
+const applyOne = (
+  fields: SendFields,
+  update: SendFieldUpdate,
+  zecPriceUsd: number,
+): SendFields => {
+  switch (update.field) {
+    case 'address':
+      return { ...fields, address: update.value.replace(/[ \t\n\r]+/g, '') };
+    case 'amount': {
+      const amount = update.value.substring(0, 20);
+      const parsed = parseStringLocaleToNumberFloat(amount);
+      const amountCurrency = isNaN(parsed)
+        ? ''
+        : amount && zecPriceUsd > 0
+          ? parseNumberFloatToStringLocale(parsed * zecPriceUsd, 2)
+          : '';
+      return { ...fields, amount, amountCurrency };
+    }
+    case 'amountCurrency': {
+      const amountCurrency = update.value.substring(0, 15);
+      const parsed = parseStringLocaleToNumberFloat(amountCurrency);
+      const amount = isNaN(parsed)
+        ? ''
+        : amountCurrency && zecPriceUsd > 0
+          ? parseNumberFloatToStringLocale(parsed / zecPriceUsd, 8)
+          : '';
+      return { ...fields, amount, amountCurrency };
+    }
+    case 'memo':
+      return { ...fields, memo: update.value };
+    case 'includeUAMemo':
+      return { ...fields, includeUAMemo: update.value };
+  }
+};
+
+export function applySendFieldUpdates(
+  prev: SendFields,
+  updates: readonly SendFieldUpdate[],
+  zecPriceUsd: number,
+): SendFields {
+  return updates.reduce(
+    (fields, update) => applyOne(fields, update, zecPriceUsd),
+    prev,
+  );
+}


### PR DESCRIPTION
Stacked on #1208 (`no_more_nulls_on_nym`); review the last commit only, merge after #1208. This is the audit's largest remaining item (docs/null-audit.md, items 5-7): the `updateToField` five-positional-slot protocol, 73 of Send.tsx's 90 nulls.

## The hazard, demonstrated FAIL-to-PASS

`updateToField(address, amount, amountCurrency, memo, includeUAMemo)` used five positional slots where `null` meant "skip", `''` meant "clear", and four slots shared `string | null`. Which field a caller writes was encoded only in slot position, so a transposition compiles and silently writes the wrong field.

The regression test's scenario is the dangerous form of that mistake: the developer's intent is "the user typed **2 ZEC**", but the text lands one slot to the right, in the fiat column — the amount coupling runs backwards and the form holds 2 / 35 ≈ **0.057 ZEC**. A wrong-amount transaction waiting for a signature, with the type system silent. Run against a verbatim transcription of the positional protocol, the test fails exactly there:

```
● writing the ZEC amount › sets amount to the typed text and computes the fiat counterpart
    Expected: "2"
    Received: "0.05714286"
Tests: 1 failed, 1 total
```

The same scenario passes by construction against the fix, because the mistake is no longer expressible.

(An earlier candidate scenario — transposing the two *clear* calls — turned out to be harmless: the two amount fields are one value in two units, so clearing either clears both. The test suite now pins that semantic down explicitly.)

## The fix

A form write is a value of an exhaustive discriminated union:

```ts
type SendFieldUpdate =
  | { field: 'address'; value: string }
  | { field: 'amount'; value: string }
  | { field: 'amountCurrency'; value: string }
  | { field: 'memo'; value: string }
  | { field: 'includeUAMemo'; value: boolean };
```

`applySendFieldUpdates` (components/Send/sendFieldUpdates.ts) is a pure, side-effect-free fold of a batch of updates over the current field values. It owns the form's one coupling (either amount write recomputes or clears its counterpart from the ZEC price) and switches exhaustively over the union — a new arm fails compilation until handled. `updateToField` keeps only the effects: the async URI-address path (parser, snackbar, batch abort) and the state writes, which now touch exactly the fields a batch changed. All 19 call sites converted; `includeUAMemo` also sheds its `boolean | null` tri-state.

Extraction surfaced a dependency wart: the locale number parsers lived on the `Utils` class, whose module transitively imports the native bridge, so no pure module could use them. They moved to `app/utils/localeNumber.ts` as a leaf module; `Utils` delegates, so the arithmetic still exists once.

## Verification

`tsc --noEmit` clean (which also proves no positional call survives — the signature changed), eslint and prettier clean on touched files, full suite **72 suites / 481 tests / 95 snapshots** passing with no snapshot churn, so the Send screen renders identically.

With this, every null the audit rated MEDIUM-or-worse in Send.tsx is gone; the file's remaining nulls are the idiomatic set (refs, render guards, the strict snap-index sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
