### PR TITLE
fix(android): make wallet saves durable across power loss

### DIFF
--- a/android/app/src/main/java/org/ZingoLabs/Zingo/DurableWalletWrite.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/DurableWalletWrite.kt
@@ -1,0 +1,51 @@
+package org.ZingoLabs.Zingo
+
+/**
+ * The write callback must return after the file and its directory entry are
+ * durable. The previous content remains in the recovery file until startup
+ * recovery can verify the replacement.
+ */
+internal class DurableWalletWrite(
+    private val exists: (String) -> Boolean,
+    private val read: (String) -> String,
+    private val write: (String, String) -> Unit,
+    private val delete: (String) -> Boolean,
+    private val ensureDurable: (String) -> Unit,
+    private val onRecovered: (String, String) -> Unit,
+    private val onRecoveryError: (String, Exception) -> Unit,
+) {
+    fun save(fileName: String, content: String) {
+        val tempName = "$fileName.write.tmp"
+        if (exists(fileName)) {
+            write(tempName, read(fileName))
+        }
+        write(fileName, content)
+    }
+
+    fun complete(fileNames: Iterable<String>) {
+        for (fileName in fileNames) {
+            val tempName = "$fileName.write.tmp"
+            try {
+                if (!exists(tempName)) continue
+
+                val targetReadable = exists(fileName) && try {
+                    read(fileName)
+                    true
+                } catch (_: Exception) {
+                    false
+                }
+                if (!targetReadable) {
+                    write(fileName, read(tempName))
+                    onRecovered(fileName, tempName)
+                } else {
+                    ensureDurable(fileName)
+                }
+
+                // A failed cleanup leaves the recovery copy for the next launch.
+                delete(tempName)
+            } catch (e: Exception) {
+                onRecoveryError(fileName, e)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/DurableWalletWrite.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/DurableWalletWrite.kt
@@ -1,5 +1,13 @@
 package org.ZingoLabs.Zingo
 
+internal object WalletFileCoordinator {
+    // React Native and WorkManager own separate RPCModule instances that
+    // operate on the same wallet files.
+    private val monitor = Any()
+
+    fun <T> withLock(block: () -> T): T = synchronized(monitor, block)
+}
+
 /**
  * The write callback must return after the file and its directory entry are
  * durable. The previous content remains in the recovery file until startup
@@ -14,7 +22,7 @@ internal class DurableWalletWrite(
     private val onRecovered: (String, String) -> Unit,
     private val onRecoveryError: (String, Exception) -> Unit,
 ) {
-    fun save(fileName: String, content: String) {
+    fun save(fileName: String, content: String) = WalletFileCoordinator.withLock {
         val tempName = "$fileName.write.tmp"
         if (exists(fileName)) {
             write(tempName, read(fileName))
@@ -22,7 +30,7 @@ internal class DurableWalletWrite(
         write(fileName, content)
     }
 
-    fun complete(fileNames: Iterable<String>) {
+    fun complete(fileNames: Iterable<String>) = WalletFileCoordinator.withLock {
         for (fileName in fileNames) {
             val tempName = "$fileName.write.tmp"
             try {
@@ -46,6 +54,15 @@ internal class DurableWalletWrite(
             } catch (e: Exception) {
                 onRecoveryError(fileName, e)
             }
+        }
+    }
+
+    fun discard(fileName: String) = WalletFileCoordinator.withLock {
+        val tempName = "$fileName.write.tmp"
+        if (exists(tempName) && !delete(tempName)) {
+            false
+        } else {
+            delete(fileName)
         }
     }
 }

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/DurableWalletWrite.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/DurableWalletWrite.kt
@@ -19,13 +19,22 @@ internal class DurableWalletWrite(
     private val write: (String, String) -> Unit,
     private val delete: (String) -> Boolean,
     private val ensureDurable: (String) -> Unit,
+    private val onStashReadError: (String, Exception) -> Unit,
     private val onRecovered: (String, String) -> Unit,
     private val onRecoveryError: (String, Exception) -> Unit,
 ) {
     fun save(fileName: String, content: String) = WalletFileCoordinator.withLock {
         val tempName = "$fileName.write.tmp"
         if (exists(fileName)) {
-            write(tempName, read(fileName))
+            val previousContent = try {
+                read(fileName)
+            } catch (e: Exception) {
+                onStashReadError(fileName, e)
+                null
+            }
+            if (previousContent != null) {
+                write(tempName, previousContent)
+            }
         }
         write(fileName, content)
     }

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
@@ -76,6 +76,12 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
     // decrypted with the wrong keyset). Instead we keep a plain binary .migrating
     // backup until the encrypted write is confirmed, then delete it.
     fun migrateFileIfNeeded(fileName: String) {
+        WalletFileCoordinator.withLock {
+            migrateFileIfNeededLocked(fileName)
+        }
+    }
+
+    private fun migrateFileIfNeededLocked(fileName: String) {
         val file = File(applicationContext.filesDir, fileName)
         val backupFile = File(applicationContext.filesDir, "$fileName.migrating")
 
@@ -165,6 +171,12 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
     }
 
     fun fileExists(fileName: String): Boolean {
+        return WalletFileCoordinator.withLock {
+            fileExistsLocked(fileName)
+        }
+    }
+
+    private fun fileExistsLocked(fileName: String): Boolean {
         // Check if a file already exists
         val file = File(applicationContext.filesDir, fileName)
         return if (file.exists()) {
@@ -352,6 +364,12 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
     //   between (3)–(4): main != temp AND backup == temp → nothing to write
     // Idempotent — no-op when no temp file is present.
     fun completePendingSwap() {
+        WalletFileCoordinator.withLock {
+            completePendingSwapLocked()
+        }
+    }
+
+    private fun completePendingSwapLocked() {
         val tempFile = java.io.File(applicationContext.filesDir, WalletTempSwapFileName.value)
         if (!tempFile.exists()) return
         try {
@@ -391,21 +409,27 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
 
     @ReactMethod
     fun walletExists(promise: Promise) {
-        // Check if a wallet already exists.
-        // Write recovery runs first: a half-written save can leave main
-        // missing, which would make a pending swap unable to read main.
-        completePendingWrite()
-        completePendingSwap()
-        promise.resolve(fileExists(WalletFileName.value))
+        val exists = WalletFileCoordinator.withLock {
+            // Check if a wallet already exists.
+            // Write recovery runs first: a half-written save can leave main
+            // missing, which would make a pending swap unable to read main.
+            completePendingWrite()
+            completePendingSwap()
+            fileExists(WalletFileName.value)
+        }
+        promise.resolve(exists)
     }
 
     @ReactMethod
     fun walletBackupExists(promise: Promise) {
-        // Check if a wallet backup already exists. See walletExists for
-        // why write recovery runs before swap recovery.
-        completePendingWrite()
-        completePendingSwap()
-        promise.resolve(fileExists(WalletBackupFileName.value))
+        val exists = WalletFileCoordinator.withLock {
+            // Check if a wallet backup already exists. See walletExists for
+            // why write recovery runs before swap recovery.
+            completePendingWrite()
+            completePendingSwap()
+            fileExists(WalletBackupFileName.value)
+        }
+        promise.resolve(exists)
     }
 
     // The FFI contract is structural (zingo-mobile#1151; audit Issue Q):
@@ -414,6 +438,12 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
     // is unrepresentable, so no validator exists to disagree with the file
     // format, which stays base64 and is encoded only at this write site.
     fun saveWalletFile(): Boolean {
+        return WalletFileCoordinator.withLock {
+            saveWalletFileLocked()
+        }
+    }
+
+    private fun saveWalletFileLocked(): Boolean {
         return try {
             uniffi.zingo.initLogging()
 
@@ -433,6 +463,12 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
     }
 
     private fun saveWalletBackupFile(): Boolean {
+        return WalletFileCoordinator.withLock {
+            saveWalletBackupFileLocked()
+        }
+    }
+
+    private fun saveWalletBackupFileLocked(): Boolean {
         return try {
             val content = readFileAsB64(WalletFileName.value)
             writeEncryptedFileDurably(WalletBackupFileName.value, content)
@@ -662,6 +698,12 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
     // Throws on failure; callers own the error channel (a rejected promise
     // here, the worker's catch in BackgroundSyncWorker).
     fun loadExistingWalletNative(serveruri: String, chainhint: String, performancelevel: String, minconfirmations: String): String {
+        return WalletFileCoordinator.withLock {
+            loadExistingWalletNativeLocked(serveruri, chainhint, performancelevel, minconfirmations)
+        }
+    }
+
+    private fun loadExistingWalletNativeLocked(serveruri: String, chainhint: String, performancelevel: String, minconfirmations: String): String {
         // Migrate both files from old binary format to encrypted Base64 if needed.
         // Safe to call even if files don't exist or are already migrated.
         migrateFileIfNeeded(WalletFileName.value)
@@ -677,14 +719,20 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
 
     @ReactMethod
     fun restoreExistingWalletBackup(promise: Promise) {
-        try {
+        val restored = WalletFileCoordinator.withLock {
+            restoreExistingWalletBackupLocked()
+        }
+        promise.resolve(restored)
+    }
+
+    private fun restoreExistingWalletBackupLocked(): Boolean {
+        return try {
             val backup = readFileAsB64(WalletBackupFileName.value)
             // Check the content is correct before swapping it into place.
             // Stored encoded, so the guard is structural (zingo-mobile#1151).
             if (!WalletBackup.isRestorable(backup)) {
                 Log.e("MAIN", "[Native] backup restore: content failed validation")
-                promise.resolve(false)
-                return
+                return false
             }
             if (fileExists(WalletFileName.value)) {
                 // Audit Issue P (b) — durable swap via temp file. The original
@@ -721,34 +769,24 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
                 // duplicate copy as backup is far safer than none.
                 writeEncryptedFile(WalletFileName.value, backup)
             }
-            promise.resolve(true)
+            true
         } catch (e: FileNotFoundException) {
             Log.e("MAIN", "[Native] file not found during backup restore", e)
-            promise.resolve(false)
+            false
         } catch (e: Exception) {
             Log.e("MAIN", "[Native] Unexpected error during backup restore: $e")
-            promise.resolve(false)
+            false
         }
     }
 
     @ReactMethod
     fun deleteExistingWallet(promise: Promise) {
-        // check first if the file exists
-        if (fileExists(WalletFileName.value)) {
-            promise.resolve(deleteFile(WalletFileName.value))
-        } else {
-            promise.resolve(false)
-        }
+        promise.resolve(durableWalletWrite.discard(WalletFileName.value))
     }
 
     @ReactMethod
     fun deleteExistingWalletBackup(promise: Promise) {
-        // check first if the file exists
-        if (fileExists(WalletBackupFileName.value)) {
-            promise.resolve(deleteFile((WalletBackupFileName.value)))
-        } else {
-            promise.resolve(false)
-        }
+        promise.resolve(durableWalletWrite.discard(WalletBackupFileName.value))
     }
 
     // saveWalletFile/saveWalletBackupFile still contain their own failures

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
@@ -28,6 +28,9 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
             write = ::writeEncryptedFile,
             delete = ::deleteFile,
             ensureDurable = ::syncWalletFile,
+            onStashReadError = { fileName, error ->
+                Log.w("MAIN", "[$fileName] could not preserve unreadable wallet before replacement: $error")
+            },
             onRecovered = { fileName, tempName ->
                 Log.i("MAIN", "[Native] completePendingWrite: restored $fileName from $tempName")
             },

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/RPCModule.kt
@@ -1,8 +1,10 @@
 package org.ZingoLabs.Zingo
 
 import android.content.Context
-import android.util.Log
+import android.system.Os
+import android.system.OsConstants
 import android.util.Base64
+import android.util.Log
 import androidx.security.crypto.EncryptedFile
 import androidx.security.crypto.MasterKeys
 import com.facebook.react.bridge.ReactApplicationContext
@@ -12,12 +14,28 @@ import com.facebook.react.bridge.Promise
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
+import java.io.RandomAccessFile
 import org.json.JSONArray
 import org.json.JSONObject
 import org.ZingoLabs.Zingo.Constants.*
 
 class RPCModule internal constructor(private val reactContext: ReactApplicationContext?) : ReactContextBaseJavaModule(reactContext) {
     private val applicationContext: Context = reactContext?.applicationContext ?: MainApplication.getAppContext()!!
+    private val durableWalletWrite by lazy {
+        DurableWalletWrite(
+            exists = ::fileExists,
+            read = ::readFileAsB64,
+            write = ::writeEncryptedFile,
+            delete = ::deleteFile,
+            ensureDurable = ::syncWalletFile,
+            onRecovered = { fileName, tempName ->
+                Log.i("MAIN", "[Native] completePendingWrite: restored $fileName from $tempName")
+            },
+            onRecoveryError = { fileName, error ->
+                Log.e("MAIN", "[Native] completePendingWrite for $fileName failed: $error", error)
+            },
+        )
+    }
 
     override fun getName(): String {
         return "RPCModule"
@@ -171,7 +189,11 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
 
     private fun deleteFile(fileName: String): Boolean {
         val file = applicationContext.getFileStreamPath(fileName)
-        return file!!.delete()
+        val deleted = file!!.delete()
+        if (deleted) {
+            syncDirectory(applicationContext.filesDir)
+        }
+        return deleted
     }
 
     private fun readEncryptedFile(fileName: String): String {
@@ -240,16 +262,42 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
         }
     }
 
+    private fun syncFile(file: File) {
+        RandomAccessFile(file, "rw").use { it.fd.sync() }
+    }
+
+    private fun syncDirectory(directory: File) {
+        val descriptor = Os.open(
+            directory.absolutePath,
+            OsConstants.O_RDONLY,
+            0,
+        )
+        try {
+            Os.fsync(descriptor)
+        } finally {
+            Os.close(descriptor)
+        }
+    }
+
+    private fun syncWalletFile(fileName: String) {
+        syncFile(File(applicationContext.filesDir, fileName))
+        syncDirectory(applicationContext.filesDir)
+    }
+
     private fun writeEncryptedFile(fileName: String, content: String) {
         // EncryptedFile keys its keyset in SharedPreferences by file path, so
         // temp-file-then-rename would decrypt with the wrong key. We delete the
         // existing file first (required by openFileOutput) and write directly to
         // the final name — the same keyset is reused on every write to that path.
         val file = File(applicationContext.filesDir, fileName)
-        file.delete()
+        if (file.delete()) {
+            syncDirectory(applicationContext.filesDir)
+        }
         buildEncryptedFile(fileName).openFileOutput().use { out ->
             out.write(content.toByteArray(Charsets.UTF_8))
         }
+        syncFile(file)
+        syncDirectory(applicationContext.filesDir)
     }
 
     // Audit Issue P (a) — durable wrapper around writeEncryptedFile.
@@ -264,67 +312,26 @@ class RPCModule internal constructor(private val reactContext: ReactApplicationC
     // writeEncryptedFile call) BEFORE the destructive delete. If a crash
     // lands in the racy window of the inner write, `completePendingWrite`
     // at the next launch detects the temp and restores the original.
+    // The temp remains after a successful write until startup verifies the
+    // replacement, preserving the last known-good copy through a hard shutdown.
     //
     // Cost: one extra read + one extra write per save (≈3× I/O vs the
     // raw call). Saves happen on sync milestones, not on the hot path,
     // so the cost is acceptable. iOS doesn't need this — its `writeFile`
     // uses `String.write(toFile: atomically: true)` which is OS-atomic.
     private fun writeEncryptedFileDurably(fileName: String, content: String) {
-        val tempName = "$fileName.write.tmp"
-        if (fileExists(fileName)) {
-            try {
-                val previous = readFileAsB64(fileName)
-                writeEncryptedFile(tempName, previous)
-            } catch (e: Exception) {
-                // Original is unreadable already — saving new content over
-                // it can't make things worse. Proceed without temp protection
-                // for this single write.
-                Log.w("MAIN", "[$fileName] could not stash original to temp; durable write degraded to raw: $e")
-            }
-        }
-        writeEncryptedFile(fileName, content)
-        // Best-effort cleanup. If we crash before reaching here,
-        // completePendingWrite will see the orphan temp and clean it up
-        // (the target file is now valid).
-        try {
-            File(applicationContext.filesDir, tempName).delete()
-        } catch (e: Exception) {
-            Log.w("MAIN", "[$tempName] orphan temp cleanup failed: $e")
-        }
+        durableWalletWrite.save(fileName, content)
     }
 
     // Audit Issue P (a) — durable-write recovery.
     //
-    // If `writeEncryptedFileDurably` crashed between the inner delete and
-    // the inner write, the target file is missing and a temp file with
-    // the original content sits at "$fileName.write.tmp". Restore from
-    // the temp. If the target file is already valid, the temp is just a
-    // post-write cleanup orphan and gets deleted.
+    // If a crash or hard shutdown leaves the target missing or unreadable,
+    // restore it from "$fileName.write.tmp". A valid target is synced again
+    // before the retained temp is deleted.
     //
     // Idempotent — no-op when no temp files are present.
     fun completePendingWrite() {
-        for (fileName in listOf(WalletFileName.value, WalletBackupFileName.value)) {
-            val tempName = "$fileName.write.tmp"
-            if (!fileExists(tempName)) continue
-            try {
-                val targetReadable = fileExists(fileName) && try {
-                    readFileAsB64(fileName)
-                    true
-                } catch (_: Exception) {
-                    false
-                }
-                if (!targetReadable) {
-                    // Crash during the inner write — restore original from temp.
-                    val tempContent = readFileAsB64(tempName)
-                    writeEncryptedFile(fileName, tempContent)
-                    Log.i("MAIN", "[Native] completePendingWrite: restored $fileName from $tempName")
-                }
-                deleteFile(tempName)
-            } catch (e: Exception) {
-                Log.e("MAIN", "[Native] completePendingWrite for $fileName failed: $e", e)
-                // Leave temp in place for diagnosis / next attempt.
-            }
-        }
+        durableWalletWrite.complete(listOf(WalletFileName.value, WalletBackupFileName.value))
     }
 
     // Audit Issue P (b) — wallet ↔ backup swap recovery.

--- a/android/app/src/test/java/org/ZingoLabs/Zingo/DurableWalletWriteTest.kt
+++ b/android/app/src/test/java/org/ZingoLabs/Zingo/DurableWalletWriteTest.kt
@@ -1,0 +1,199 @@
+package org.ZingoLabs.Zingo
+
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DurableWalletWriteTest {
+    @Test
+    fun saveStashesPreviousContentBeforeReplacement() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "old"))
+
+        writer(store).save("wallet.dat", "new")
+
+        assertEquals("new", store.files["wallet.dat"])
+        assertEquals("old", store.files["wallet.dat.write.tmp"])
+        assertEquals(
+            listOf(
+                "exists:wallet.dat",
+                "read:wallet.dat",
+                "write:wallet.dat.write.tmp:old",
+                "write:wallet.dat:new",
+            ),
+            store.events,
+        )
+    }
+
+    @Test
+    fun failedStashLeavesPreviousTargetUntouched() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "old"))
+        store.writeFailures += "wallet.dat.write.tmp"
+
+        val error = try {
+            writer(store).save("wallet.dat", "new")
+            null
+        } catch (e: IOException) {
+            e
+        }
+
+        assertNotNull(error)
+        assertEquals("old", store.files["wallet.dat"])
+        assertFalse(store.events.any { it == "write:wallet.dat:new" })
+    }
+
+    @Test
+    fun failedReplacementLeavesTheStashedCopy() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "old"))
+        store.writeFailures += "wallet.dat"
+
+        val error = try {
+            writer(store).save("wallet.dat", "new")
+            null
+        } catch (e: IOException) {
+            e
+        }
+
+        assertNotNull(error)
+        assertEquals("old", store.files["wallet.dat"])
+        assertEquals("old", store.files["wallet.dat.write.tmp"])
+    }
+
+    @Test
+    fun recoveryRestoresUnreadableTargetAndCleansTemp() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "torn", "wallet.dat.write.tmp" to "old"))
+        store.unreadable += "wallet.dat"
+        val errors = mutableListOf<Exception>()
+        val recovered = mutableListOf<Pair<String, String>>()
+
+        writer(store, errors, recovered).complete(listOf("wallet.dat"))
+
+        assertEquals("old", store.files["wallet.dat"])
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
+        assertTrue(errors.isEmpty())
+        assertEquals(listOf("wallet.dat" to "wallet.dat.write.tmp"), recovered)
+        assertTrue(store.events.indexOf("write:wallet.dat:old") < store.events.indexOf("delete:wallet.dat.write.tmp"))
+    }
+
+    @Test
+    fun recoveryKeepsValidTargetAndIsIdempotent() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "new", "wallet.dat.write.tmp" to "old"))
+        val recovery = writer(store)
+
+        recovery.complete(listOf("wallet.dat"))
+        recovery.complete(listOf("wallet.dat"))
+
+        assertEquals("new", store.files["wallet.dat"])
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
+        assertEquals(1, store.events.count { it == "delete:wallet.dat.write.tmp" })
+        assertTrue(store.events.indexOf("durable:wallet.dat") < store.events.indexOf("delete:wallet.dat.write.tmp"))
+    }
+
+    @Test
+    fun failedRestoreRetainsTempForTheNextLaunch() {
+        val store = Store(files = mutableMapOf("wallet.dat.write.tmp" to "old"))
+        store.writeFailures += "wallet.dat"
+        val errors = mutableListOf<Exception>()
+        val recovery = writer(store, errors)
+
+        recovery.complete(listOf("wallet.dat"))
+
+        assertTrue(store.files.containsKey("wallet.dat.write.tmp"))
+        assertEquals(1, errors.size)
+
+        store.writeFailures.clear()
+        recovery.complete(listOf("wallet.dat"))
+
+        assertEquals("old", store.files["wallet.dat"])
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
+    }
+
+    @Test
+    fun failedCleanupRetainsTempUntilCleanupSucceeds() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "new", "wallet.dat.write.tmp" to "old"))
+        store.deleteFailures += "wallet.dat.write.tmp"
+        val recovery = writer(store)
+
+        recovery.complete(listOf("wallet.dat"))
+
+        assertTrue(store.files.containsKey("wallet.dat.write.tmp"))
+        assertEquals("new", store.files["wallet.dat"])
+
+        store.deleteFailures.clear()
+        recovery.complete(listOf("wallet.dat"))
+
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
+    }
+
+    @Test
+    fun failedDurabilityCheckRetainsTempUntilTheTargetIsSafe() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "new", "wallet.dat.write.tmp" to "old"))
+        store.durabilityFailures += "wallet.dat"
+        val errors = mutableListOf<Exception>()
+        val recovery = writer(store, errors)
+
+        recovery.complete(listOf("wallet.dat"))
+
+        assertTrue(store.files.containsKey("wallet.dat.write.tmp"))
+        assertEquals(1, errors.size)
+
+        store.durabilityFailures.clear()
+        recovery.complete(listOf("wallet.dat"))
+
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
+    }
+
+    private fun writer(
+        store: Store,
+        errors: MutableList<Exception> = mutableListOf(),
+        recovered: MutableList<Pair<String, String>> = mutableListOf(),
+    ) = DurableWalletWrite(
+        exists = store::exists,
+        read = store::read,
+        write = store::write,
+        delete = store::delete,
+        ensureDurable = store::ensureDurable,
+        onRecovered = { fileName, tempName -> recovered += fileName to tempName },
+        onRecoveryError = { _, error -> errors += error },
+    )
+
+    private class Store(
+        val files: MutableMap<String, String> = mutableMapOf(),
+    ) {
+        val events = mutableListOf<String>()
+        val unreadable = mutableSetOf<String>()
+        val writeFailures = mutableSetOf<String>()
+        val deleteFailures = mutableSetOf<String>()
+        val durabilityFailures = mutableSetOf<String>()
+
+        fun exists(fileName: String): Boolean {
+            events += "exists:$fileName"
+            return files.containsKey(fileName)
+        }
+
+        fun read(fileName: String): String {
+            events += "read:$fileName"
+            if (fileName in unreadable) throw IOException("unreadable $fileName")
+            return files[fileName] ?: throw IOException("missing $fileName")
+        }
+
+        fun write(fileName: String, content: String) {
+            events += "write:$fileName:$content"
+            if (fileName in writeFailures) throw IOException("write failed $fileName")
+            files[fileName] = content
+        }
+
+        fun delete(fileName: String): Boolean {
+            events += "delete:$fileName"
+            if (fileName in deleteFailures) return false
+            return files.remove(fileName) != null
+        }
+
+        fun ensureDurable(fileName: String) {
+            events += "durable:$fileName"
+            if (fileName in durabilityFailures) throw IOException("durability check failed $fileName")
+        }
+    }
+}

--- a/android/app/src/test/java/org/ZingoLabs/Zingo/DurableWalletWriteTest.kt
+++ b/android/app/src/test/java/org/ZingoLabs/Zingo/DurableWalletWriteTest.kt
@@ -125,20 +125,45 @@ class DurableWalletWriteTest {
     }
 
     @Test
+    fun saveReplacesAnUnreadableTargetWithoutARecoveryCopy() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "torn"))
+        store.unreadable += "wallet.dat"
+        val stashReadErrors = mutableListOf<Pair<String, Exception>>()
+
+        writer(store, stashReadErrors = stashReadErrors).save("wallet.dat", "new")
+
+        assertEquals("new", store.files["wallet.dat"])
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
+        assertEquals(1, stashReadErrors.size)
+        assertEquals("wallet.dat", stashReadErrors.single().first)
+    }
+
+    @Test
     fun failedReplacementLeavesTheStashedCopy() {
         val store = Store(files = mutableMapOf("wallet.dat" to "old"))
-        store.writeFailures += "wallet.dat"
+        val durableWrite = writer(store) { fileName, content ->
+            if (fileName == "wallet.dat") {
+                store.files.remove(fileName)
+                throw IOException("write failed $fileName")
+            }
+            store.write(fileName, content)
+        }
 
         val error = try {
-            writer(store).save("wallet.dat", "new")
+            durableWrite.save("wallet.dat", "new")
             null
         } catch (e: IOException) {
             e
         }
 
         assertNotNull(error)
-        assertEquals("old", store.files["wallet.dat"])
+        assertFalse(store.files.containsKey("wallet.dat"))
         assertEquals("old", store.files["wallet.dat.write.tmp"])
+
+        writer(store).complete(listOf("wallet.dat"))
+
+        assertEquals("old", store.files["wallet.dat"])
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
     }
 
     @Test
@@ -229,6 +254,7 @@ class DurableWalletWriteTest {
         store: Store,
         errors: MutableList<Exception> = mutableListOf(),
         recovered: MutableList<Pair<String, String>> = mutableListOf(),
+        stashReadErrors: MutableList<Pair<String, Exception>> = mutableListOf(),
         write: (String, String) -> Unit = store::write,
     ) = DurableWalletWrite(
         exists = store::exists,
@@ -236,6 +262,7 @@ class DurableWalletWriteTest {
         write = write,
         delete = store::delete,
         ensureDurable = store::ensureDurable,
+        onStashReadError = { fileName, error -> stashReadErrors += fileName to error },
         onRecovered = { fileName, tempName -> recovered += fileName to tempName },
         onRecoveryError = { _, error -> errors += error },
     )

--- a/android/app/src/test/java/org/ZingoLabs/Zingo/DurableWalletWriteTest.kt
+++ b/android/app/src/test/java/org/ZingoLabs/Zingo/DurableWalletWriteTest.kt
@@ -1,6 +1,10 @@
 package org.ZingoLabs.Zingo
 
 import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -8,6 +12,82 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DurableWalletWriteTest {
+    @Test
+    fun recoveryWaitsForAnInFlightReplacementFromAnotherWriter() {
+        val store = Store(files = mutableMapOf("wallet.dat" to "old"))
+        val replacementStarted = CountDownLatch(1)
+        val allowReplacement = CountDownLatch(1)
+        val saveError = AtomicReference<Throwable>()
+        val savingWriter = writer(store) { fileName, content ->
+            if (fileName == "wallet.dat") {
+                replacementStarted.countDown()
+                if (!allowReplacement.await(5, TimeUnit.SECONDS)) {
+                    throw IOException("timed out waiting to replace $fileName")
+                }
+                store.files.remove(fileName)
+                throw IOException("write failed $fileName")
+            }
+            store.write(fileName, content)
+        }
+        val recoveringWriter = writer(store)
+
+        val saveThread = thread(start = true, name = "wallet-save") {
+            try {
+                savingWriter.save("wallet.dat", "new")
+            } catch (error: Throwable) {
+                saveError.set(error)
+            }
+        }
+        assertTrue(replacementStarted.await(5, TimeUnit.SECONDS))
+
+        val recoveryThread = thread(start = true, name = "wallet-recovery") {
+            recoveringWriter.complete(listOf("wallet.dat"))
+        }
+        assertThreadBlocked(recoveryThread)
+
+        allowReplacement.countDown()
+        saveThread.join(5_000)
+        recoveryThread.join(5_000)
+
+        assertFalse(saveThread.isAlive)
+        assertFalse(recoveryThread.isAlive)
+        assertTrue(saveError.get() is IOException)
+        assertEquals("old", store.files["wallet.dat"])
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
+    }
+
+    @Test
+    fun deleteRemovesTheRecoveryCopyBeforeTheTarget() {
+        val store = Store(
+            files = mutableMapOf(
+                "wallet.dat" to "new",
+                "wallet.dat.write.tmp" to "old",
+            ),
+        )
+
+        assertTrue(writer(store).discard("wallet.dat"))
+
+        assertFalse(store.files.containsKey("wallet.dat"))
+        assertFalse(store.files.containsKey("wallet.dat.write.tmp"))
+        assertTrue(store.events.indexOf("delete:wallet.dat.write.tmp") < store.events.indexOf("delete:wallet.dat"))
+    }
+
+    @Test
+    fun failedRecoveryCleanupKeepsTheTarget() {
+        val store = Store(
+            files = mutableMapOf(
+                "wallet.dat" to "new",
+                "wallet.dat.write.tmp" to "old",
+            ),
+        )
+        store.deleteFailures += "wallet.dat.write.tmp"
+
+        assertFalse(writer(store).discard("wallet.dat"))
+
+        assertEquals("new", store.files["wallet.dat"])
+        assertEquals("old", store.files["wallet.dat.write.tmp"])
+    }
+
     @Test
     fun saveStashesPreviousContentBeforeReplacement() {
         val store = Store(files = mutableMapOf("wallet.dat" to "old"))
@@ -149,15 +229,24 @@ class DurableWalletWriteTest {
         store: Store,
         errors: MutableList<Exception> = mutableListOf(),
         recovered: MutableList<Pair<String, String>> = mutableListOf(),
+        write: (String, String) -> Unit = store::write,
     ) = DurableWalletWrite(
         exists = store::exists,
         read = store::read,
-        write = store::write,
+        write = write,
         delete = store::delete,
         ensureDurable = store::ensureDurable,
         onRecovered = { fileName, tempName -> recovered += fileName to tempName },
         onRecoveryError = { _, error -> errors += error },
     )
+
+    private fun assertThreadBlocked(thread: Thread) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (thread.isAlive && thread.state != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+            Thread.yield()
+        }
+        assertEquals(Thread.State.BLOCKED, thread.state)
+    }
 
     private class Store(
         val files: MutableMap<String, String> = mutableMapOf(),


### PR DESCRIPTION
Fixes #1224.

## Problem

Android closed each encrypted wallet write without syncing the file or its parent directory. The save path then deleted its recovery copy in the same session. A hard power loss could leave a torn target on disk and no recovery file.

An already-corrupt target also prevented the recovery screen from replacing it with a newly created or restored wallet.

## Changes

- Sync encrypted wallet files and directory metadata after creates and deletes.
- Keep the previous wallet in `*.write.tmp` until a later startup decrypts and syncs the replacement.
- Restore the retained copy when the target is missing or unreadable.
- Serialize wallet-file operations across app and background-worker module instances so recovery cannot overlap a save.
- Remove retained recovery files before deleting wallets, preventing deleted wallets from returning at startup.
- Permit replacement of an unreadable target while still requiring successful preservation of a readable target.
- Add JVM tests for interrupted writes, recovery, cleanup, deletion, unreadable targets, durability failures, and concurrent recovery.

The encrypted format, filenames, native bridge API, dependencies, and iOS path remain unchanged.

## Verification

Manual API 30 x86_64 emulator check during development:

- Created a wallet, observed a wallet save, killed the emulator process, then cold-booted the same AVD.
- Confirmed the wallet loaded and startup removed the retained recovery file after validating the target.
- Confirmed wallet deletion removed the recovery file first and did not resurrect the wallet after relaunch.

The targeted Android JVM suite and release unit suite passed before the final unreadable-target follow-up. They were not rerun at the current head. Pull request CI will run the current branch.
