### PR TITLE
ci: space the ci-build image pull retries across a registry outage

### DIFF
--- a/.github/workflows/android-ubuntu-integration-test-ci.yaml
+++ b/.github/workflows/android-ubuntu-integration-test-ci.yaml
@@ -332,8 +332,15 @@ jobs:
           echo "CI_BUILD_TAG=$TAG" >> "$GITHUB_ENV"
           echo "Computed ci-build tag: $TAG"
 
+      # A runner can lose registry egress for minutes at a time (2026-07-25:
+      # four consecutive 60s dial timeouts to registry-1.docker.io cancelled
+      # a whole run through fail-all). Space the retries across ~13 minutes
+      # to outlast such an outage. Podman does not retry 4xx responses, so a
+      # tag that was never published still fails on the first attempt.
       - name: Pull ci-build image
-        run: podman pull docker.io/zingodevops/ci-build:${CI_BUILD_TAG}
+        run: |
+          podman pull --retry 8 --retry-delay 45s \
+            docker.io/zingodevops/ci-build:${CI_BUILD_TAG}
 
       - name: Extract binaries & params from image
         run: |


### PR DESCRIPTION
Hardens the integration buckets' ci-build image pull against transient registry outages. Based on `dev` so every PR benefits; the feat/nym stack picks it up on its next rebase.

## The failure this prevents

In run 30166451562 (PR #1208) the "accounts" bucket lost all egress to `registry-1.docker.io` for over four minutes: four consecutive `dial tcp <ip>:443: i/o timeout` failures against four different registry IPs. Podman's default three retries fire one second apart, so all of them burned inside the outage, the step failed with exit 125, and the bucket's fail-all step cancelled the entire run, killing the APK build mid-compile. The two sibling buckets pulled the identical tag successfully in the same window: one runner's network, not the registry and not the tag.

## The change

`podman pull --retry 8 --retry-delay 45s`. The attempts now span roughly thirteen minutes instead of four, long enough to ride out an egress blip while the bucket would otherwise be idling toward the ci-gate artifact hold anyway. A healthy pull is unchanged. A tag that was never published still fails on the first attempt, because podman retries only errors it classifies as transient (timeouts, 5xx, 429) and never 4xx responses such as manifest-unknown.

The flags require podman 4.7; the ubuntu-24.04 runners ship 4.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
