### PR TITLE
refactor: remove dead code agreed on by three audit tools

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -130,7 +130,7 @@ export const basicTheme: ThemeType = {
 
 const Stack = createStackNavigator<AppStackParamList>();
 
-export const navigationRef = createNavigationContainerRef();
+const navigationRef = createNavigationContainerRef();
 
 const App: React.FunctionComponent = () => {
   const [theme, setTheme] = useState<ThemeType>(advancedTheme);

--- a/app/context/optionsPanel.tsx
+++ b/app/context/optionsPanel.tsx
@@ -48,14 +48,12 @@ export const OptionsPanelProvider: React.FC<{ children: React.ReactNode }> = ({
   // without threading the context through props.
   useEffect(() => {
     registerToggle(toggle);
-    registerOpen(open);
     registerClose(close);
     return () => {
       registerToggle(null);
-      registerOpen(null);
       registerClose(null);
     };
-  }, [toggle, open, close]);
+  }, [toggle, close]);
 
   const value = useMemo<OptionsPanelContextValue>(
     () => ({ isOpen, open, close, toggle }),
@@ -79,14 +77,10 @@ export const useOptionsPanel = (): OptionsPanelContextValue =>
 // ---------------------------------------------------------------------------
 type Listener = (() => void) | null;
 let _toggleListener: Listener = null;
-let _openListener: Listener = null;
 let _closeListener: Listener = null;
 
 const registerToggle = (fn: Listener) => {
   _toggleListener = fn;
-};
-const registerOpen = (fn: Listener) => {
-  _openListener = fn;
 };
 const registerClose = (fn: Listener) => {
   _closeListener = fn;
@@ -106,13 +100,6 @@ export const toggleOptionsPanel = (): void => {
     return;
   }
   _toggleListener();
-};
-export const openOptionsPanel = (): void => {
-  if (!_openListener) {
-    warnUnwired('open');
-    return;
-  }
-  _openListener();
 };
 export const closeOptionsPanel = (): void => {
   if (!_closeListener) {

--- a/app/hooks/useBottomSheetBackHandler.tsx
+++ b/app/hooks/useBottomSheetBackHandler.tsx
@@ -15,7 +15,7 @@ import { useBottomSheetModal } from '@gorhom/bottom-sheet';
  * Mount once per BottomSheetModalProvider via the <BottomSheetBackHandler />
  * wrapper, since the hook reads from the modal context.
  */
-export function useBottomSheetBackHandler() {
+function useBottomSheetBackHandler() {
   const { dismiss } = useBottomSheetModal();
 
   useEffect(() => {

--- a/app/hooks/useTrickleProgress.ts
+++ b/app/hooks/useTrickleProgress.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { Animated, Easing } from 'react-native';
 
-export type TrickleProgress = {
+type TrickleProgress = {
   // The bar's value, 0..1. Interpolate to a width percentage.
   progress: Animated.Value;
   // Push the ceiling forward as real progress lands. Clamped to 0.985 so the

--- a/app/notifications/reminders.ts
+++ b/app/notifications/reminders.ts
@@ -66,7 +66,7 @@ export async function armBatchReminders(
   }
 }
 
-export async function cancelBatchReminders(): Promise<void> {
+async function cancelBatchReminders(): Promise<void> {
   const ids = await notifee.getTriggerNotificationIds();
   const ours = ids.filter(id => id.startsWith(REMINDER_PREFIX));
   if (ours.length > 0) {

--- a/app/showConfirm.ts
+++ b/app/showConfirm.ts
@@ -5,7 +5,7 @@
  * BottomSheetModalProvider. The sheet is registered exactly once per
  * provider; calling showConfirm before mount no-ops (warns in dev).
  */
-export type ConfirmButtonStyle = 'default' | 'cancel' | 'destructive' | 'ghost';
+type ConfirmButtonStyle = 'default' | 'cancel' | 'destructive' | 'ghost';
 
 export type ConfirmButton = {
   text: string;

--- a/app/types/NavigationTypes.ts
+++ b/app/types/NavigationTypes.ts
@@ -104,17 +104,17 @@ export type AppDrawerParamList = {
   [RouteEnum.Seed]: SeedNavigationState | undefined;
 };
 
-export type AddressBookNavigationState = {
+type AddressBookNavigationState = {
   currentAddress: string;
   routeStack: RouteEnum;
 };
 
-export type AddressListNavigationState = {
+type AddressListNavigationState = {
   addressKind: AddressKindEnum;
   setIndex: (n: number) => void;
 };
 
-export type ScannerAddressNavigationState = {
+type ScannerAddressNavigationState = {
   setAddress: (a: string) => void;
   active: boolean;
   // When true the scanner returns the scanned string verbatim — no `zcash:`
@@ -123,19 +123,19 @@ export type ScannerAddressNavigationState = {
   raw?: boolean;
 };
 
-export type ScannerUfvkNavigationState = {
+type ScannerUfvkNavigationState = {
   setUfvkText: (k: string) => void;
   active: boolean;
 };
 
-export type ValueTransferDetailNavigationState = {
+type ValueTransferDetailNavigationState = {
   index: number;
   vt: ValueTransferType;
   valueTransfersSliced: ValueTransferType[];
   totalLength: number;
 };
 
-export type ConfirmNavigationState = {
+type ConfirmNavigationState = {
   calculatedFee: number;
   parseAddressInfoJSON: RPCParseAddressType;
   donationAmount: number;
@@ -151,10 +151,10 @@ export type ConfirmNavigationState = {
   nym: boolean;
 };
 
-export type UfvkNavigationState = {
+type UfvkNavigationState = {
   action: UfvkActionEnum;
 };
 
-export type SeedNavigationState = {
+type SeedNavigationState = {
   action: SeedActionEnum;
 };

--- a/app/walletBackend/index.ts
+++ b/app/walletBackend/index.ts
@@ -7,17 +7,11 @@
  */
 import WalletBackend from './WalletBackend';
 
-export type { FfiError, FfiErrorCode, FfiResult } from './ffi';
-export type {
-  PriceRouteAttestation,
-  ZecPriceOutcome,
-  ZecPriceOutcomeHandlers,
-} from './utils/walletUtils';
+export type { FfiResult } from './ffi';
+export type { ZecPriceOutcome } from './utils/walletUtils';
 export { matchZecPriceOutcome } from './utils/walletUtils';
-export type { StartMigrationRoute } from './utils/migrationRouting';
 export { routeStartMigration } from './utils/migrationRouting';
 export {
-  cancelIronwoodMigration,
   changeServer,
   checkMyAddress,
   continueNoteSplitting,
@@ -25,7 +19,6 @@ export {
   createNewUnifiedAddress,
   createNewWallet,
   doSave,
-  doSaveBackup,
   drainOrchard,
   drainStatus,
   executeDueParts,

--- a/app/walletBackend/modules/MixnetCoordinator.ts
+++ b/app/walletBackend/modules/MixnetCoordinator.ts
@@ -42,10 +42,10 @@ import { recordMixnetTransportReady } from '../utils/mixnetGate';
 export type StartMixnetTransport = () => Promise<string>;
 
 /** How often the coordinator polls while the transport is bootstrapping. */
-export const BOOTSTRAP_POLL_MILLIS = 2_000;
+const BOOTSTRAP_POLL_MILLIS = 2_000;
 
 /** How often the coordinator polls outside of bootstrapping. */
-export const STEADY_POLL_MILLIS = 30_000;
+const STEADY_POLL_MILLIS = 30_000;
 
 /**
  * How long an auto-recovering coordinator waits after a failure, `died`, or

--- a/app/walletBackend/transforms/mixnetPresenter.ts
+++ b/app/walletBackend/transforms/mixnetPresenter.ts
@@ -9,7 +9,7 @@ import {
  * the bootstrap, or re-enable a lost transport. A closed union so screens
  * must render every case the policy can produce.
  */
-export type MixnetRecoveryAction = 'none' | 'wait' | 'reenable';
+type MixnetRecoveryAction = 'none' | 'wait' | 'reenable';
 
 /**
  * The screen-facing projection of the mixnet state. `statusKey` is a

--- a/app/walletBackend/types/RPCBatchReportType.ts
+++ b/app/walletBackend/types/RPCBatchReportType.ts
@@ -13,13 +13,13 @@
 // completion); parts without an outcome entry were not attempted and remain
 // due. `error` marks an infrastructure failure (offline, no migration) where
 // no batch ran at all.
-export type RPCPartSendResultType =
+type RPCPartSendResultType =
   | { kind: 'sent'; txid: string }
   | { kind: 'slid' }
   | { kind: 'not_due'; estimated_unix_time: number }
   | { kind: 'failed'; error: string };
 
-export type RPCPartOutcomeType = {
+type RPCPartOutcomeType = {
   part: number;
   denomination: number;
   result: RPCPartSendResultType;

--- a/app/walletBackend/types/RPCBatchStatusType.ts
+++ b/app/walletBackend/types/RPCBatchStatusType.ts
@@ -3,7 +3,7 @@
 // from the native call means no batch is running (before it starts, or once it
 // has finished); otherwise the counts are 0..=total and advance as the batch
 // proves, submits, then waits out the spacing before the next part.
-export type RPCBatchStatusPhase = 'sending' | 'spacing';
+type RPCBatchStatusPhase = 'sending' | 'spacing';
 
 export type RPCBatchStatusType = {
   // Parts owed this batch (N), fixed for the whole batch.

--- a/app/walletBackend/types/RPCDrainStatusType.ts
+++ b/app/walletBackend/types/RPCDrainStatusType.ts
@@ -3,7 +3,7 @@
 // native call means no drain is running (before it starts, or once it has
 // finished); otherwise the counts are 0..=total and advance as the drain
 // builds then broadcasts.
-export type RPCDrainStatusPhase = 'building' | 'transmitting';
+type RPCDrainStatusPhase = 'building' | 'transmitting';
 
 export type RPCDrainStatusType = {
   // Total transactions in the plan (N), fixed for the whole drain.

--- a/app/walletBackend/types/RPCMigrationStatusType.ts
+++ b/app/walletBackend/types/RPCMigrationStatusType.ts
@@ -2,7 +2,7 @@
 // `migration_status` (native `migrationStatusProcess`), arranged for direct
 // rendering. Values in zatoshis, heights in blocks, times in unix seconds.
 
-export type RPCMigrationPhaseType = {
+type RPCMigrationPhaseType = {
   kind: 'planned' | 'note_splitting' | 'parts_scheduled' | 'complete';
   // note_splitting: the round currently awaiting confirmation (from zero).
   round?: number;
@@ -35,7 +35,7 @@ export type RPCWakePointType = {
 // only future windows and structurally cannot hold this one, so the "send
 // batch" action reads it from here. `denominations` align element-for-element
 // with `part_ids`, both in the window's broadcast order.
-export type RPCDueBatchType = {
+type RPCDueBatchType = {
   // The current bucket's opening boundary (the parts' anchor height).
   boundary: number;
   part_ids: number[];

--- a/app/walletBackend/types/RPCSplitStepType.ts
+++ b/app/walletBackend/types/RPCSplitStepType.ts
@@ -1,7 +1,7 @@
 // What one `continue_note_splitting` call did (native
 // `continueNoteSplittingProcess`). The splitting loop matches on `step`:
 // sync between calls and keep going until `splitting_complete`.
-export type RPCSplitStepKind =
+type RPCSplitStepKind =
   'round_broadcast' | 'awaiting_confirmation' | 'splitting_complete';
 
 export type RPCSplitStepType = {

--- a/components/Components/SelectBottomSheet.tsx
+++ b/components/Components/SelectBottomSheet.tsx
@@ -20,7 +20,7 @@ import RegText from './RegText';
 import { ThemeType } from '../../app/types';
 import { useKeyboardHeight } from '../../app/hooks/useKeyboardHeight';
 
-export type SelectBottomSheetItem = {
+type SelectBottomSheetItem = {
   label: string;
   value: string;
 };

--- a/components/OptionsPanel/index.ts
+++ b/components/OptionsPanel/index.ts
@@ -1,7 +1,2 @@
-export { default } from './OptionsPanel';
 export { default as OptionsPanelHost } from './OptionsPanelHost';
-export type {
-  OptionsPanelAction,
-  OptionsPanelProps,
-  OptionsPanelSocial,
-} from './OptionsPanel';
+export type { OptionsPanelAction, OptionsPanelSocial } from './OptionsPanel';


### PR DESCRIPTION
Stacked on #1209 (`send_field_update_union`). Review the last commit only; merge after #1209.

## What this is

A dead-code audit of all 383 TypeScript sources with three independent tools: knip, ts-prune, and ts-unused-exports (run against the repo's TypeScript 5.5.4). Raw flag counts were 192, 129, and 44. Only findings all three tools agreed on were acted on. Knip found zero fully-unused files.

## What changed

**Deleted one dead implementation.** `openOptionsPanel` in `app/context/optionsPanel.tsx` had no caller anywhere; its siblings `toggleOptionsPanel` and `closeOptionsPanel` are both live in LoadedApp. Its listener wiring (`_openListener`, `registerOpen`) went with it.

**Pruned nine dead barrel re-exports.** Every consumer of these symbols imports them from the defining module, never through the barrel. `app/walletBackend/index.ts` loses `FfiError`, `FfiErrorCode`, `PriceRouteAttestation`, `ZecPriceOutcomeHandlers`, `StartMigrationRoute`, `doSaveBackup`, and `cancelIronwoodMigration`. `components/OptionsPanel/index.ts` loses its `default` re-export and `OptionsPanelProps`.

**Stripped 24 dead `export` keywords.** These symbols are used inside their own module and nowhere else, so the declarations stay and the keyword goes. The clusters: eight `*NavigationState` types in `app/types/NavigationTypes.ts`, seven `RPC*` phase/kind types under `app/walletBackend/types/`, the two `MixnetCoordinator` poll constants, `MixnetRecoveryAction`, `navigationRef`, `useBottomSheetBackHandler`, `TrickleProgress`, `cancelBatchReminders`, `ConfirmButtonStyle`, and `SelectBottomSheetItem`.

## Flagged, deliberately not removed

Three functions are unanimously unused by production code but stay exported:

- `cancelIronwoodMigration` (`walletUtils.ts`) has unit tests and no production caller. Either the cancel UI is coming or the function and its tests should go together.
- `enableMixnet` (`mixnetUtils.ts`) is the documented exec-fallback path for spawning the bundled nym-proxy; the shim-hosted path uses `attachMixnet`.
- `stopMixnetTransport` (`nymTransport.ts`) is the documented shutdown teardown for the platform-hosted proxy.

The two mixnet wrappers are unwired API on this feature branch. Un-exporting them fails lint because nothing calls them yet, so they keep their exports until the wiring lands or a decision retires them.

## Verification

`tsc --noEmit` and `eslint` over every touched file are clean. The tools' raw outputs and the intersection script are reproducible with `npx knip`, `npx ts-prune -p tsconfig.json`, and `ts-unused-exports tsconfig.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
