### PR TITLE
fix: pin zingolib by rev, unbreaking CI after the branch deletion

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "pepper-sync"
 version = "0.5.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
 dependencies = [
  "bip32",
  "byteorder",
@@ -2291,7 +2291,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_transparent",
  "zingo-memo",
- "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood)",
+ "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0)",
  "zingo-status",
  "zip32",
 ]
@@ -5005,7 +5005,7 @@ source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b22
 [[package]]
 name = "zingo-memo"
 version = "0.1.1"
-source = "git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
 dependencies = [
  "zcash_address",
  "zcash_encoding",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "zingo-netutils"
 version = "5.0.1"
-source = "git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
 dependencies = [
  "http",
  "lightwallet-protocol",
@@ -5044,7 +5044,7 @@ dependencies = [
 [[package]]
 name = "zingo-price"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
 dependencies = [
  "byteorder",
  "reqwest",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "zingo-status"
 version = "0.2.1"
-source = "git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
 dependencies = [
  "byteorder",
  "zcash_protocol",
@@ -5082,7 +5082,7 @@ source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b22
 [[package]]
 name = "zingolib"
 version = "5.0.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
 dependencies = [
  "append-only-vec",
  "bech32",
@@ -5129,7 +5129,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_transparent",
  "zingo-memo",
- "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood)",
+ "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0)",
  "zingo-price",
  "zingo-status",
  "zingo_common_components",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "zingolib_testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
 dependencies = [
  "http",
  "nonempty",
@@ -5152,7 +5152,7 @@ dependencies = [
  "zcash_local_net",
  "zcash_primitives",
  "zcash_protocol",
- "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?branch=feat%2Fironwood)",
+ "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0)",
  "zingo_common_components",
  "zingo_test_vectors",
  "zingolib",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "pepper-sync"
 version = "0.5.0"
-source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d#b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d"
 dependencies = [
  "bip32",
  "byteorder",
@@ -2291,7 +2291,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_transparent",
  "zingo-memo",
- "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0)",
+ "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d)",
  "zingo-status",
  "zip32",
 ]
@@ -5005,7 +5005,7 @@ source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b22
 [[package]]
 name = "zingo-memo"
 version = "0.1.1"
-source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d#b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d"
 dependencies = [
  "zcash_address",
  "zcash_encoding",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "zingo-netutils"
 version = "5.0.1"
-source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d#b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d"
 dependencies = [
  "http",
  "lightwallet-protocol",
@@ -5044,7 +5044,7 @@ dependencies = [
 [[package]]
 name = "zingo-price"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d#b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d"
 dependencies = [
  "byteorder",
  "reqwest",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "zingo-status"
 version = "0.2.1"
-source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d#b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d"
 dependencies = [
  "byteorder",
  "zcash_protocol",
@@ -5082,7 +5082,7 @@ source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b22
 [[package]]
 name = "zingolib"
 version = "5.0.0"
-source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d#b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d"
 dependencies = [
  "append-only-vec",
  "bech32",
@@ -5129,7 +5129,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_transparent",
  "zingo-memo",
- "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0)",
+ "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d)",
  "zingo-price",
  "zingo-status",
  "zingo_common_components",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "zingolib_testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0#ba5fdef493264f813ee74e87a7c533f1176f2eb0"
+source = "git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d#b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d"
 dependencies = [
  "http",
  "nonempty",
@@ -5152,7 +5152,7 @@ dependencies = [
  "zcash_local_net",
  "zcash_primitives",
  "zcash_protocol",
- "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=ba5fdef493264f813ee74e87a7c533f1176f2eb0)",
+ "zingo-netutils 5.0.1 (git+https://github.com/zingolabs/zingolib?rev=b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d)",
  "zingo_common_components",
  "zingo_test_vectors",
  "zingolib",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,12 +4,15 @@ resolver = "2"
 
 [workspace.dependencies]
 # feat/ironwood merged into zingolib dev (zingolib#2419) and the branch was
-# deleted, which broke every branch-based resolve. Pin the exact commit the
-# lockfile was already frozen at; moving to zingolib dev is a deliberate
-# follow-up, not part of this unbreak.
-zingolib = { git = "https://github.com/zingolabs/zingolib", rev = "ba5fdef493264f813ee74e87a7c533f1176f2eb0" }
-pepper-sync = { git = "https://github.com/zingolabs/zingolib", rev = "ba5fdef493264f813ee74e87a7c533f1176f2eb0" }
-zingolib_testutils = { git = "https://github.com/zingolabs/zingolib", rev = "ba5fdef493264f813ee74e87a7c533f1176f2eb0" }
+# deleted, which broke every branch-based resolve. Pin the branch's final
+# tip: the previously locked ba5fdef4 predates the pool-activation
+# derivation fix (zingolib ADR 0014), without which regtest wallets never
+# treat Ironwood as active and the calibrated integration ledger fails.
+# Moving onto zingolib dev is a deliberate follow-up, not part of this
+# unbreak.
+zingolib = { git = "https://github.com/zingolabs/zingolib", rev = "b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d" }
+pepper-sync = { git = "https://github.com/zingolabs/zingolib", rev = "b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d" }
+zingolib_testutils = { git = "https://github.com/zingolabs/zingolib", rev = "b09ebf53c72f94abbdb3e4e4836ea8b1782aab6d" }
 regchest_utils = { git = "https://github.com/zingolabs/zingo-regchest", branch = "dev" }
 zingomobile_utils = { path = "zingomobile_utils" }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,9 +3,13 @@ members = ["lib", "android", "ios", "zingomobile_utils", "workbench"]
 resolver = "2"
 
 [workspace.dependencies]
-zingolib = { git = "https://github.com/zingolabs/zingolib", branch = "feat/ironwood" }
-pepper-sync = { git = "https://github.com/zingolabs/zingolib", branch = "feat/ironwood" }
-zingolib_testutils = { git = "https://github.com/zingolabs/zingolib", branch = "feat/ironwood" }
+# feat/ironwood merged into zingolib dev (zingolib#2419) and the branch was
+# deleted, which broke every branch-based resolve. Pin the exact commit the
+# lockfile was already frozen at; moving to zingolib dev is a deliberate
+# follow-up, not part of this unbreak.
+zingolib = { git = "https://github.com/zingolabs/zingolib", rev = "ba5fdef493264f813ee74e87a7c533f1176f2eb0" }
+pepper-sync = { git = "https://github.com/zingolabs/zingolib", rev = "ba5fdef493264f813ee74e87a7c533f1176f2eb0" }
+zingolib_testutils = { git = "https://github.com/zingolabs/zingolib", rev = "ba5fdef493264f813ee74e87a7c533f1176f2eb0" }
 regchest_utils = { git = "https://github.com/zingolabs/zingo-regchest", branch = "dev" }
 zingomobile_utils = { path = "zingomobile_utils" }
 


### PR DESCRIPTION
Unbreaks every dev-based CI run. Upstream merged `feat/ironwood` into zingolib `dev` (zingolib#2419, 2026-07-24 04:59 UTC) and deleted the branch, so the "Resolve zingolib rev" step's `git ls-remote` resolves nothing and fail-all cancels the run. Both nightlies and every PR against dev have been red from this single cause since; the last good resolve was 2026-07-23 21:23 UTC.

This pins `zingolib`, `pepper-sync`, and `zingolib_testutils` to `b09ebf53`, the deleted branch's final tip. The first commit pinned the lockfile's frozen `ba5fdef4`; running CI on it exposed the second, older failure: the lock had silently lagged the branch, and the eleven commits it was missing include the pool-activation derivation fix (zingolib ADR 0014), without which regtest wallets never treat Ironwood as active and the calibrated integration ledger fails (issue #1213, ironwood 0 / orchard 710000). Moving the pin forward to zingolib `dev` is a deliberate follow-up with its own review, not part of this unbreak.

Related: #1211 hardens the image pull that a separate runner egress flake killed; it is blocked on red checks that this PR unbreaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
