### PR TITLE
Teach the Android send test the mixnet-only rule

### DIFF
--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
@@ -29,6 +29,15 @@ fun regtestChainHint(): String {
 inline fun <reified T> ObjectMapper.readValue(src: String): T =
     readValue(src, object : TypeReference<T>() {})
 
+/** Returns the mixnet refusal [attempt] raises, and fails the test if it answers instead. */
+fun <T> refusedWithoutMixnet(what: String, attempt: () -> T): String? =
+    try {
+        val answered = attempt()
+        throw AssertionError("the $what answered without a mixnet: $answered")
+    } catch (e: uniffi.zingo.ZingolibException.Mixnet) {
+        e.message
+    }
+
 object Seeds {
     const val HOSPITAL = "hospital museum valve antique skate museum unfold vocal weird milk scale social vessel identify crowd hospital control album rib bulb path oven civil tank"
 }
@@ -427,14 +436,10 @@ class ExecuteSendFromOrchard {
         // never attached one, so the send must refuse. A transaction here
         // would mean the wallet reached the network over clearnet, which is
         // the leak the mixnet-only rule exists to prevent.
-        val refusal: String? = try {
+        val refusal: String? = refusedWithoutMixnet("send") {
             val proposeJson: String = uniffi.zingo.send(mapper.writeValueAsString(listOf(send)))
             val confirmJson: String = uniffi.zingo.confirm()
-            throw AssertionError(
-                "the send answered without a mixnet: propose=$proposeJson confirm=$confirmJson"
-            )
-        } catch (e: uniffi.zingo.ZingolibException.Mixnet) {
-            e.message
+            "propose=$proposeJson confirm=$confirmJson"
         }
         println("\nSend refused without a mixnet:")
         println(refusal)
@@ -510,12 +515,7 @@ class UpdateCurrentPriceAndValueTransfersFromSeed {
         // never attached one, so the fetch must refuse. A price here would
         // mean the wallet reached an oracle over clearnet, which is the
         // leak the mixnet-only rule exists to prevent.
-        val refusal: String? = try {
-            val price = uniffi.zingo.zecPrice()
-            throw AssertionError("the price fetch answered without a mixnet: $price")
-        } catch (e: uniffi.zingo.ZingolibException.Mixnet) {
-            e.message
-        }
+        val refusal: String? = refusedWithoutMixnet("price fetch") { uniffi.zingo.zecPrice() }
         println("\nPrice refused without a mixnet:")
         println(refusal)
 

--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
@@ -423,13 +423,21 @@ class ExecuteSendFromOrchard {
 
         val send = taddresses[0].encoded_address?.let { Send(it, 100000, null) }
 
-        val proposeJson: String = uniffi.zingo.send(mapper.writeValueAsString(listOf(send)))
-        println("\nPropose:")
-        println(proposeJson)
-
-        val confirmJson: String = uniffi.zingo.confirm()
-        println("\nConfirm Txid:")
-        println(confirmJson)
+        // A send rides the mixnet or does not happen (ADR 0011). This wallet
+        // never attached one, so the send must refuse. A transaction here
+        // would mean the wallet reached the network over clearnet, which is
+        // the leak the mixnet-only rule exists to prevent.
+        val refusal: String? = try {
+            val proposeJson: String = uniffi.zingo.send(mapper.writeValueAsString(listOf(send)))
+            val confirmJson: String = uniffi.zingo.confirm()
+            throw AssertionError(
+                "the send answered without a mixnet: propose=$proposeJson confirm=$confirmJson"
+            )
+        } catch (e: uniffi.zingo.ZingolibException.Mixnet) {
+            e.message
+        }
+        println("\nSend refused without a mixnet:")
+        println(refusal)
 
         // A second launch while the first sync still runs is idempotent:
         // the bridge answers with status on the data channel ("Sync task
@@ -462,13 +470,13 @@ class ExecuteSendFromOrchard {
         }
 
         balanceJson = uniffi.zingo.getBalance()
-        println("\nBalance post-send:")
+        println("\nBalance after the refused send:")
         println(balanceJson)
-        val balancePostSend: Balance = mapper.readValue(balanceJson)
-        assertThat(balancePostSend.total_orchard_balance).isEqualTo(885000)
-        // the transparent funds are unconfirmed...
-        assertThat(balancePostSend.confirmed_transparent_balance).isEqualTo(0)
-        assertThat(balancePostSend.unconfirmed_transparent_balance).isEqualTo(100000)
+        val balanceAfterRefusal: Balance = mapper.readValue(balanceJson)
+        // A refused send leaves no trace: no fee taken, no pending output.
+        assertThat(balanceAfterRefusal.confirmed_orchard_balance).isEqualTo(1000000)
+        assertThat(balanceAfterRefusal.confirmed_transparent_balance).isEqualTo(0)
+        assertThat(balanceAfterRefusal.unconfirmed_transparent_balance).isEqualTo(0)
     }
 }
 


### PR DESCRIPTION
Closes part of ZIN-68.

PR #1276 made both send and price mixnet-only. The price test learned the rule and asserts a refusal. The send test did not. It sent without a mixnet, zingolib threw `ZingolibException$Mixnet: the Nym mixnet is not enabled`, and the `accounts`, `chain`, and `ledger-and-parsing` buckets went red on every branch. #1276 merged in that state, so `dev` has been red there since.

## What this does

`executeSendFromOrchard` now asserts what the rule promises. Propose and confirm must refuse without an attached mixnet, and a send that answers is the failure:

```kotlin
val refusal: String? = refusedWithoutMixnet("send") {
    val proposeJson: String = uniffi.zingo.send(mapper.writeValueAsString(listOf(send)))
    val confirmJson: String = uniffi.zingo.confirm()
    "propose=$proposeJson confirm=$confirmJson"
}
```

The price test reads the same way, against the other half of the rule:

```kotlin
val refusal: String? = refusedWithoutMixnet("price fetch") { uniffi.zingo.zecPrice() }
```

It then checks that the refusal left no trace: the orchard balance whole, no unconfirmed transparent output. A rule that takes a fee before refusing would be worse than no rule, and nothing tested that before.

Both call sites reach one assertion. A file-level `refusedWithoutMixnet` helper, beside the `testMapper` and `regtestChainHint` helpers this file already keeps, states it once:

```kotlin
/** Returns the mixnet refusal [attempt] raises, and fails the test if it answers instead. */
fun <T> refusedWithoutMixnet(what: String, attempt: () -> T): String? =
    try {
        val answered = attempt()
        throw AssertionError("the $what answered without a mixnet: $answered")
    } catch (e: uniffi.zingo.ZingolibException.Mixnet) {
        e.message
    }
```

It is generic in the attempt's return type, so a further surface under the mixnet-only rule needs no change to it.

## What this does not do

It does not restore proof that a send works.

ZIN-68 proposed putting that in the nightly lane behind a real mixnet. That cannot work in this harness. The regtest server is `http://10.0.2.2:20000`, an address that exists only inside the emulator, and a mixnet routes through a public exit node that cannot reach it. Attaching a mixnet and sending would fail for a reason that has nothing to do with the wallet.

The coverage needs either a publicly reachable regtest, which is infrastructure work, or a home in zingolib's own suite, where a test can send through a mixnet against a public endpoint without an emulator in the way. The issue carries that analysis and stays open for it.

## Verification

`:app:compileProdDebugAndroidTestKotlin` passes. The behaviour is CI's to prove, since the assertion needs the regtest harness the integration buckets bring up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
