### PR TITLE
fix: sync migration bugs

### DIFF
--- a/__tests__/MeetIronwood.trigger.unit.tsx
+++ b/__tests__/MeetIronwood.trigger.unit.tsx
@@ -60,6 +60,16 @@ function setChainTip(instance: LoadedAppClass, latestBlock: number) {
   };
 }
 
+// Puts the wallet's scan progress on `state`. The trigger must not fire while
+// a scan is short of the tip: mid-sync, confirmed_orchard_balance can carry
+// notes that are not yet spendable.
+function setSyncStatus(instance: LoadedAppClass, syncingStatus: any) {
+  (instance as any).state = {
+    ...(instance as any).state,
+    syncingStatus,
+  };
+}
+
 function makeInstance(latestBlock: number = activation): LoadedAppClass {
   const props: any = {
     navigation: mockNavigation,
@@ -154,6 +164,42 @@ describe('MeetIronwood auto-launch trigger', () => {
     setChainTip(instance, activation);
     await instance.checkMeetIronwood(makeBalance(0.001));
 
+    expect(navigate).toHaveBeenCalledWith(RouteEnum.MeetIronwood);
+  });
+
+  test('does not navigate while a sync is still short of the tip', async () => {
+    const instance = makeInstance();
+    const navigate = jest.fn();
+    (instance as any).drawerNav = { navigate };
+    setSyncStatus(instance, {
+      scan_ranges: [{}],
+      percentage_total_outputs_scanned: 40,
+    });
+
+    await instance.checkMeetIronwood(makeBalance(0.001));
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test('navigates once the scan reaches the tip', async () => {
+    const instance = makeInstance();
+    const navigate = jest.fn();
+    (instance as any).drawerNav = { navigate };
+
+    // mid-sync: the balance is not yet trustworthy, so no launch.
+    setSyncStatus(instance, {
+      scan_ranges: [{}],
+      percentage_total_outputs_scanned: 40,
+    });
+    await instance.checkMeetIronwood(makeBalance(0.001));
+    expect(navigate).not.toHaveBeenCalled();
+
+    // a later tick lands the scan at the tip; now the balance is spendable.
+    setSyncStatus(instance, {
+      scan_ranges: [{}],
+      percentage_total_outputs_scanned: 100,
+    });
+    await instance.checkMeetIronwood(makeBalance(0.001));
     expect(navigate).toHaveBeenCalledWith(RouteEnum.MeetIronwood);
   });
 

--- a/__tests__/walletBackend.syncProgress.unit.test.ts
+++ b/__tests__/walletBackend.syncProgress.unit.test.ts
@@ -1,0 +1,59 @@
+import { scanInProgress } from '../app/walletBackend/utils/syncProgress';
+import { RPCSyncStatusType } from '../app/walletBackend/types/RPCSyncStatusType';
+
+const status = (s: Partial<RPCSyncStatusType>) => s as RPCSyncStatusType;
+
+describe('scanInProgress', () => {
+  test('empty status reads as not scanning', () => {
+    expect(scanInProgress(status({}))).toBe(false);
+  });
+
+  test('no open scan ranges reads as not scanning', () => {
+    expect(
+      scanInProgress(
+        status({ scan_ranges: [], percentage_total_outputs_scanned: 40 }),
+      ),
+    ).toBe(false);
+  });
+
+  test('scanning short of the tip is in progress', () => {
+    expect(
+      scanInProgress(
+        status({
+          scan_ranges: [{}] as RPCSyncStatusType['scan_ranges'],
+          percentage_total_outputs_scanned: 40,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test('scan at the tip is done', () => {
+    expect(
+      scanInProgress(
+        status({
+          scan_ranges: [{}] as RPCSyncStatusType['scan_ranges'],
+          percentage_total_outputs_scanned: 100,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test('falls back to block percentage when outputs are absent', () => {
+    expect(
+      scanInProgress(
+        status({
+          scan_ranges: [{}] as RPCSyncStatusType['scan_ranges'],
+          percentage_total_blocks_scanned: 100,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test('open ranges with no percentage yet is in progress', () => {
+    expect(
+      scanInProgress(
+        status({ scan_ranges: [{}] as RPCSyncStatusType['scan_ranges'] }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -1249,10 +1249,29 @@ export class LoadedAppClass extends Component<
       );
       return;
     }
-    // zingolib's confirmed_orchard_balance sums only unspent, confirmed,
-    // non-dust notes (each note must exceed the ZIP-317 marginal fee of
-    // 5000 zats), so a positive value means the wallet holds at least one
-    // spendable non-dust Orchard note.
+    // The balance is only trustworthy once the scan reaches the tip. Mid-sync,
+    // zingolib reports a note as confirmed the moment it is scanned, before its
+    // witness is built up to a spendable anchor, so confirmed_orchard_balance
+    // can carry funds the wallet cannot yet spend. Launching then drops the
+    // user into a migration for an amount with no spendable notes behind it,
+    // and the send errors out when it tries to assemble the transaction and
+    // cannot source them. Wait out the scan; setSyncingStatus re-runs this on
+    // every tick, so it fires the moment sync completes. Mirrors
+    // SyncCoordinator's in-refresh test.
+    const ss = this.state.syncingStatus;
+    const scanInProgress =
+      !!ss.scan_ranges &&
+      ss.scan_ranges.length > 0 &&
+      (ss.percentage_total_outputs_scanned ??
+        ss.percentage_total_blocks_scanned ??
+        0) < 100;
+    if (scanInProgress) {
+      console.log('meet ironwood: sync still in progress');
+      return;
+    }
+    // Scan at the tip: confirmed_orchard_balance now reflects witnessed,
+    // spendable, non-dust notes (each above the ZIP-317 marginal fee of 5000
+    // zats). A positive value means at least one migratable note.
     if (!totalBalance || totalBalance.confirmedOrchardBalance <= 0) {
       console.log(
         'meet ironwood: no spendable non-dust orchard funds',

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -34,6 +34,7 @@ import {
   loadExistingWallet,
   parseAddress,
   reconcileMigration,
+  scanInProgress,
   setConfigWalletToProd,
 } from '../walletBackend';
 import {
@@ -1256,16 +1257,8 @@ export class LoadedAppClass extends Component<
     // user into a migration for an amount with no spendable notes behind it,
     // and the send errors out when it tries to assemble the transaction and
     // cannot source them. Wait out the scan; setSyncingStatus re-runs this on
-    // every tick, so it fires the moment sync completes. Mirrors
-    // SyncCoordinator's in-refresh test.
-    const ss = this.state.syncingStatus;
-    const scanInProgress =
-      !!ss.scan_ranges &&
-      ss.scan_ranges.length > 0 &&
-      (ss.percentage_total_outputs_scanned ??
-        ss.percentage_total_blocks_scanned ??
-        0) < 100;
-    if (scanInProgress) {
+    // every tick, so it fires the moment sync completes.
+    if (scanInProgress(this.state.syncingStatus)) {
       console.log('meet ironwood: sync still in progress');
       return;
     }

--- a/app/hooks/useSyncStatus.ts
+++ b/app/hooks/useSyncStatus.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Animated } from 'react-native';
 import { isEqual } from 'lodash';
 import { RPCSyncStatusType } from '../walletBackend/types/RPCSyncStatusType';
+import { scanInProgress } from '../walletBackend/utils/syncProgress';
 
 /**
  * Derives display-ready sync state from the raw RPC sync status.
@@ -50,13 +51,7 @@ export function useSyncStatus({
           syncingStatus.percentage_total_blocks_scanned ??
           0,
       );
-      setSyncInProgress(
-        !!syncingStatus.scan_ranges &&
-          syncingStatus.scan_ranges.length > 0 &&
-          (syncingStatus.percentage_total_outputs_scanned ??
-            syncingStatus.percentage_total_blocks_scanned ??
-            0) < 100,
-      );
+      setSyncInProgress(scanInProgress(syncingStatus));
     }
   }, [
     syncingStatus,

--- a/app/walletBackend/index.ts
+++ b/app/walletBackend/index.ts
@@ -18,6 +18,7 @@ export {
   routeRescheduleParts,
   routeStartMigration,
 } from './utils/migrationRouting';
+export { scanInProgress } from './utils/syncProgress';
 export {
   cancelIronwoodMigration,
   changeServer,

--- a/app/walletBackend/modules/SyncCoordinator.ts
+++ b/app/walletBackend/modules/SyncCoordinator.ts
@@ -16,6 +16,7 @@ import { TotalBalanceClass, GlobalConst } from '../../AppState';
 import RPCModule from '../../RPCModule';
 import { RPCSyncStatusType } from '../types/RPCSyncStatusType';
 import { RPCSyncPollType } from '../types/RPCSyncPollType';
+import { scanInProgress } from '../utils/syncProgress';
 import { RPCPerformanceLevelEnum } from '../enums/RPCPerformanceLevelEnum';
 import { WalletBackendConfig } from '../config/WalletBackendConfig';
 import { DataService } from './DataService';
@@ -298,12 +299,7 @@ export class SyncCoordinator {
             : Number(ss.percentage_total_blocks_scanned?.toFixed(2));
 
       // Close the poll timer if the sync finished(checked via promise above)
-      const inR: boolean =
-        !!ss.scan_ranges &&
-        ss.scan_ranges.length > 0 &&
-        (ss.percentage_total_outputs_scanned ??
-          ss.percentage_total_blocks_scanned ??
-          0) < 100;
+      const inR = scanInProgress(ss);
       if (!inR) {
         this.config.keepAwake(false);
       } else {

--- a/app/walletBackend/utils/syncProgress.ts
+++ b/app/walletBackend/utils/syncProgress.ts
@@ -1,0 +1,15 @@
+import { RPCSyncStatusType } from '../types/RPCSyncStatusType';
+
+// True while a scan is running and short of the chain tip. A note only becomes spendable once the scan
+// reaches the tip, so spend-dependent work gates on this. An absent or empty
+// scan range means no active scan (idle/startup) and reads as false. Callers
+// that want to treat startup as busy wrap this themselves (see useSyncStatus).
+export function scanInProgress(ss: RPCSyncStatusType): boolean {
+  return (
+    !!ss.scan_ranges &&
+    ss.scan_ranges.length > 0 &&
+    (ss.percentage_total_outputs_scanned ??
+      ss.percentage_total_blocks_scanned ??
+      0) < 100
+  );
+}


### PR DESCRIPTION
Fixes an issue where the migration onboard would launch but now allow any action when the wallet had some unspendable Orchard notes due to sync not having finished.