### PR TITLE
test: retake the History snapshots c92baa9e left stale

### DIFF
--- a/__tests__/__snapshots__/History.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/History.snapshot.tsx.snap
@@ -693,40 +693,13 @@ exports[`Component History - test History currency USD, privacy high & mode adva
           {
             "paddingBottom": 18,
             "paddingHorizontal": 12,
-            "paddingTop": 8,
+            "paddingTop": 0,
           }
         }
       >
         <View
           entering={AnimationBuilder {}}
         >
-          <View
-            style={
-              {
-                "backgroundColor": "#1A1200",
-                "borderColor": "#3D2A00",
-                "borderRadius": 10,
-                "borderWidth": 1,
-                "marginBottom": 10,
-                "paddingHorizontal": 14,
-                "paddingVertical": 12,
-              }
-            }
-          >
-            <Text
-              style={
-                {
-                  "color": "#888888",
-                  "fontSize": 13,
-                  "lineHeight": 19,
-                }
-              }
-            >
-              <Text>
-                text translated
-              </Text>
-            </Text>
-          </View>
           <View
             style={
               {
@@ -781,28 +754,6 @@ exports[`Component History - test History currency USD, privacy high & mode adva
                 >
                   text translated
                 </Text>
-                <View
-                  style={
-                    {
-                      "backgroundColor": "rgba(249, 157, 0, 0.15)",
-                      "borderRadius": 6,
-                      "marginLeft": 8,
-                      "paddingHorizontal": 8,
-                      "paddingVertical": 2,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      {
-                        "color": "#F99D00",
-                        "fontSize": 12,
-                      }
-                    }
-                  >
-                    text translated
-                  </Text>
-                </View>
               </View>
               <Text
                 style={
@@ -1492,40 +1443,13 @@ exports[`Component History - test History no currency, privacy normal & mode bas
           {
             "paddingBottom": 18,
             "paddingHorizontal": 12,
-            "paddingTop": 8,
+            "paddingTop": 0,
           }
         }
       >
         <View
           entering={AnimationBuilder {}}
         >
-          <View
-            style={
-              {
-                "backgroundColor": "#1A1200",
-                "borderColor": "#3D2A00",
-                "borderRadius": 10,
-                "borderWidth": 1,
-                "marginBottom": 10,
-                "paddingHorizontal": 14,
-                "paddingVertical": 12,
-              }
-            }
-          >
-            <Text
-              style={
-                {
-                  "color": "#888888",
-                  "fontSize": 13,
-                  "lineHeight": 19,
-                }
-              }
-            >
-              <Text>
-                text translated
-              </Text>
-            </Text>
-          </View>
           <View
             style={
               {
@@ -1580,28 +1504,6 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                 >
                   text translated
                 </Text>
-                <View
-                  style={
-                    {
-                      "backgroundColor": "rgba(249, 157, 0, 0.15)",
-                      "borderRadius": 6,
-                      "marginLeft": 8,
-                      "paddingHorizontal": 8,
-                      "paddingVertical": 2,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      {
-                        "color": "#F99D00",
-                        "fontSize": 12,
-                      }
-                    }
-                  >
-                    text translated
-                  </Text>
-                </View>
               </View>
               <Text
                 style={


### PR DESCRIPTION
Dev has been silently red on jest since c92baa9e ("feat: do-nothing option") removed the amber Warning strip from the History surface without retaking the two History snapshots that record it. That commit's CI verdict was cancelled, so the failure surfaced only through descendant PRs: every branch against dev inherits the red, and fail-all then cancels the whole matrix (see #1230's run for the pattern).

This PR retakes the two snapshots against dev's actual rendering. Jest on this branch: 404/404, 95/95 snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
