### PR TITLE
test: regenerate History snapshots after the banner slim-down

### DIFF
--- a/__tests__/__snapshots__/History.snapshot.tsx.snap
+++ b/__tests__/__snapshots__/History.snapshot.tsx.snap
@@ -693,40 +693,13 @@ exports[`Component History - test History currency USD, privacy high & mode adva
           {
             "paddingBottom": 18,
             "paddingHorizontal": 12,
-            "paddingTop": 8,
+            "paddingTop": 0,
           }
         }
       >
         <View
           entering={AnimationBuilder {}}
         >
-          <View
-            style={
-              {
-                "backgroundColor": "#1A1200",
-                "borderColor": "#3D2A00",
-                "borderRadius": 10,
-                "borderWidth": 1,
-                "marginBottom": 10,
-                "paddingHorizontal": 14,
-                "paddingVertical": 12,
-              }
-            }
-          >
-            <Text
-              style={
-                {
-                  "color": "#888888",
-                  "fontSize": 13,
-                  "lineHeight": 19,
-                }
-              }
-            >
-              <Text>
-                text translated
-              </Text>
-            </Text>
-          </View>
           <View
             style={
               {
@@ -781,28 +754,6 @@ exports[`Component History - test History currency USD, privacy high & mode adva
                 >
                   text translated
                 </Text>
-                <View
-                  style={
-                    {
-                      "backgroundColor": "rgba(249, 157, 0, 0.15)",
-                      "borderRadius": 6,
-                      "marginLeft": 8,
-                      "paddingHorizontal": 8,
-                      "paddingVertical": 2,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      {
-                        "color": "#F99D00",
-                        "fontSize": 12,
-                      }
-                    }
-                  >
-                    text translated
-                  </Text>
-                </View>
               </View>
               <Text
                 style={
@@ -1492,40 +1443,13 @@ exports[`Component History - test History no currency, privacy normal & mode bas
           {
             "paddingBottom": 18,
             "paddingHorizontal": 12,
-            "paddingTop": 8,
+            "paddingTop": 0,
           }
         }
       >
         <View
           entering={AnimationBuilder {}}
         >
-          <View
-            style={
-              {
-                "backgroundColor": "#1A1200",
-                "borderColor": "#3D2A00",
-                "borderRadius": 10,
-                "borderWidth": 1,
-                "marginBottom": 10,
-                "paddingHorizontal": 14,
-                "paddingVertical": 12,
-              }
-            }
-          >
-            <Text
-              style={
-                {
-                  "color": "#888888",
-                  "fontSize": 13,
-                  "lineHeight": 19,
-                }
-              }
-            >
-              <Text>
-                text translated
-              </Text>
-            </Text>
-          </View>
           <View
             style={
               {
@@ -1580,28 +1504,6 @@ exports[`Component History - test History no currency, privacy normal & mode bas
                 >
                   text translated
                 </Text>
-                <View
-                  style={
-                    {
-                      "backgroundColor": "rgba(249, 157, 0, 0.15)",
-                      "borderRadius": 6,
-                      "marginLeft": 8,
-                      "paddingHorizontal": 8,
-                      "paddingVertical": 2,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      {
-                        "color": "#F99D00",
-                        "fontSize": 12,
-                      }
-                    }
-                  >
-                    text translated
-                  </Text>
-                </View>
               </View>
               <Text
                 style={


### PR DESCRIPTION
Regenerates the two stale History snapshots that have kept dev's jest job red since the #1222 chain merged.

## Root cause

Commit c92baa9e (feat: do-nothing option) removed the warning strip and the "at risk" badge from `IronwoodMigrationBanner.tsx`, and 9d6bc74f (chore: restore price-fetch) dropped the default variant's top padding from 8 to 0. Neither regenerated `__tests__/__snapshots__/History.snapshot.tsx.snap`, so the two History snapshot tests fail on dev (the 2026-07-28 nightly shows the same failures at 862ef4bf). Through the fail-all step, the failing jest job cancels every pull request's entire run, which is what painted PR #1230 red across eight jobs.

## The fix

`yarn jest __tests__/History.snapshot.tsx -u` against dev HEAD. One file, snapshot content only. The full local suite passes: 63 suites, 404 tests, 95 snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
