### PR TITLE
fix: harden Mixnet Mode core against the four review findings (1226-1229)

### DIFF
--- a/__tests__/walletBackend.mixnetCoordinator.unit.test.ts
+++ b/__tests__/walletBackend.mixnetCoordinator.unit.test.ts
@@ -218,6 +218,37 @@ describe('MixnetCoordinator', () => {
     coordinator.stop();
   });
 
+  it('a stale bootstrapping publication cannot overwrite a newer view (#1228)', async () => {
+    mockedBridge.attachMixnet.mockResolvedValue(
+      statusPayload('bootstrapping'),
+    );
+    // The narration fetch hangs until the test releases it, modeling a
+    // slow native call racing a user action.
+    let releaseNarration!: (payload: string) => void;
+    mockedBridge.mixnetBootstrapDetailInfo.mockReturnValue(
+      new Promise<string>(resolve => {
+        releaseNarration = resolve;
+      }),
+    );
+    mockedBridge.disableMixnet.mockResolvedValue(statusPayload('off'));
+    const startTransport = jest.fn().mockResolvedValue('127.0.0.1:1080');
+    const published: MixnetView[] = [];
+    const coordinator = new MixnetCoordinator(startTransport, view =>
+      published.push(view),
+    );
+
+    await coordinator.ensureForConnectedSession();
+    await coordinator.disable();
+    await flushPromises();
+    releaseNarration(JSON.stringify({ detail: 'connecting to a gateway' }));
+    await flushPromises();
+
+    const latest = published[published.length - 1];
+    expect(latest.statusKey).toBe('mixnet.status.off');
+    expect(latest.sendBlocked).toBe(false);
+    coordinator.stop();
+  });
+
   it('a poll reporting off after a deliberate disable keeps clearnet consent (#1226)', async () => {
     mockedBridge.attachMixnet.mockResolvedValue(statusPayload('ready', '127.0.0.1:1080'));
     mockedBridge.disableMixnet.mockResolvedValue(statusPayload('off'));

--- a/__tests__/walletBackend.mixnetCoordinator.unit.test.ts
+++ b/__tests__/walletBackend.mixnetCoordinator.unit.test.ts
@@ -1,5 +1,8 @@
 import { RPCMixnetModeEnum } from '../app/walletBackend/enums/RPCMixnetModeEnum';
-import { MixnetCoordinator } from '../app/walletBackend/modules/MixnetCoordinator';
+import {
+  MixnetCoordinator,
+  STEADY_POLL_MILLIS,
+} from '../app/walletBackend/modules/MixnetCoordinator';
 import { deriveMixnetView } from '../app/walletBackend/transforms/mixnetPresenter';
 import { MixnetView } from '../app/walletBackend/transforms/mixnetPresenter';
 
@@ -188,6 +191,52 @@ describe('MixnetCoordinator', () => {
     expect(published[0].sendBlocked).toBe(true);
     expect(published[0].recovery).toBe('reenable');
     expect(mockedBridge.attachMixnet).not.toHaveBeenCalled();
+    coordinator.stop();
+  });
+
+  it('keeps sends blocked when the first poll after a transport failure reports off (#1226)', async () => {
+    const startTransport = jest
+      .fn()
+      .mockRejectedValue(new Error('shim missing'));
+    const published: MixnetView[] = [];
+    const coordinator = new MixnetCoordinator(startTransport, view =>
+      published.push(view),
+    );
+    await coordinator.ensureForConnectedSession();
+    await flushPromises();
+
+    // The wallet was never attached, so its default mode is `off` — the
+    // same string a deliberate disable produces. The poll must not read
+    // it as consent.
+    mockedBridge.mixnetModeInfo.mockResolvedValue(statusPayload('off'));
+    jest.advanceTimersByTime(STEADY_POLL_MILLIS);
+    await flushPromises();
+
+    const latest = published[published.length - 1];
+    expect(latest.sendBlocked).toBe(true);
+    expect(latest.recovery).toBe('reenable');
+    coordinator.stop();
+  });
+
+  it('a poll reporting off after a deliberate disable keeps clearnet consent (#1226)', async () => {
+    mockedBridge.attachMixnet.mockResolvedValue(statusPayload('ready', '127.0.0.1:1080'));
+    mockedBridge.disableMixnet.mockResolvedValue(statusPayload('off'));
+    const startTransport = jest.fn().mockResolvedValue('127.0.0.1:1080');
+    const published: MixnetView[] = [];
+    const coordinator = new MixnetCoordinator(startTransport, view =>
+      published.push(view),
+    );
+    await coordinator.ensureForConnectedSession();
+    await coordinator.disable();
+    await flushPromises();
+
+    mockedBridge.mixnetModeInfo.mockResolvedValue(statusPayload('off'));
+    jest.advanceTimersByTime(STEADY_POLL_MILLIS);
+    await flushPromises();
+
+    const latest = published[published.length - 1];
+    expect(latest.statusKey).toBe('mixnet.status.off');
+    expect(latest.sendBlocked).toBe(false);
     coordinator.stop();
   });
 

--- a/__tests__/walletBackend.sendFailureTransform.unit.test.ts
+++ b/__tests__/walletBackend.sendFailureTransform.unit.test.ts
@@ -153,3 +153,28 @@ describe('sendFailureMessage', () => {
     ).toBe(CONNECTION_REFUSED);
   });
 });
+
+/**
+ * The classification seam is mobile-owned (#1229): our own
+ * `ZingolibError::Mixnet` display prefix marks a mixnet refusal, so a
+ * zingolib rewording of the refusal prose cannot silently revert refusals
+ * to the switch-server-and-retry dance. The zingolib phrase stays as a
+ * secondary marker for texts wrapped under other variants by old builds.
+ */
+describe('the mobile-owned refusal marker (#1229)', () => {
+  it('classifies our own mixnet prefix as a refusal, whatever zingolib says inside', () => {
+    const reworded =
+      'Error: mixnet: the tunnel is not ready to carry this operation';
+    const failure = classifySendFailure(reworded);
+    expect(failure.kind).toBe('mixnetRefusal');
+    expect(retryOnAnotherServer(failure)).toBe(false);
+  });
+
+  it('the excluded-indexer exhaustion is a deliberate serverSuspect: switching servers changes eligibility', () => {
+    const exhaustion =
+      "Error: indexer: no eligible Broadcast Indexer remains after excluding the synchronization endpoint's host";
+    const failure = classifySendFailure(exhaustion);
+    expect(failure.kind).toBe('serverSuspect');
+    expect(retryOnAnotherServer(failure)).toBe(true);
+  });
+});

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/NymTransportModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/NymTransportModule.kt
@@ -31,6 +31,31 @@ import uniffi.zingo_nym_proxy_ffi.ProxyDeathReason
  * rejected start, sends stay blocked, and the app survives to offer
  * re-enable or the clearnet consent path.
  */
+/**
+ * The identity decision for a proxy death report (zingo-mobile#1227): a
+ * death may clear only the handle its observer was started for. A closed
+ * union so the observer must render both verdicts.
+ */
+internal sealed interface HandleDeathVerdict {
+    /** The stored handle is the one that died; clear it. */
+    data object ClearStored : HandleDeathVerdict
+
+    /** The stored handle is a replacement (or absent); leave it running. */
+    data object RetainStored : HandleDeathVerdict
+}
+
+/**
+ * Pure: the stored handle is cleared only when it is identically the one
+ * the reporting observer watched. Reference identity is the contract —
+ * every start stores the exact instance it created.
+ */
+internal fun <T : Any> verdictOnDeath(stored: T?, watched: T?): HandleDeathVerdict =
+    if (stored != null && stored === watched) {
+        HandleDeathVerdict.ClearStored
+    } else {
+        HandleDeathVerdict.RetainStored
+    }
+
 class NymTransportModule internal constructor(reactContext: ReactApplicationContext?) :
     ReactContextBaseJavaModule(reactContext) {
     override fun getName(): String {
@@ -41,12 +66,6 @@ class NymTransportModule internal constructor(reactContext: ReactApplicationCont
         // One proxy per app process, shared across React context reloads.
         private val handleLock = Any()
         private var handle: MixnetProxyHandle? = null
-
-        private fun clearHandle() {
-            synchronized(handleLock) {
-                handle = null
-            }
-        }
     }
 
     /**
@@ -54,10 +73,23 @@ class NymTransportModule internal constructor(reactContext: ReactApplicationCont
      * stored handle (its endpoint is dead, so it must not be stopped or
      * reused). Recovery stays with the user-driven re-enable; the wallet's
      * own liveness probe lands the `died` mode the app is already polling.
+     *
+     * Identity-checked (#1227): the observer speaks only for the handle it
+     * was started with, so a dying predecessor's late report cannot wipe a
+     * fresh replacement. `watched` is assigned inside the same
+     * `handleLock` section that stores the started handle, and `onDeath`
+     * takes the lock, so a death can never observe a half-started state.
      */
     private class HandleClearingObserver : ProxyDeathObserver {
+        var watched: MixnetProxyHandle? = null
+
         override fun onDeath(reason: ProxyDeathReason) {
-            clearHandle()
+            synchronized(handleLock) {
+                when (verdictOnDeath(handle, watched)) {
+                    HandleDeathVerdict.ClearStored -> handle = null
+                    HandleDeathVerdict.RetainStored -> Unit
+                }
+            }
         }
     }
 
@@ -78,7 +110,9 @@ class NymTransportModule internal constructor(reactContext: ReactApplicationCont
             guardingLinkage {
                 synchronized(handleLock) {
                     handle?.stop()
-                    val started = MixnetProxyHandle.start(HandleClearingObserver())
+                    val observer = HandleClearingObserver()
+                    val started = MixnetProxyHandle.start(observer)
+                    observer.watched = started
                     handle = started
                     val endpoint = started.socks5Endpoint()
                     "${endpoint.host}:${endpoint.port}"

--- a/android/app/src/test/java/org/ZingoLabs/Zingo/NymTransportHandleTest.kt
+++ b/android/app/src/test/java/org/ZingoLabs/Zingo/NymTransportHandleTest.kt
@@ -1,0 +1,47 @@
+package org.ZingoLabs.Zingo
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The handle-identity contract for proxy death reports (zingo-mobile#1227):
+ * a death may clear only the handle it was observed for. Without identity,
+ * a dying predecessor's late report wipes a fresh replacement, leaving the
+ * replacement orphaned with its port bound and stop a no-op.
+ */
+class NymTransportHandleTest {
+    @Test
+    fun aDeathReportClearsTheHandleItWatched() {
+        val proxy = Any()
+        assertEquals(
+            HandleDeathVerdict.ClearStored,
+            verdictOnDeath(stored = proxy, watched = proxy),
+        )
+    }
+
+    @Test
+    fun aLateDeathOfAReplacedProxyRetainsTheReplacement() {
+        val predecessor = Any()
+        val replacement = Any()
+        assertEquals(
+            HandleDeathVerdict.RetainStored,
+            verdictOnDeath(stored = replacement, watched = predecessor),
+        )
+    }
+
+    @Test
+    fun aDeathWithNothingStoredRetainsNothing() {
+        assertEquals(
+            HandleDeathVerdict.RetainStored,
+            verdictOnDeath(stored = null, watched = Any()),
+        )
+    }
+
+    @Test
+    fun anObserverThatNeverSawItsStartRetains() {
+        assertEquals(
+            HandleDeathVerdict.RetainStored,
+            verdictOnDeath(stored = Any(), watched = null),
+        )
+    }
+}

--- a/app/walletBackend/modules/MixnetCoordinator.ts
+++ b/app/walletBackend/modules/MixnetCoordinator.ts
@@ -20,8 +20,10 @@
  */
 import { RPCMixnetModeEnum } from '../enums/RPCMixnetModeEnum';
 import {
+  ClearnetConsent,
   MixnetStatusReport,
   describeRejection,
+  vetPolledStatus,
 } from '../transforms/mixnetTransform';
 import {
   MixnetView,
@@ -53,6 +55,10 @@ export class MixnetCoordinator {
   private pollTimerID?: ReturnType<typeof setInterval>;
   private pollLock: boolean = false;
   private lastStatus: MixnetStatusReport | null = null;
+  // The consent bit belongs to the coordinator, not the wallet: the wallet
+  // reports `off` both for a deliberate disable and for a never-attached
+  // session, and only the former is consent (#1226).
+  private consent: ClearnetConsent = 'none';
 
   constructor(
     startTransport: StartMixnetTransport,
@@ -70,6 +76,7 @@ export class MixnetCoordinator {
    * re-enable — never a silent fall-through to clearnet.
    */
   async ensureForConnectedSession(): Promise<void> {
+    this.consent = 'none';
     try {
       const socks5Addr = await this.startTransport();
       this.publish(await attachMixnet(socks5Addr));
@@ -81,6 +88,7 @@ export class MixnetCoordinator {
 
   /** The user's deliberate per-session consent to clearnet. */
   async disable(): Promise<void> {
+    this.consent = 'disabledThisSession';
     this.publish(await disableMixnet());
   }
 
@@ -103,7 +111,7 @@ export class MixnetCoordinator {
     }
     this.pollLock = true;
     try {
-      this.publish(await getMixnetStatus());
+      this.publish(vetPolledStatus(await getMixnetStatus(), this.consent));
     } finally {
       this.pollLock = false;
     }

--- a/app/walletBackend/modules/MixnetCoordinator.ts
+++ b/app/walletBackend/modules/MixnetCoordinator.ts
@@ -42,6 +42,15 @@ import {
  */
 export type StartMixnetTransport = () => Promise<string>;
 
+/**
+ * Whether a publication is still the latest one issued. Pure. A
+ * publication that awaited a native narration fetch may resolve after a
+ * newer immediate one; only the latest may reach the screen (#1228).
+ */
+export function isCurrentPublication(seq: number, latest: number): boolean {
+  return seq === latest;
+}
+
 /** How often the coordinator polls while the transport is bootstrapping. */
 export const BOOTSTRAP_POLL_MILLIS = 2_000;
 
@@ -135,19 +144,31 @@ export class MixnetCoordinator {
     );
   }
 
+  private publishSeq: number = 0;
+
   private publish(status: MixnetStatusReport): void {
     const wasBootstrapping = this.isBootstrapping();
     this.lastStatus = status;
-    this.publishView(status);
+    this.publishSeq += 1;
+    this.publishView(status, this.publishSeq);
     if (this.pollTimerID !== undefined && wasBootstrapping !== this.isBootstrapping()) {
       this.schedulePolling();
     }
   }
 
-  private async publishView(status: MixnetStatusReport): Promise<void> {
+  private async publishView(
+    status: MixnetStatusReport,
+    seq: number,
+  ): Promise<void> {
     const narration = this.isBootstrapping()
       ? await getMixnetBootstrapDetail()
       : null;
+    // The narration await opened a gap; a newer publication may have
+    // superseded this one meanwhile, and stale state must not reach the
+    // screen (#1228).
+    if (!isCurrentPublication(seq, this.publishSeq)) {
+      return;
+    }
     this.onChange(deriveMixnetView(status, narration));
   }
 }

--- a/app/walletBackend/transforms/mixnetTransform.ts
+++ b/app/walletBackend/transforms/mixnetTransform.ts
@@ -14,7 +14,8 @@ import {
 export type MixnetFailure =
   | { readonly reason: 'nativeRejection'; readonly message: string }
   | { readonly reason: 'malformedPayload'; readonly payload: string }
-  | { readonly reason: 'unrecognizedMode'; readonly claimed: string };
+  | { readonly reason: 'unrecognizedMode'; readonly claimed: string }
+  | { readonly reason: 'unconsentedOff' };
 
 /**
  * The validated outcome of a mixnet status call. A discriminated union so
@@ -36,6 +37,38 @@ export type MixnetStatusReport =
 export type MixnetDetailReport =
   | { readonly kind: 'detail'; readonly detail: string }
   | { readonly kind: 'failure'; readonly failure: MixnetFailure };
+
+/**
+ * Whether this session holds the user's deliberate clearnet consent.
+ * `off` from the wallet is trustworthy only under `disabledThisSession`:
+ * a never-attached wallet (and a silently recreated one) also reports
+ * `off`, and that must not open the send gate (zingo-mobile#1226).
+ */
+export type ClearnetConsent = 'none' | 'disabledThisSession';
+
+/**
+ * Vets a polled status against the session's consent. A polled `off`
+ * without consent is re-typed as the policy failure it actually is, so the
+ * derived view keeps sends blocked and offers re-enable instead of
+ * silently opening clearnet. Every other report passes through untouched;
+ * direct reports (an attach result, a disable result) are authoritative
+ * and are not vetted.
+ *
+ * Pure function — no side effects.
+ */
+export function vetPolledStatus(
+  status: MixnetStatusReport,
+  consent: ClearnetConsent,
+): MixnetStatusReport {
+  if (
+    status.kind === 'status' &&
+    status.mode === RPCMixnetModeEnum.off &&
+    consent === 'none'
+  ) {
+    return { kind: 'failure', failure: { reason: 'unconsentedOff' } };
+  }
+  return status;
+}
 
 /**
  * Converts a value thrown by the native bridge — the error channel — into

--- a/app/walletBackend/transforms/sendFailureTransform.ts
+++ b/app/walletBackend/transforms/sendFailureTransform.ts
@@ -35,8 +35,19 @@ const DUPLICATE_NULLIFIER_MARKERS = [
 ] as const;
 
 /**
+ * The mobile-owned refusal marker (#1229): the display prefix of our own
+ * `ZingolibError::Mixnet`, minted in rust/lib/src/lib.rs. It survives any
+ * zingolib rewording, because both sides of it live in this repository.
+ */
+const OWNED_MIXNET_MARKER = 'Error: mixnet:';
+
+/**
  * Both fail-closed refusal texts (bootstrapping and died) carry this phrase;
- * no server or consensus error does.
+ * no server or consensus error does. Secondary to
+ * [`OWNED_MIXNET_MARKER`]: it still catches refusal texts that older
+ * builds wrapped under other variants, but it is zingolib's prose and a
+ * rewording there silently defeats it — which is why the owned marker
+ * exists.
  */
 const MIXNET_REFUSAL_MARKER = 'Nym mixnet';
 
@@ -54,7 +65,10 @@ export function classifySendFailure(error: string): SendFailureClass {
   if (error.includes('64: dust')) {
     return { kind: 'dust', error };
   }
-  if (error.includes(MIXNET_REFUSAL_MARKER)) {
+  if (
+    error.includes(OWNED_MIXNET_MARKER) ||
+    error.includes(MIXNET_REFUSAL_MARKER)
+  ) {
     return { kind: 'mixnetRefusal', error };
   }
   if (error.includes(INTERNAL_RPC_MARKER)) {

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -158,9 +158,14 @@ fn ffi_error(e: LightClientError) -> ZingolibError {
         LightClientError::PriceError(_) | LightClientError::PriceFetchRequiresMixnet => {
             ZingolibError::Read(text)
         }
-        LightClientError::MixnetNotReady(_) | LightClientError::NoEligibleBroadcastIndexer => {
-            ZingolibError::Mixnet(text)
-        }
+        LightClientError::MixnetNotReady(_) => ZingolibError::Mixnet(text),
+        // A deliberate verdict (#1229): exhausting the eligible Broadcast
+        // Indexers is a server-topology problem, not a mixnet refusal —
+        // switching the synchronization endpoint changes eligibility, so
+        // the app's switch-and-retry routing can genuinely help. Mapping it
+        // to Mixnet would stamp it with the owned refusal marker and turn
+        // it never-retry.
+        LightClientError::NoEligibleBroadcastIndexer => ZingolibError::Indexer(text),
         LightClientError::MigrationBroadcastTargetIsSyncEndpoint { .. } => {
             ZingolibError::Migration(text)
         }
@@ -851,6 +856,39 @@ pub fn save_wallet_bytes() -> Result<Option<Vec<u8>>, ZingolibError> {
             map_wallet_save(wallet.save())
         })
     })
+}
+
+/// The classification seam contract (#1229): the app routes send failures
+/// by our own error variants' display prefixes, so each zingolib failure
+/// must land in the variant whose routing verdict it deserves. A mixnet
+/// refusal is never-retry; the excluded-indexer exhaustion is a
+/// server-topology problem where switching servers genuinely changes
+/// eligibility, so it must NOT carry the mixnet marker.
+#[cfg(test)]
+mod ffi_error_routing_tests {
+    use super::*;
+
+    #[test]
+    fn a_mixnet_refusal_maps_to_the_owned_mixnet_marker() {
+        let mapped = ffi_error(LightClientError::MixnetNotReady(
+            zingolib::nym::MixnetNotReady::Bootstrapping,
+        ));
+        assert!(
+            matches!(&mapped, ZingolibError::Mixnet(_)),
+            "a refusal must carry the owned mixnet marker: {mapped:?}"
+        );
+        assert!(mapped.to_string().starts_with("Error: mixnet:"));
+    }
+
+    #[test]
+    fn excluded_indexer_exhaustion_is_an_indexer_failure_not_a_refusal() {
+        let mapped = ffi_error(LightClientError::NoEligibleBroadcastIndexer);
+        assert!(
+            matches!(&mapped, ZingolibError::Indexer(_)),
+            "exhaustion routes as server-suspect, so it must not wear the mixnet marker: {mapped:?}"
+        );
+        assert!(mapped.to_string().starts_with("Error: indexer:"));
+    }
 }
 
 /// The save-path contract (zingolabs/zingo-mobile#1151; audit Issue Q), now

--- a/rust/lib/src/uniffi/zingo/zingo.kt
+++ b/rust/lib/src/uniffi/zingo/zingo.kt
@@ -827,6 +827,30 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -844,11 +868,15 @@ internal interface IntegrityCheckingUniffiLib : Library {
     // Integrity check functions only
     fun uniffi_zingo_checksum_func_attach_mixnet(
 ): Short
+fun uniffi_zingo_checksum_func_cancel_ironwood_migration(
+): Short
 fun uniffi_zingo_checksum_func_change_server(
 ): Short
 fun uniffi_zingo_checksum_func_check_my_address(
 ): Short
 fun uniffi_zingo_checksum_func_confirm(
+): Short
+fun uniffi_zingo_checksum_func_continue_note_splitting(
 ): Short
 fun uniffi_zingo_checksum_func_create_new_transparent_address(
 ): Short
@@ -861,6 +889,10 @@ fun uniffi_zingo_checksum_func_drain_orchard_to_ironwood(
 fun uniffi_zingo_checksum_func_drain_status(
 ): Short
 fun uniffi_zingo_checksum_func_enable_mixnet(
+): Short
+fun uniffi_zingo_checksum_func_execute_due_parts(
+): Short
+fun uniffi_zingo_checksum_func_execute_due_parts_status(
 ): Short
 fun uniffi_zingo_checksum_func_get_balance(
 ): Short
@@ -916,6 +948,8 @@ fun uniffi_zingo_checksum_func_init_logging(
 ): Short
 fun uniffi_zingo_checksum_func_init_new(
 ): Short
+fun uniffi_zingo_checksum_func_migration_status(
+): Short
 fun uniffi_zingo_checksum_func_mixnet_bootstrap_detail(
 ): Short
 fun uniffi_zingo_checksum_func_mixnet_ip_correlation_disclaimer(
@@ -928,11 +962,19 @@ fun uniffi_zingo_checksum_func_parse_ufvk(
 ): Short
 fun uniffi_zingo_checksum_func_pause_sync(
 ): Short
+fun uniffi_zingo_checksum_func_plan_ironwood_migration(
+): Short
 fun uniffi_zingo_checksum_func_plan_orchard_drain(
 ): Short
 fun uniffi_zingo_checksum_func_poll_sync(
 ): Short
+fun uniffi_zingo_checksum_func_quick_split(
+): Short
+fun uniffi_zingo_checksum_func_reconcile_migration(
+): Short
 fun uniffi_zingo_checksum_func_remove_transaction(
+): Short
+fun uniffi_zingo_checksum_func_reschedule_parts(
 ): Short
 fun uniffi_zingo_checksum_func_run_rescan(
 ): Short
@@ -952,9 +994,15 @@ fun uniffi_zingo_checksum_func_set_option_wallet(
 ): Short
 fun uniffi_zingo_checksum_func_shield(
 ): Short
+fun uniffi_zingo_checksum_func_split_status(
+): Short
+fun uniffi_zingo_checksum_func_start_ironwood_migration(
+): Short
 fun uniffi_zingo_checksum_func_status_sync(
 ): Short
 fun uniffi_zingo_checksum_func_wallet_kind(
+): Short
+fun uniffi_zingo_checksum_func_window_timeline(
 ): Short
 fun uniffi_zingo_checksum_func_zec_price(
 ): Short
@@ -1005,11 +1053,15 @@ internal interface UniffiLib : Library {
     // FFI functions
     fun uniffi_zingo_fn_func_attach_mixnet(`socks5Addr`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_cancel_ironwood_migration(uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_change_server(`serveruri`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_check_my_address(`address`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_confirm(uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_continue_note_splitting(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_create_new_transparent_address(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1022,6 +1074,10 @@ fun uniffi_zingo_fn_func_drain_orchard_to_ironwood(uniffi_out_err: UniffiRustCal
 fun uniffi_zingo_fn_func_drain_status(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_enable_mixnet(`proxyPath`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_execute_due_parts(`spacingMs`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_execute_due_parts_status(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_get_balance(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1077,6 +1133,8 @@ fun uniffi_zingo_fn_func_init_logging(uniffi_out_err: UniffiRustCallStatus,
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_init_new(`serveruri`: RustBuffer.ByValue,`birthday`: Int,`chainhint`: RustBuffer.ByValue,`performancelevel`: RustBuffer.ByValue,`minconfirmations`: Int,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_migration_status(uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_mixnet_bootstrap_detail(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_mixnet_ip_correlation_disclaimer(uniffi_out_err: UniffiRustCallStatus, 
@@ -1089,11 +1147,19 @@ fun uniffi_zingo_fn_func_parse_ufvk(`ufvk`: RustBuffer.ByValue,uniffi_out_err: U
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_pause_sync(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_plan_ironwood_migration(uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_plan_orchard_drain(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_poll_sync(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_quick_split(uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_reconcile_migration(uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_remove_transaction(`txid`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_reschedule_parts(`perBucket`: Int,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_run_rescan(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1113,9 +1179,15 @@ fun uniffi_zingo_fn_func_set_option_wallet(uniffi_out_err: UniffiRustCallStatus,
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_shield(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_split_status(uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_start_ironwood_migration(`planHashHex`: RustBuffer.ByValue,`perBucket`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_status_sync(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_wallet_kind(uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_zingo_fn_func_window_timeline(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_zingo_fn_func_zec_price(uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1248,6 +1320,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_zingo_checksum_func_attach_mixnet() != 63024.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_zingo_checksum_func_cancel_ironwood_migration() != 44347.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_zingo_checksum_func_change_server() != 47175.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1255,6 +1330,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_zingo_checksum_func_confirm() != 11704.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_zingo_checksum_func_continue_note_splitting() != 26867.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_zingo_checksum_func_create_new_transparent_address() != 37063.toShort()) {
@@ -1273,6 +1351,12 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_zingo_checksum_func_enable_mixnet() != 3319.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_zingo_checksum_func_execute_due_parts() != 55009.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_zingo_checksum_func_execute_due_parts_status() != 21746.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_zingo_checksum_func_get_balance() != 46672.toShort()) {
@@ -1356,6 +1440,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_zingo_checksum_func_init_new() != 65130.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_zingo_checksum_func_migration_status() != 14110.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_zingo_checksum_func_mixnet_bootstrap_detail() != 12980.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1374,13 +1461,25 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_zingo_checksum_func_pause_sync() != 1407.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_zingo_checksum_func_plan_ironwood_migration() != 49625.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_zingo_checksum_func_plan_orchard_drain() != 34771.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_zingo_checksum_func_poll_sync() != 35296.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_zingo_checksum_func_quick_split() != 1449.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_zingo_checksum_func_reconcile_migration() != 36661.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_zingo_checksum_func_remove_transaction() != 54006.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_zingo_checksum_func_reschedule_parts() != 2084.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_zingo_checksum_func_run_rescan() != 52086.toShort()) {
@@ -1410,10 +1509,19 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_zingo_checksum_func_shield() != 33728.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_zingo_checksum_func_split_status() != 31456.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_zingo_checksum_func_start_ironwood_migration() != 47149.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_zingo_checksum_func_status_sync() != 2462.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_zingo_checksum_func_wallet_kind() != 56355.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_zingo_checksum_func_window_timeline() != 7109.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_zingo_checksum_func_zec_price() != 16513.toShort()) {
@@ -1524,6 +1632,29 @@ public object FfiConverterUInt: FfiConverter<UInt, Int> {
 /**
  * @suppress
  */
+public object FfiConverterULong: FfiConverter<ULong, Long> {
+    override fun lift(value: Long): ULong {
+        return value.toULong()
+    }
+
+    override fun read(buf: ByteBuffer): ULong {
+        return lift(buf.getLong())
+    }
+
+    override fun lower(value: ULong): Long {
+        return value.toLong()
+    }
+
+    override fun allocationSize(value: ULong) = 8UL
+
+    override fun write(value: ULong, buf: ByteBuffer) {
+        buf.putLong(value.toLong())
+    }
+}
+
+/**
+ * @suppress
+ */
 public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
     // Note: we don't inherit from FfiConverterRustBuffer, because we use a
     // special encoding when lowering/lifting.  We can use `RustBuffer.len` to
@@ -1619,6 +1750,32 @@ sealed class ZingolibException(message: String): kotlin.Exception(message) {
         
         class Read(message: String) : ZingolibException(message)
         
+        class Send(message: String) : ZingolibException(message)
+        
+        class Shield(message: String) : ZingolibException(message)
+        
+        class InvalidInput(message: String) : ZingolibException(message)
+        
+        class Wallet(message: String) : ZingolibException(message)
+        
+        class Indexer(message: String) : ZingolibException(message)
+        
+        class Offline(message: String) : ZingolibException(message)
+        
+        class SideChannelPoisoned(message: String) : ZingolibException(message)
+        
+        class MigrationNotInProgress(message: String) : ZingolibException(message)
+        
+        class MigrationAlreadyInProgress(message: String) : ZingolibException(message)
+        
+        class MigrationConsentStale(message: String) : ZingolibException(message)
+        
+        class MigrationCadenceFixed(message: String) : ZingolibException(message)
+        
+        class MigrationSplit(message: String) : ZingolibException(message)
+        
+        class Migration(message: String) : ZingolibException(message)
+        
         class Mixnet(message: String) : ZingolibException(message)
         
 
@@ -1642,7 +1799,20 @@ public object FfiConverterTypeZingolibError : FfiConverterRustBuffer<ZingolibExc
             6 -> ZingolibException.Sync(FfiConverterString.read(buf))
             7 -> ZingolibException.Rescan(FfiConverterString.read(buf))
             8 -> ZingolibException.Read(FfiConverterString.read(buf))
-            9 -> ZingolibException.Mixnet(FfiConverterString.read(buf))
+            9 -> ZingolibException.Send(FfiConverterString.read(buf))
+            10 -> ZingolibException.Shield(FfiConverterString.read(buf))
+            11 -> ZingolibException.InvalidInput(FfiConverterString.read(buf))
+            12 -> ZingolibException.Wallet(FfiConverterString.read(buf))
+            13 -> ZingolibException.Indexer(FfiConverterString.read(buf))
+            14 -> ZingolibException.Offline(FfiConverterString.read(buf))
+            15 -> ZingolibException.SideChannelPoisoned(FfiConverterString.read(buf))
+            16 -> ZingolibException.MigrationNotInProgress(FfiConverterString.read(buf))
+            17 -> ZingolibException.MigrationAlreadyInProgress(FfiConverterString.read(buf))
+            18 -> ZingolibException.MigrationConsentStale(FfiConverterString.read(buf))
+            19 -> ZingolibException.MigrationCadenceFixed(FfiConverterString.read(buf))
+            20 -> ZingolibException.MigrationSplit(FfiConverterString.read(buf))
+            21 -> ZingolibException.Migration(FfiConverterString.read(buf))
+            22 -> ZingolibException.Mixnet(FfiConverterString.read(buf))
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
         
@@ -1686,13 +1856,97 @@ public object FfiConverterTypeZingolibError : FfiConverterRustBuffer<ZingolibExc
                 buf.putInt(8)
                 Unit
             }
-            is ZingolibException.Mixnet -> {
+            is ZingolibException.Send -> {
                 buf.putInt(9)
+                Unit
+            }
+            is ZingolibException.Shield -> {
+                buf.putInt(10)
+                Unit
+            }
+            is ZingolibException.InvalidInput -> {
+                buf.putInt(11)
+                Unit
+            }
+            is ZingolibException.Wallet -> {
+                buf.putInt(12)
+                Unit
+            }
+            is ZingolibException.Indexer -> {
+                buf.putInt(13)
+                Unit
+            }
+            is ZingolibException.Offline -> {
+                buf.putInt(14)
+                Unit
+            }
+            is ZingolibException.SideChannelPoisoned -> {
+                buf.putInt(15)
+                Unit
+            }
+            is ZingolibException.MigrationNotInProgress -> {
+                buf.putInt(16)
+                Unit
+            }
+            is ZingolibException.MigrationAlreadyInProgress -> {
+                buf.putInt(17)
+                Unit
+            }
+            is ZingolibException.MigrationConsentStale -> {
+                buf.putInt(18)
+                Unit
+            }
+            is ZingolibException.MigrationCadenceFixed -> {
+                buf.putInt(19)
+                Unit
+            }
+            is ZingolibException.MigrationSplit -> {
+                buf.putInt(20)
+                Unit
+            }
+            is ZingolibException.Migration -> {
+                buf.putInt(21)
+                Unit
+            }
+            is ZingolibException.Mixnet -> {
+                buf.putInt(22)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalUInt: FfiConverterRustBuffer<kotlin.UInt?> {
+    override fun read(buf: ByteBuffer): kotlin.UInt? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterUInt.read(buf)
+    }
+
+    override fun allocationSize(value: kotlin.UInt?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterUInt.allocationSize(value)
+        }
+    }
+
+    override fun write(value: kotlin.UInt?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterUInt.write(value, buf)
+        }
+    }
 }
 
 
@@ -1736,6 +1990,16 @@ public object FfiConverterOptionalByteArray: FfiConverterRustBuffer<kotlin.ByteA
     }
     
 
+    @Throws(ZingolibException::class) fun `cancelIronwoodMigration`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_cancel_ironwood_migration(
+        _status)
+}
+    )
+    }
+    
+
     @Throws(ZingolibException::class) fun `changeServer`(`serveruri`: kotlin.String): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCallWithError(ZingolibException) { _status ->
@@ -1760,6 +2024,16 @@ public object FfiConverterOptionalByteArray: FfiConverterRustBuffer<kotlin.ByteA
             return FfiConverterString.lift(
     uniffiRustCallWithError(ZingolibException) { _status ->
     UniffiLib.INSTANCE.uniffi_zingo_fn_func_confirm(
+        _status)
+}
+    )
+    }
+    
+
+    @Throws(ZingolibException::class) fun `continueNoteSplitting`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_continue_note_splitting(
         _status)
 }
     )
@@ -1821,6 +2095,26 @@ public object FfiConverterOptionalByteArray: FfiConverterRustBuffer<kotlin.ByteA
     uniffiRustCallWithError(ZingolibException) { _status ->
     UniffiLib.INSTANCE.uniffi_zingo_fn_func_enable_mixnet(
         FfiConverterString.lower(`proxyPath`),_status)
+}
+    )
+    }
+    
+
+    @Throws(ZingolibException::class) fun `executeDueParts`(`spacingMs`: kotlin.ULong): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_execute_due_parts(
+        FfiConverterULong.lower(`spacingMs`),_status)
+}
+    )
+    }
+    
+
+    @Throws(ZingolibException::class) fun `executeDuePartsStatus`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_execute_due_parts_status(
+        _status)
 }
     )
     }
@@ -2096,6 +2390,16 @@ public object FfiConverterOptionalByteArray: FfiConverterRustBuffer<kotlin.ByteA
     }
     
 
+    @Throws(ZingolibException::class) fun `migrationStatus`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_migration_status(
+        _status)
+}
+    )
+    }
+    
+
     @Throws(ZingolibException::class) fun `mixnetBootstrapDetail`(): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCallWithError(ZingolibException) { _status ->
@@ -2155,6 +2459,16 @@ public object FfiConverterOptionalByteArray: FfiConverterRustBuffer<kotlin.ByteA
     }
     
 
+    @Throws(ZingolibException::class) fun `planIronwoodMigration`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_plan_ironwood_migration(
+        _status)
+}
+    )
+    }
+    
+
     @Throws(ZingolibException::class) fun `planOrchardDrain`(): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCallWithError(ZingolibException) { _status ->
@@ -2175,11 +2489,41 @@ public object FfiConverterOptionalByteArray: FfiConverterRustBuffer<kotlin.ByteA
     }
     
 
+    @Throws(ZingolibException::class) fun `quickSplit`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_quick_split(
+        _status)
+}
+    )
+    }
+    
+
+    @Throws(ZingolibException::class) fun `reconcileMigration`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_reconcile_migration(
+        _status)
+}
+    )
+    }
+    
+
     @Throws(ZingolibException::class) fun `removeTransaction`(`txid`: kotlin.String): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCallWithError(ZingolibException) { _status ->
     UniffiLib.INSTANCE.uniffi_zingo_fn_func_remove_transaction(
         FfiConverterString.lower(`txid`),_status)
+}
+    )
+    }
+    
+
+    @Throws(ZingolibException::class) fun `rescheduleParts`(`perBucket`: kotlin.UInt): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_reschedule_parts(
+        FfiConverterUInt.lower(`perBucket`),_status)
 }
     )
     }
@@ -2275,6 +2619,26 @@ public object FfiConverterOptionalByteArray: FfiConverterRustBuffer<kotlin.ByteA
     }
     
 
+    @Throws(ZingolibException::class) fun `splitStatus`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_split_status(
+        _status)
+}
+    )
+    }
+    
+
+    @Throws(ZingolibException::class) fun `startIronwoodMigration`(`planHashHex`: kotlin.String, `perBucket`: kotlin.UInt?): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_start_ironwood_migration(
+        FfiConverterString.lower(`planHashHex`),FfiConverterOptionalUInt.lower(`perBucket`),_status)
+}
+    )
+    }
+    
+
     @Throws(ZingolibException::class) fun `statusSync`(): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCallWithError(ZingolibException) { _status ->
@@ -2289,6 +2653,16 @@ public object FfiConverterOptionalByteArray: FfiConverterRustBuffer<kotlin.ByteA
             return FfiConverterString.lift(
     uniffiRustCallWithError(ZingolibException) { _status ->
     UniffiLib.INSTANCE.uniffi_zingo_fn_func_wallet_kind(
+        _status)
+}
+    )
+    }
+    
+
+    @Throws(ZingolibException::class) fun `windowTimeline`(): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(ZingolibException) { _status ->
+    UniffiLib.INSTANCE.uniffi_zingo_fn_func_window_timeline(
         _status)
 }
     )


### PR DESCRIPTION
## Summary

The four findings of the automated review on #1225 (https://github.com/zingolabs/zingo-mobile/pull/1225#issuecomment-5100064169), each fixed in one test-and-fix commit, TDD throughout: every commit's test was red against the head of `nym_mixnet_core` and is green with its fix. Fixes #1226, #1227, #1228, #1229.

## The commits

**#1226 — a polled `off` is no longer read as consent.** The consent bit moves into the coordinator, where it belongs: the wallet reports `off` both for a deliberate disable and for a never-attached session, and only the coordinator knows which happened. The new pure `vetPolledStatus` (transform layer) re-types a polled `off` without consent as the typed `unconsentedOff` failure — a new arm of the `MixnetFailure` union — so the derived view keeps sends blocked and offers re-enable. `disable()` grants the session's consent; every `ensureForConnectedSession` resets it, which also closes the issue's second path (a recreated client reporting `off` cannot shed the forced-on policy). The red test advances one steady poll past where the old suite stopped.

**#1227 — a death report may clear only the handle it watched.** The identity decision is a pure `verdictOnDeath` over a closed verdict union (`ClearStored` / `RetainStored`); the observer captures its handle inside the same `handleLock` section that stores it, so a dying predecessor's late report can no longer wipe a fresh replacement. Four identity cases pinned in `NymTransportHandleTest`.

**#1228 — a superseded publication is dropped, not the newest.** Publications carry a sequence number and the pure `isCurrentPublication` decides whether a narration-delayed publication may still reach the screen. The red test held the narration fetch open across a disable and watched the stale bootstrapping view land last.

**#1229 — the refusal marker is mobile-owned, and the exhaustion verdict is explicit.** `classifySendFailure` now matches our own `ZingolibError::Mixnet` display prefix (`Error: mixnet:`) first, keeping zingolib's `'Nym mixnet'` phrase as a secondary catch, so a zingolib rewording cannot silently revert refusals to switch-and-retry. The open question gets its ruling: `NoEligibleBroadcastIndexer` maps to `ZingolibError::Indexer` — switching the synchronization endpoint changes eligibility, so switch-and-retry genuinely helps — and Rust plus TS tests pin the mapping and routing on both sides.

## Testing

TS: 34 tests green across the coordinator, transform, and send-failure suites (`tsc --noEmit` clean, eslint clean). Rust: 37 of 37 green, clippy and fmt clean. Kotlin: the new `NymTransportHandleTest` compiles clean, but the JVM suite cannot execute on this head because the base branch's own Kotlin compile is broken (`RPCModule.kt` references bindings the slice's generated uniffi surface lacks — the same errors failing `android-build` on #1225). The Kotlin commit's message records that caveat; the tests will run as soon as the base compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
