### PR TITLE
refactor(ffi): move every read-only endpoint onto the LIGHTCLIENT read accessor

### DIFF
--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1672,7 +1672,7 @@ pub fn get_seed() -> Result<String, ZingolibError> {
 }
 
 pub fn get_ufvk() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             let wallet = lightclient.wallet().read().await;
             let ufvk: UnifiedFullViewingKey = wallet

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1927,7 +1927,7 @@ pub fn get_balance() -> Result<String, ZingolibError> {
 }
 
 pub fn get_total_memobytes_to_address() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             match lightclient.do_total_memobytes_to_address().await {
                 Ok(total_memo_bytes) => Ok(json::JsonValue::from(total_memo_bytes).pretty(2)),

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2007,7 +2007,7 @@ pub fn get_spendable_balance_with_address(
 }
 
 pub fn get_spendable_balance_total() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             let wallet = lightclient.wallet().read().await;
             let spendable_balance = wallet

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2036,19 +2036,8 @@ pub fn get_unified_addresses() -> Result<String, ZingolibError> {
 }
 
 pub fn get_transparent_addresses() -> Result<String, ZingolibError> {
-    with_panic_guard(|| {
-        let mut guard = LIGHTCLIENT
-            .write()
-            .map_err(|_| ZingolibError::LightclientLockPoisoned)?;
-        if let Some(lightclient) = &mut *guard {
-            Ok(
-                RT.block_on(
-                    async move { lightclient.transparent_addresses_json().await.pretty(2) },
-                ),
-            )
-        } else {
-            Err(ZingolibError::LightclientNotInitialized)
-        }
+    with_initialized_lightclient_read(|lightclient| {
+        Ok(RT.block_on(async move { lightclient.transparent_addresses_json().await.pretty(2) }))
     })
 }
 

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1938,7 +1938,7 @@ pub fn get_total_memobytes_to_address() -> Result<String, ZingolibError> {
 }
 
 pub fn get_total_value_to_address() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             match lightclient.do_total_value_to_address().await {
                 Ok(total_values) => Ok(json::JsonValue::from(total_values).pretty(2)),

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2228,24 +2228,17 @@ pub fn get_config_wallet_performance() -> Result<String, ZingolibError> {
 }
 
 pub fn get_wallet_version() -> Result<String, ZingolibError> {
-    with_panic_guard(|| {
-        let mut guard = LIGHTCLIENT
-            .write()
-            .map_err(|_| ZingolibError::LightclientLockPoisoned)?;
-        if let Some(lightclient) = &mut *guard {
-            Ok(RT.block_on(async move {
-                let wallet = lightclient.wallet().read().await;
-                let current_version = wallet.current_version();
-                let read_version = wallet.read_version();
-                object! {
-                    "current_version" => current_version,
-                    "read_version" => read_version
-                }
-                .pretty(2)
-            }))
-        } else {
-            Err(ZingolibError::LightclientNotInitialized)
-        }
+    with_initialized_lightclient_read(|lightclient| {
+        Ok(RT.block_on(async move {
+            let wallet = lightclient.wallet().read().await;
+            let current_version = wallet.current_version();
+            let read_version = wallet.read_version();
+            object! {
+                "current_version" => current_version,
+                "read_version" => read_version
+            }
+            .pretty(2)
+        }))
     })
 }
 

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -407,6 +407,9 @@ where
     })
 }
 
+#[cfg(test)]
+mod lock_discipline_tests;
+
 /// Parses the schedule suffix of a `regtest:<schedule>` chain hint into
 /// activation heights.
 ///
@@ -1446,18 +1449,11 @@ pub fn get_latest_block_server(server_uri: String) -> Result<String, ZingolibErr
 }
 
 pub fn get_latest_block_wallet() -> Result<String, ZingolibError> {
-    with_panic_guard(|| {
-        let mut guard = LIGHTCLIENT
-            .write()
-            .map_err(|_| ZingolibError::LightclientLockPoisoned)?;
-        if let Some(lightclient) = &mut *guard {
-            Ok(RT.block_on(async move {
-                let wallet = lightclient.wallet().read().await;
-                object! { "height" => json::JsonValue::from(wallet.sync_state.last_known_chain_height().map_or(0, u32::from))}.pretty(2)
-            }))
-        } else {
-            Err(ZingolibError::LightclientNotInitialized)
-        }
+    with_initialized_lightclient_read(|lightclient| {
+        Ok(RT.block_on(async move {
+            let wallet = lightclient.wallet().read().await;
+            object! { "height" => json::JsonValue::from(wallet.sync_state.last_known_chain_height().map_or(0, u32::from))}.pretty(2)
+        }))
     })
 }
 

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2156,18 +2156,11 @@ pub fn check_my_address(address: String) -> Result<String, ZingolibError> {
 }
 
 pub fn get_wallet_save_required() -> Result<String, ZingolibError> {
-    with_panic_guard(|| {
-        let mut guard = LIGHTCLIENT
-            .write()
-            .map_err(|_| ZingolibError::LightclientLockPoisoned)?;
-        if let Some(lightclient) = &mut *guard {
-            Ok(RT.block_on(async move {
-                let save_required = lightclient.is_save_required().await;
-                object! { "save_required" => save_required }.pretty(2)
-            }))
-        } else {
-            Err(ZingolibError::LightclientNotInitialized)
-        }
+    with_initialized_lightclient_read(|lightclient| {
+        Ok(RT.block_on(async move {
+            let save_required = lightclient.is_save_required().await;
+            object! { "save_required" => save_required }.pretty(2)
+        }))
     })
 }
 

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1916,7 +1916,7 @@ pub fn get_messages(address: String) -> Result<String, ZingolibError> {
 }
 
 pub fn get_balance() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             match lightclient.account_balance(AccountId::ZERO).await {
                 Ok(bal) => Ok(json::JsonValue::from(bal).pretty(2)),

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1949,7 +1949,7 @@ pub fn get_total_value_to_address() -> Result<String, ZingolibError> {
 }
 
 pub fn get_total_spends_to_address() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             match lightclient.do_total_spends_to_address().await {
                 Ok(total_spends) => Ok(json::JsonValue::from(total_spends).pretty(2)),

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1990,7 +1990,7 @@ pub fn get_spendable_balance_with_address(
     address: String,
     zennies: String,
 ) -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         let address = address_from_str(&address)
             .map_err(|_| ZingolibError::InvalidInput("unknown address format".to_string()))?;
         let zennies = zennies.parse().map_err(|_| {

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1648,7 +1648,7 @@ fn chain_name_short(chain: ChainType) -> &'static str {
 // TODO: rename "get_seed_phrase" or "get_mnemonic_phrase"
 // or if other recovery info is being used could rename "get_recovery_info" ?
 pub fn get_seed() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             let wallet = lightclient.wallet().read().await;
             let recovery_info = wallet.recovery_info().ok_or_else(|| {

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1482,7 +1482,7 @@ fn splice_migrated_values(
 }
 
 pub fn get_value_transfers() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             let wallet = lightclient.wallet().read().await;
 

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2086,7 +2086,7 @@ pub fn create_new_transparent_address() -> Result<String, ZingolibError> {
 }
 
 pub fn check_my_address(address: String) -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             let wallet = lightclient.wallet().read().await;
             let address_ref = wallet

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1720,53 +1720,46 @@ pub fn change_server(server_uri: String) -> Result<String, ZingolibError> {
 }
 
 pub fn wallet_kind() -> Result<String, ZingolibError> {
-    with_panic_guard(|| {
-        let mut guard = LIGHTCLIENT
-            .write()
-            .map_err(|_| ZingolibError::LightclientLockPoisoned)?;
-        if let Some(lightclient) = &mut *guard {
-            Ok(RT.block_on(async move {
-                let wallet = lightclient.wallet().read().await;
-                if wallet.mnemonic_phrase().is_some() {
-                    object! {"kind" => "Loaded from seed or mnemonic phrase",
-                            "transparent" => true,
-                            "sapling" => true,
-                            "orchard" => true,
-                    }
-                    .pretty(2)
-                } else {
-                    match wallet
-                        .unified_key_store
-                        .get(&AccountId::ZERO)
-                        .expect("account 0 must always exist")
-                    {
-                        UnifiedKeyStore::Spend(_) => object! {
-                            "kind" => "Loaded from unified spending key",
-                            "transparent" => true,
-                            "sapling" => true,
-                            "orchard" => true,
-                        }
-                        .pretty(2),
-                        UnifiedKeyStore::View(ufvk) => object! {
-                            "kind" => "Loaded from unified full viewing key",
-                            "transparent" => ufvk.transparent().is_some(),
-                            "sapling" => ufvk.sapling().is_some(),
-                            "orchard" => ufvk.orchard().is_some(),
-                        }
-                        .pretty(2),
-                        UnifiedKeyStore::Empty => object! {
-                            "kind" => "No keys found",
-                            "transparent" => false,
-                            "sapling" => false,
-                            "orchard" => false,
-                        }
-                        .pretty(2),
-                    }
+    with_initialized_lightclient_read(|lightclient| {
+        Ok(RT.block_on(async move {
+            let wallet = lightclient.wallet().read().await;
+            if wallet.mnemonic_phrase().is_some() {
+                object! {"kind" => "Loaded from seed or mnemonic phrase",
+                        "transparent" => true,
+                        "sapling" => true,
+                        "orchard" => true,
                 }
-            }))
-        } else {
-            Err(ZingolibError::LightclientNotInitialized)
-        }
+                .pretty(2)
+            } else {
+                match wallet
+                    .unified_key_store
+                    .get(&AccountId::ZERO)
+                    .expect("account 0 must always exist")
+                {
+                    UnifiedKeyStore::Spend(_) => object! {
+                        "kind" => "Loaded from unified spending key",
+                        "transparent" => true,
+                        "sapling" => true,
+                        "orchard" => true,
+                    }
+                    .pretty(2),
+                    UnifiedKeyStore::View(ufvk) => object! {
+                        "kind" => "Loaded from unified full viewing key",
+                        "transparent" => ufvk.transparent().is_some(),
+                        "sapling" => ufvk.sapling().is_some(),
+                        "orchard" => ufvk.orchard().is_some(),
+                    }
+                    .pretty(2),
+                    UnifiedKeyStore::Empty => object! {
+                        "kind" => "No keys found",
+                        "transparent" => false,
+                        "sapling" => false,
+                        "orchard" => false,
+                    }
+                    .pretty(2),
+                }
+            }
+        }))
     })
 }
 

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1582,7 +1582,7 @@ pub fn pause_sync() -> Result<String, ZingolibError> {
 }
 
 fn status_sync() -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async {
             let wallet = lightclient.wallet().read().await;
             match pepper_sync::sync_status(&*wallet).await {

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2030,15 +2030,8 @@ pub fn get_option_wallet() -> Result<String, ZingolibError> {
 }
 
 pub fn get_unified_addresses() -> Result<String, ZingolibError> {
-    with_panic_guard(|| {
-        let mut guard = LIGHTCLIENT
-            .write()
-            .map_err(|_| ZingolibError::LightclientLockPoisoned)?;
-        if let Some(lightclient) = &mut *guard {
-            Ok(RT.block_on(async move { lightclient.unified_addresses_json().await.pretty(2) }))
-        } else {
-            Err(ZingolibError::LightclientNotInitialized)
-        }
+    with_initialized_lightclient_read(|lightclient| {
+        Ok(RT.block_on(async move { lightclient.unified_addresses_json().await.pretty(2) }))
     })
 }
 

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2213,24 +2213,17 @@ pub fn set_config_wallet_to_prod(
 }
 
 pub fn get_config_wallet_performance() -> Result<String, ZingolibError> {
-    with_panic_guard(|| {
-        let mut guard = LIGHTCLIENT
-            .write()
-            .map_err(|_| ZingolibError::LightclientLockPoisoned)?;
-        if let Some(lightclient) = &mut *guard {
-            Ok(RT.block_on(async move {
-                let wallet = lightclient.wallet().read().await;
-                let performance_level = match wallet.wallet_settings.sync_config.performance_level {
-                    PerformanceLevel::Low => "Low",
-                    PerformanceLevel::Medium => "Medium",
-                    PerformanceLevel::High => "High",
-                    PerformanceLevel::Maximum => "Maximum",
-                };
-                object! { "performance_level" => performance_level }.pretty(2)
-            }))
-        } else {
-            Err(ZingolibError::LightclientNotInitialized)
-        }
+    with_initialized_lightclient_read(|lightclient| {
+        Ok(RT.block_on(async move {
+            let wallet = lightclient.wallet().read().await;
+            let performance_level = match wallet.wallet_settings.sync_config.performance_level {
+                PerformanceLevel::Low => "Low",
+                PerformanceLevel::Medium => "Medium",
+                PerformanceLevel::High => "High",
+                PerformanceLevel::Maximum => "Maximum",
+            };
+            object! { "performance_level" => performance_level }.pretty(2)
+        }))
     })
 }
 

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1902,7 +1902,7 @@ pub fn get_version() -> Result<String, ZingolibError> {
 }
 
 pub fn get_messages(address: String) -> Result<String, ZingolibError> {
-    with_initialized_lightclient(|lightclient| {
+    with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             match lightclient
                 .messages_containing(Some(address.as_str()))

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -235,6 +235,19 @@ fn spendable_balance_with_address_refuses_beside_a_held_read_guard() {
 }
 
 #[test]
+fn spendable_balance_total_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_spendable_balance_total);
+    // A fresh wallet holds nothing spendable.
+    assert_eq!(
+        answer["spendable_balance"].as_u64(),
+        Some(0),
+        "the fixture wallet's spendable total is zero: {answer}"
+    );
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -1,0 +1,69 @@
+//! Lock-discipline tests for the read-only FFI endpoints (zingo-mobile#1223).
+//!
+//! Each test initializes the offline wallet, then calls its endpoint from
+//! another thread while the test thread holds a read guard on `LIGHTCLIENT`.
+//! An endpoint on the read lock answers concurrently; one that takes the
+//! write lock queues behind the held guard and times out. The answer is then
+//! checked against the fixture wallet, so a port that silences the endpoint
+//! fails just as loudly as one that keeps the write lock.
+
+use super::*;
+
+/// Serializes the tests that initialize or lock the global `LIGHTCLIENT`.
+/// nextest isolates each test in its own process; this guard keeps the
+/// suite correct under plain `cargo test`'s in-process threads too.
+static LIGHTCLIENT_SERIAL: Mutex<()> = Mutex::new(());
+
+fn serialized() -> std::sync::MutexGuard<'static, ()> {
+    LIGHTCLIENT_SERIAL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Builds a fresh Indexerless mainnet wallet (the offline `init_new` path)
+/// and stores it as the global client.
+fn init_offline_wallet() {
+    init_new(
+        String::new(),
+        0,
+        "main".to_string(),
+        "Medium".to_string(),
+        1,
+    )
+    .expect("the offline Indexerless wallet must initialize");
+}
+
+/// Runs `endpoint` on another thread while the caller's thread holds a read
+/// guard on `LIGHTCLIENT`, and returns its parsed answer. Panics if the
+/// endpoint blocks behind the guard (it takes the write lock), errors, or
+/// answers with malformed JSON.
+fn answer_under_held_read_lock(
+    endpoint: fn() -> Result<String, ZingolibError>,
+) -> json::JsonValue {
+    let _reader = LIGHTCLIENT
+        .read()
+        .expect("no serialized test leaves the lock poisoned");
+    let (answer_tx, answer_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = answer_tx.send(endpoint());
+    });
+    let answer = answer_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("the endpoint queued behind a held read guard: it takes the write lock")
+        .expect("the initialized wallet answers this endpoint");
+    json::parse(&answer).expect("the endpoint answers well-formed JSON")
+}
+
+#[test]
+fn latest_block_wallet_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_latest_block_wallet);
+    // A fresh offline wallet has no last known chain height, which this
+    // endpoint reports as 0.
+    assert_eq!(
+        answer["height"].as_u32(),
+        Some(0),
+        "the fixture wallet's height answer changed shape: {answer}"
+    );
+}

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -125,6 +125,19 @@ fn wallet_save_required_answers_beside_a_held_read_guard() {
 }
 
 #[test]
+fn config_wallet_performance_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_config_wallet_performance);
+    // The fixture initializes with the Medium performance level.
+    assert_eq!(
+        answer["performance_level"].as_str(),
+        Some("Medium"),
+        "the fixture wallet's configured level: {answer}"
+    );
+}
+
+#[test]
 fn latest_block_wallet_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -131,6 +131,29 @@ fn ufvk_answers_beside_a_held_read_guard() {
     assert_eq!(answer["chain_name"].as_str(), Some("main"), "{answer}");
 }
 
+/// The fixture wallet's own (only) unified address.
+fn fixture_unified_address() -> String {
+    let parsed = json::parse(&get_unified_addresses().expect("initialized fixture"))
+        .expect("well-formed address list");
+    parsed[0]["encoded_address"]
+        .as_str()
+        .expect("the fixture derives one address")
+        .to_string()
+}
+
+#[test]
+fn messages_answer_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let own_address = fixture_unified_address();
+    let answer = answer_under_held_read_lock(move || get_messages(own_address));
+    // No history means no messages, still under the named key.
+    assert!(
+        answer["value_transfers"].is_array() && answer["value_transfers"].is_empty(),
+        "the fixture wallet holds no messages: {answer}"
+    );
+}
+
 #[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -248,6 +248,36 @@ fn spendable_balance_total_answers_beside_a_held_read_guard() {
 }
 
 #[test]
+fn check_my_address_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let own_address = fixture_unified_address();
+    let expected_encoding = own_address.clone();
+    let answer = answer_under_held_read_lock(move || check_my_address(own_address));
+    // The wallet recognizes its own derived unified address.
+    assert_eq!(
+        answer["is_wallet_address"].as_bool(),
+        Some(true),
+        "{answer}"
+    );
+    assert_eq!(answer["address_type"].as_str(), Some("unified"), "{answer}");
+    assert_eq!(
+        answer["encoded_address"].as_str(),
+        Some(expected_encoding.as_str()),
+        "{answer}"
+    );
+    // And disowns an address it did not derive.
+    let foreign = answer_under_held_read_lock(|| {
+        check_my_address(get_developer_donation_address().expect("static address"))
+    });
+    assert_eq!(
+        foreign["is_wallet_address"].as_bool(),
+        Some(false),
+        "{foreign}"
+    );
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -93,6 +93,25 @@ fn unified_addresses_answer_beside_a_held_read_guard() {
 }
 
 #[test]
+fn transparent_addresses_answer_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_transparent_addresses);
+    // A fresh wallet derives exactly one external transparent address for
+    // account 0.
+    assert_eq!(answer.len(), 1, "one derived address: {answer}");
+    let address = &answer[0];
+    assert_eq!(address["account"].as_u32(), Some(0), "{answer}");
+    assert_eq!(address["scope"].as_str(), Some("external"), "{answer}");
+    assert!(
+        address["encoded_address"]
+            .as_str()
+            .is_some_and(|encoded| encoded.starts_with("t1")),
+        "a mainnet P2PKH address encodes with the t1 prefix: {answer}"
+    );
+}
+
+#[test]
 fn latest_block_wallet_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -34,22 +34,44 @@ pub(crate) fn init_offline_wallet() {
 }
 
 /// Runs `endpoint` on another thread while the caller's thread holds a read
-/// guard on `LIGHTCLIENT`, and returns its parsed answer. Panics if the
-/// endpoint blocks behind the guard (it takes the write lock), errors, or
-/// answers with malformed JSON.
-fn answer_under_held_read_lock(endpoint: fn() -> Result<String, ZingolibError>) -> json::JsonValue {
+/// guard on `LIGHTCLIENT`, and returns its outcome. Panics only if the
+/// endpoint blocks behind the guard (it takes the write lock).
+fn outcome_under_held_read_lock(
+    endpoint: impl FnOnce() -> Result<String, ZingolibError> + Send + 'static,
+) -> Result<String, ZingolibError> {
     let _reader = LIGHTCLIENT
         .read()
         .expect("no serialized test leaves the lock poisoned");
-    let (answer_tx, answer_rx) = std::sync::mpsc::channel();
+    let (outcome_tx, outcome_rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let _ = answer_tx.send(endpoint());
+        let _ = outcome_tx.send(endpoint());
     });
-    let answer = answer_rx
+    outcome_rx
         .recv_timeout(std::time::Duration::from_secs(5))
         .expect("the endpoint queued behind a held read guard: it takes the write lock")
+}
+
+/// [`outcome_under_held_read_lock`] for the common case: the endpoint must
+/// answer Ok with well-formed JSON.
+fn answer_under_held_read_lock(
+    endpoint: impl FnOnce() -> Result<String, ZingolibError> + Send + 'static,
+) -> json::JsonValue {
+    let answer = outcome_under_held_read_lock(endpoint)
         .expect("the initialized wallet answers this endpoint");
     json::parse(&answer).expect("the endpoint answers well-formed JSON")
+}
+
+#[test]
+fn value_transfers_answer_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_value_transfers);
+    // A fresh wallet has no history, and the empty list still arrives
+    // under its named key.
+    assert!(
+        answer["value_transfers"].is_array() && answer["value_transfers"].is_empty(),
+        "the fixture wallet's history is an empty list: {answer}"
+    );
 }
 
 #[test]

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -113,6 +113,25 @@ fn seed_answers_beside_a_held_read_guard() {
 }
 
 #[test]
+fn ufvk_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_ufvk);
+    // The seed wallet's spending key views down to a mainnet UFVK.
+    assert!(
+        answer["ufvk"]
+            .as_str()
+            .is_some_and(|encoded| encoded.starts_with("uview1")),
+        "a mainnet UFVK encodes with the uview1 prefix: {answer}"
+    );
+    assert!(
+        answer["birthday"].as_u32().is_some_and(|height| height > 0),
+        "the UFVK travels with the positive birthday: {answer}"
+    );
+    assert_eq!(answer["chain_name"].as_str(), Some("main"), "{answer}");
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -14,7 +14,7 @@ use super::*;
 /// suite correct under plain `cargo test`'s in-process threads too.
 static LIGHTCLIENT_SERIAL: Mutex<()> = Mutex::new(());
 
-fn serialized() -> std::sync::MutexGuard<'static, ()> {
+pub(crate) fn serialized() -> std::sync::MutexGuard<'static, ()> {
     LIGHTCLIENT_SERIAL
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -22,7 +22,7 @@ fn serialized() -> std::sync::MutexGuard<'static, ()> {
 
 /// Builds a fresh Indexerless mainnet wallet (the offline `init_new` path)
 /// and stores it as the global client.
-fn init_offline_wallet() {
+pub(crate) fn init_offline_wallet() {
     init_new(
         String::new(),
         0,
@@ -37,9 +37,7 @@ fn init_offline_wallet() {
 /// guard on `LIGHTCLIENT`, and returns its parsed answer. Panics if the
 /// endpoint blocks behind the guard (it takes the write lock), errors, or
 /// answers with malformed JSON.
-fn answer_under_held_read_lock(
-    endpoint: fn() -> Result<String, ZingolibError>,
-) -> json::JsonValue {
+fn answer_under_held_read_lock(endpoint: fn() -> Result<String, ZingolibError>) -> json::JsonValue {
     let _reader = LIGHTCLIENT
         .read()
         .expect("no serialized test leaves the lock poisoned");
@@ -52,6 +50,27 @@ fn answer_under_held_read_lock(
         .expect("the endpoint queued behind a held read guard: it takes the write lock")
         .expect("the initialized wallet answers this endpoint");
     json::parse(&answer).expect("the endpoint answers well-formed JSON")
+}
+
+#[test]
+fn wallet_kind_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(wallet_kind);
+    // The offline fixture is a NewSeed wallet, so its kind is the mnemonic
+    // one with every receiver present.
+    assert_eq!(
+        answer["kind"].as_str(),
+        Some("Loaded from seed or mnemonic phrase"),
+        "the fixture wallet's kind answer changed shape: {answer}"
+    );
+    for receiver in ["transparent", "sapling", "orchard"] {
+        assert_eq!(
+            answer[receiver].as_bool(),
+            Some(true),
+            "a seed wallet carries every receiver: {answer}"
+        );
+    }
 }
 
 #[test]

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -214,6 +214,27 @@ fn total_spends_to_address_answer_beside_a_held_read_guard() {
 }
 
 #[test]
+fn spendable_balance_with_address_refuses_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    // A never-synced wallet cannot propose, so the endpoint's correct
+    // answer is the typed Send refusal, still delivered beside the guard.
+    let outcome = outcome_under_held_read_lock(|| {
+        get_spendable_balance_with_address(
+            get_developer_donation_address().expect("static address"),
+            "false".to_string(),
+        )
+    });
+    match outcome {
+        Err(ZingolibError::Send(reason)) => assert!(
+            reason.contains("Must scan blocks first"),
+            "the refusal names the missing scan: {reason}"
+        ),
+        other => panic!("expected the typed Send refusal, got: {other:?}"),
+    }
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -155,6 +155,25 @@ fn messages_answer_beside_a_held_read_guard() {
 }
 
 #[test]
+fn balance_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_balance);
+    // Every pool balance of the fresh wallet is zero, and all four pools
+    // (including Ironwood) report.
+    let mut fields = 0;
+    for (field, value) in answer.entries() {
+        assert_eq!(value.as_u64(), Some(0), "{field} of a fresh wallet: {answer}");
+        fields += 1;
+    }
+    assert_eq!(fields, 12, "three figures for each of four pools: {answer}");
+    assert!(
+        answer["total_ironwood_balance"].as_u64().is_some(),
+        "the Ironwood pool reports: {answer}"
+    );
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -138,6 +138,25 @@ fn config_wallet_performance_answers_beside_a_held_read_guard() {
 }
 
 #[test]
+fn wallet_version_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_wallet_version);
+    // A freshly created wallet reads back at the version it was written
+    // with, so the two versions agree and are positive.
+    let current = answer["current_version"].as_u32();
+    assert!(
+        current.is_some_and(|version| version > 0),
+        "the wallet has a positive serialization version: {answer}"
+    );
+    assert_eq!(
+        answer["read_version"].as_u32(),
+        current,
+        "a fresh wallet's read version matches current: {answer}"
+    );
+}
+
+#[test]
 fn latest_block_wallet_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -174,6 +174,18 @@ fn balance_answers_beside_a_held_read_guard() {
 }
 
 #[test]
+fn total_memobytes_answer_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_total_memobytes_to_address);
+    // No sends yet, so the per-address tally is an empty object.
+    assert!(
+        answer.is_object() && answer.is_empty(),
+        "the fixture wallet has sent no memos: {answer}"
+    );
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -75,6 +75,23 @@ fn value_transfers_answer_beside_a_held_read_guard() {
 }
 
 #[test]
+fn status_sync_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(status_sync);
+    // A never-synced wallet reports an empty scan plan with zero progress.
+    assert!(
+        answer["scan_ranges"].is_array() && answer["scan_ranges"].is_empty(),
+        "no scan ranges before a first sync: {answer}"
+    );
+    assert_eq!(
+        answer["total_outputs_scanned"].as_u64(),
+        Some(0),
+        "nothing scanned before a first sync: {answer}"
+    );
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -92,6 +92,27 @@ fn status_sync_answers_beside_a_held_read_guard() {
 }
 
 #[test]
+fn seed_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_seed);
+    // The NewSeed fixture carries a 24-word mnemonic, its Library Birthday,
+    // and the wallet's own chain.
+    assert_eq!(
+        answer["seed_phrase"]
+            .as_str()
+            .map(|phrase| phrase.split_whitespace().count()),
+        Some(24),
+        "the recovery info carries the 24-word mnemonic: {answer}"
+    );
+    assert!(
+        answer["birthday"].as_u32().is_some_and(|height| height > 0),
+        "an offline new wallet gets the positive Library Birthday: {answer}"
+    );
+    assert_eq!(answer["chain_name"].as_str(), Some("main"), "{answer}");
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -186,6 +186,18 @@ fn total_memobytes_answer_beside_a_held_read_guard() {
 }
 
 #[test]
+fn total_value_to_address_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_total_value_to_address);
+    // No sends yet, so the per-address tally is an empty object.
+    assert!(
+        answer.is_object() && answer.is_empty(),
+        "the fixture wallet has sent no value: {answer}"
+    );
+}
+
+#[test]
 fn wallet_kind_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -163,7 +163,11 @@ fn balance_answers_beside_a_held_read_guard() {
     // (including Ironwood) report.
     let mut fields = 0;
     for (field, value) in answer.entries() {
-        assert_eq!(value.as_u64(), Some(0), "{field} of a fresh wallet: {answer}");
+        assert_eq!(
+            value.as_u64(),
+            Some(0),
+            "{field} of a fresh wallet: {answer}"
+        );
         fields += 1;
     }
     assert_eq!(fields, 12, "three figures for each of four pools: {answer}");
@@ -194,6 +198,18 @@ fn total_value_to_address_answers_beside_a_held_read_guard() {
     assert!(
         answer.is_object() && answer.is_empty(),
         "the fixture wallet has sent no value: {answer}"
+    );
+}
+
+#[test]
+fn total_spends_to_address_answer_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_total_spends_to_address);
+    // No sends yet, so the per-address tally is an empty object.
+    assert!(
+        answer.is_object() && answer.is_empty(),
+        "the fixture wallet has spent nothing: {answer}"
     );
 }
 

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -112,6 +112,19 @@ fn transparent_addresses_answer_beside_a_held_read_guard() {
 }
 
 #[test]
+fn wallet_save_required_answers_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_wallet_save_required);
+    // A freshly created wallet has never been saved, so a save is required.
+    assert_eq!(
+        answer["save_required"].as_bool(),
+        Some(true),
+        "the fresh fixture wallet requires a save: {answer}"
+    );
+}
+
+#[test]
 fn latest_block_wallet_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();

--- a/rust/lib/src/lock_discipline_tests.rs
+++ b/rust/lib/src/lock_discipline_tests.rs
@@ -74,6 +74,25 @@ fn wallet_kind_answers_beside_a_held_read_guard() {
 }
 
 #[test]
+fn unified_addresses_answer_beside_a_held_read_guard() {
+    let _serial = serialized();
+    init_offline_wallet();
+    let answer = answer_under_held_read_lock(get_unified_addresses);
+    // A fresh wallet derives exactly one unified address, Orchard-only,
+    // for account 0.
+    assert_eq!(answer.len(), 1, "one derived address: {answer}");
+    let address = &answer[0];
+    assert_eq!(address["account"].as_u32(), Some(0), "{answer}");
+    assert_eq!(address["has_orchard"].as_bool(), Some(true), "{answer}");
+    assert!(
+        address["encoded_address"]
+            .as_str()
+            .is_some_and(|encoded| encoded.starts_with("u1")),
+        "a mainnet unified address encodes with the u1 prefix: {answer}"
+    );
+}
+
+#[test]
 fn latest_block_wallet_answers_beside_a_held_read_guard() {
     let _serial = serialized();
     init_offline_wallet();


### PR DESCRIPTION
Ports every read-only FFI endpoint off the `LIGHTCLIENT` write lock and onto `with_initialized_lightclient_read`, closing out the problem described in #1223. Independent of the Mixnet work: these 19 commits cherry-pick onto dev with no conflicts, because dev already carries the read accessor and every endpoint in its write-locked form.

## The problem

Endpoints that only read — balance polls, address lists, wallet metadata, sync status — held the exclusive `LIGHTCLIENT` write lock, so every UI poll queued behind long write-holders like sync, send, and `execute_due_parts`. The `DRAIN_PROGRESS` and `BATCH_PROGRESS` side channels exist precisely because pollers could not obtain the lock while those ran.

## The shape of each commit

One endpoint per commit, test first. Each test initializes an offline Indexerless fixture wallet, holds a read guard on `LIGHTCLIENT`, and calls the endpoint from another thread: a write-taking endpoint queues behind the guard and times out (every test was run red before its port), and the answer is then checked against the fixture, so a port that silences the endpoint fails as loudly as one that keeps the write lock. The shared harness lives in `rust/lib/src/lock_discipline_tests.rs`.

Endpoints ported: `get_latest_block_wallet`, `wallet_kind`, `get_unified_addresses`, `get_transparent_addresses`, `get_wallet_save_required`, `get_config_wallet_performance`, `get_wallet_version`, `get_value_transfers`, `status_sync`, `get_seed`, `get_ufvk`, `get_messages`, `get_balance`, `get_total_memobytes_to_address`, `get_total_value_to_address`, `get_total_spends_to_address`, `get_spendable_balance_with_address`, `get_spendable_balance_total`, `check_my_address`.

Not ported, deliberately: endpoints that mutate (sync controls, `change_server`, `save_wallet_bytes`, create/remove/config, the send surface, migration and mixnet controls), and `info_server`/`poll_sync`, where zingolib takes `&mut self`.

## Verification

`cargo nextest run -p zingo` on this branch against dev's zingolib pin: 54/54, including the 19 new lock-discipline tests. Rust-only change; the TS surface is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
