### PR TITLE
feat: append the zm_ part of the build descriptor to get_version

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -130,3 +130,11 @@ from an upstream job in the same run, instead of a `needs:` edge between
 the jobs. It lets a job front-load work that does not depend on the
 artifact, and it must abort promptly with a clear message when the
 upstream job that produces the artifact concludes without success.
+
+## Build identity
+
+**Build descriptor** — the string `get_version()` reports: a zingolib
+part and a zingo-mobile part (`zl_…-zm_…`), each derived from git
+describe against that repo's release tags. The commit count and
+5-character hash fields are elided when a part sits exactly on its
+release tag, and `_dirty` marks a part built from an uncommitted tree.

--- a/rust/android/build_android.mjs
+++ b/rust/android/build_android.mjs
@@ -43,8 +43,19 @@ if (!capture('docker', ['--version'])) {
 
 process.chdir(RUST_DIR);
 
+// The docker build context is rust/ and has no .git, so describe here.
+const gitDescribe =
+  capture('git', ['-C', REPO_DIR, 'describe', '--dirty', '--always', '--long', '--match', 'zingo-*']) ?? '';
+
 console.log('=== Building Docker image ===');
-run('docker', ['build', '--target', 'build_android', '--tag', IMAGE_TAG, '.', '-f', 'android/docker/Dockerfile']);
+run('docker', [
+  'build',
+  '--target', 'build_android',
+  '--build-arg', `ZINGO_MOBILE_GIT_DESCRIBE=${gitDescribe}`,
+  '--tag', IMAGE_TAG,
+  '.',
+  '-f', 'android/docker/Dockerfile',
+]);
 
 console.log('\n=== Creating temporary container ===');
 const containerId = capture('docker', ['create', IMAGE_TAG]);

--- a/rust/android/docker/Dockerfile
+++ b/rust/android/docker/Dockerfile
@@ -22,6 +22,10 @@ COPY Cargo.toml /opt/zingo/rust/Cargo.toml
 COPY zingomobile_utils/ /opt/zingo/rust/zingomobile_utils/
 COPY workbench/ /opt/zingo/rust/workbench/
 
+# The build context has no .git; the host passes git describe output through.
+ARG ZINGO_MOBILE_GIT_DESCRIBE
+ENV ZINGO_MOBILE_GIT_DESCRIBE=${ZINGO_MOBILE_GIT_DESCRIBE}
+
 RUN rustup default stable
 
 RUN cargo install --force --locked bindgen-cli

--- a/rust/lib/build.rs
+++ b/rust/lib/build.rs
@@ -1,3 +1,121 @@
+#![forbid(unsafe_code)]
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::{env, fs::File, process::Command};
+
+// Emitting any directive disables cargo's whole-package fallback, so the
+// watch set must cover the uniffi scaffolding inputs (src/) as well as
+// the git state behind the zm descriptor.
+fn register_rerun_watches() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-env-changed=ZINGO_MOBILE_GIT_DESCRIBE");
+    if let Some(git_dir) = git_path_query("--git-dir") {
+        println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    }
+    if let Some(common_dir) = git_path_query("--git-common-dir") {
+        println!(
+            "cargo:rerun-if-changed={}",
+            common_dir.join("packed-refs").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            common_dir.join("refs").display()
+        );
+    }
+}
+
+fn git_path_query(flag: &str) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", flag])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout)
+        .ok()?
+        .trim_end()
+        .to_string();
+    if path.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(path))
+}
+
+fn descriptor(raw: &str, tag_prefix: &str, part: &str) -> String {
+    let (body, dirty) = match raw.strip_suffix("-dirty") {
+        Some(stripped) => (stripped, true),
+        None => (raw, false),
+    };
+    let fields: Vec<&str> = body.rsplitn(3, '-').collect();
+    let formatted = match fields.as_slice() {
+        [hash, count, tag]
+            if hash.starts_with('g') && count.chars().all(|c| c.is_ascii_digit()) =>
+        {
+            let ver = tag.strip_prefix(tag_prefix).unwrap_or(tag);
+            let hash5: String = hash[1..].chars().take(5).collect();
+            if *count == "0" {
+                format!("{part}_{ver}")
+            } else {
+                format!("{part}_{ver}_{count}_{hash5}")
+            }
+        }
+        _ => {
+            let hash5: String = body.chars().take(5).collect();
+            format!("{part}_{hash5}")
+        }
+    };
+    if dirty {
+        format!("{formatted}_dirty")
+    } else {
+        formatted
+    }
+}
+
+// The docker build context is rust/ and carries no .git, so the host
+// build script passes the raw describe output through this env var.
+fn zm_description() {
+    let raw = env::var("ZINGO_MOBILE_GIT_DESCRIBE")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            Command::new("git")
+                .args([
+                    "describe",
+                    "--dirty",
+                    "--always",
+                    "--long",
+                    "--match=zingo-*",
+                ])
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|stdout| stdout.trim_end().to_string())
+                .filter(|description| !description.is_empty())
+        });
+    let description = match raw {
+        Some(raw) => descriptor(&raw, "zingo-", "zm"),
+        None => "zm_unknown".to_string(),
+    };
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("zm_description.rs");
+    let mut f = File::create(dest_path).unwrap();
+    writeln!(
+        f,
+        "/// The zingo-mobile part of the build descriptor:\n\
+        /// `zm_<tag#>[_<numcommit>_<hash5>][_dirty]`, where the bracketed\n\
+        /// fields are elided when the build sits exactly on its\n\
+        /// `zingo-<tag#>` release tag\n\
+        pub fn zm_description() -> &'static str {{\"{description}\"}}"
+    )
+    .unwrap();
+}
+
 fn main() {
+    register_rerun_watches();
     uniffi_build::generate_scaffolding("src/zingo.udl").expect("A valid UDL file");
+    zm_description();
 }

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1,5 +1,7 @@
 uniffi::include_scaffolding!("zingo");
 
+include!(concat!(env!("OUT_DIR"), "/zm_description.rs"));
+
 #[macro_use]
 extern crate lazy_static;
 extern crate android_logger;
@@ -1944,7 +1946,13 @@ pub fn parse_ufvk(ufvk: String) -> Result<String, ZingolibError> {
 }
 
 pub fn get_version() -> Result<String, ZingolibError> {
-    with_panic_guard(|| Ok(zingolib::git_description().to_string()))
+    with_panic_guard(|| {
+        Ok(format!(
+            "{}-{}",
+            zingolib::git_description(),
+            zm_description()
+        ))
+    })
 }
 
 pub fn get_messages(address: String) -> Result<String, ZingolibError> {


### PR DESCRIPTION
Fixes #1250.

`get_version()` now reports the two-part build descriptor: the zingolib part followed by `-zm_<tag#>[_<numcommit>_<hash5>][_dirty]`, derived from this repo's `zingo-<tag#>` release tags. The bracketed fields are elided when the build sits exactly on its tag, and `_dirty` marks a build from an uncommitted tree. Today's dev tip reads `zm_2.0.22-313_54_e3a7d`.

The generator lives in `rust/lib/build.rs`. It prefers the raw describe output passed through the `ZINGO_MOBILE_GIT_DESCRIBE` env var, because the docker build context is `rust/` and carries no `.git`, and falls back to running `git describe` itself, which covers local cargo builds and the `rust:android-local` path. `build_android.mjs` captures the describe host-side and hands it to the Dockerfile as a build arg. Since emitting rerun directives disables cargo's whole-package watch fallback, the watch set explicitly covers `src/` (the uniffi scaffolding inputs) alongside the git state, following the pattern zingolib's own `build.rs` documents.

The zingolib part keeps its old raw-describe shape until the zingolib pin advances past zingolabs/zingolib#2608, which reformats it to `zl_<ver>[_<numcommit>_<hash5>][_dirty]`. Once both land and the pin moves, the full string reads like `zl_3.0.1_866_3d2f2-zm_2.0.22-313_54_e3a7d`, and a tagged release collapses to `zl_3.0.1-zm_2.0.22-313`. CONTEXT.md gains the Build descriptor term.

Verified by `cargo check -p zingo` and `cargo clippy -p zingo` (clean), and by inspecting the generated `zm_description.rs`, which read `zm_2.0.22-313_54_e3a7d_dirty` for the pre-commit working tree (dirty from the then-uncommitted edits themselves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
