### PR TITLE
refactor(price): answer the price fetch on one typed outcome channel

### DIFF
--- a/__tests__/walletBackend.walletUtils.unit.test.ts
+++ b/__tests__/walletBackend.walletUtils.unit.test.ts
@@ -91,22 +91,39 @@ describe('the existence probes contain rejections as false', () => {
   });
 });
 
-describe('getZecPrice maps outcomes to its documented sentinels', () => {
+describe('getZecPrice answers on one typed outcome channel', () => {
   it.each([
-    ['a typed rejection', typedRejection('Indexer', 'oracle down'), -1],
-    ['an empty resolution', Promise.resolve(''), -2],
-    ['an { error } body', Promise.resolve('{"error":"no feed"}'), -1],
-    ['a body without a price', Promise.resolve('{}'), 0],
-    ['an unparseable body', Promise.resolve('not json'), -2],
-  ])('%s', async (_case, native, sentinel) => {
+    [
+      'a typed rejection',
+      typedRejection('Indexer', 'oracle down'),
+      'info.errorgemini',
+    ],
+    ['an empty resolution', Promise.resolve(''), 'info.errorrpcmodule'],
+    ['a body without a price', Promise.resolve('{}'), 'info.errorrpcmodule'],
+    [
+      'a null price',
+      Promise.resolve('{"current_price": null}'),
+      'info.errorrpcmodule',
+    ],
+    [
+      'a non-positive price',
+      Promise.resolve('{"current_price": 0}'),
+      'info.errorrpcmodule',
+    ],
+    ['an unparseable body', Promise.resolve('not json'), 'info.errorrpcmodule'],
+  ])('%s fails under its own key', async (_case, native, errorKey) => {
     bridge.zecPriceInfo.mockReturnValueOnce(native);
-    const { price } = await getZecPrice();
-    expect(price).toBe(sentinel);
+    const outcome = await getZecPrice();
+    expect(outcome.kind).toBe('error');
+    expect(outcome).toMatchObject({ errorKey });
   });
 
   it('a real price crosses the data channel', async () => {
     bridge.zecPriceInfo.mockResolvedValueOnce('{"current_price": 42.5}');
-    await expect(getZecPrice()).resolves.toEqual({ price: 42.5, error: '' });
+    await expect(getZecPrice()).resolves.toEqual({
+      kind: 'zecPrice',
+      usd: 42.5,
+    });
   });
 });
 

--- a/app/walletBackend/types/RPCZecPriceType.ts
+++ b/app/walletBackend/types/RPCZecPriceType.ts
@@ -1,4 +1,3 @@
 export type RPCZecPriceType = {
   current_price?: number;
-  error?: string;
 };

--- a/app/walletBackend/utils/walletUtils.ts
+++ b/app/walletBackend/utils/walletUtils.ts
@@ -10,51 +10,43 @@
  * rejection channel (typed FFI errors); resolved values are data, never
  * inspected for an error sentinel.
  */
-import { WalletType, GlobalConst } from '../../AppState';
+import { WalletType, GlobalConst, ErrorKeyed } from '../../AppState';
 import RPCModule from '../../RPCModule';
 import { callFfi, FfiResult } from '../ffi';
 import { serverUris } from '../../uris';
 import { RPCZecPriceType } from '../types/RPCZecPriceType';
 import { RPCSeedType } from '../types/RPCSeedType';
 
-/**
- * Fetches the current ZEC/USD price from the zingolib price oracle.
- *
- * Price sentinel values:
- *   0   — initial/default (no price data yet)
- *  -1   — error inside zingolib (a typed FFI rejection, or an oracle error)
- *  -2   — malformed/empty success payload
- *  > 0  — real USD price
- */
-export async function getZecPrice(): Promise<{
-  price: number;
-  error: string;
-}> {
+export type ZecPriceErrorKey = 'info.errorgemini' | 'info.errorrpcmodule';
+
+export type ZecPriceOutcome =
+  { kind: 'zecPrice'; usd: number } | ErrorKeyed<ZecPriceErrorKey>;
+
+const priceErr = (
+  errorKey: ZecPriceErrorKey,
+  param?: string,
+): ErrorKeyed<ZecPriceErrorKey> => ({ kind: 'error', errorKey, param });
+
+/** Fetches the current ZEC/USD price, which zingolib carries over the mixnet. */
+export async function getZecPrice(): Promise<ZecPriceOutcome> {
   const result = await callFfi(RPCModule.zecPriceInfo());
   if (!result.ok) {
-    return { price: -1, error: result.error.message };
+    return priceErr('info.errorgemini', result.error.message);
   }
   if (!result.value) {
-    return { price: -2, error: 'Internal Error fetching price' };
+    return priceErr('info.errorrpcmodule');
   }
   try {
-    const resultJSON: RPCZecPriceType = JSON.parse(result.value);
-    if (resultJSON.error) {
-      return { price: -1, error: resultJSON.error };
+    const payload: RPCZecPriceType = JSON.parse(result.value);
+    const usd = payload.current_price;
+    // A quote is a positive, finite number. Absent, NaN and non-positive are
+    // all malformed payloads, not prices, and none can reach a caller as one.
+    if (usd === undefined || !Number.isFinite(usd) || usd <= 0) {
+      return priceErr('info.errorrpcmodule', String(usd));
     }
-    if (!resultJSON.current_price) {
-      // if no exists the field or is empty
-      return { price: 0, error: '' };
-    }
-    if (isNaN(resultJSON.current_price)) {
-      return {
-        price: -1,
-        error: `Error fetching price ${resultJSON.current_price}`,
-      };
-    }
-    return { price: resultJSON.current_price, error: '' };
+    return { kind: 'zecPrice', usd };
   } catch (error) {
-    return { price: -2, error: `Critical Error fetching price ${error}` };
+    return priceErr('info.errorrpcmodule', String(error));
   }
 }
 

--- a/components/Components/priceFetcherStore.ts
+++ b/components/Components/priceFetcherStore.ts
@@ -74,31 +74,14 @@ async function doFetch(): Promise<void> {
   if (cooldownTimer) clearTimeout(cooldownTimer);
   cooldownTimer = setTimeout(emit, COOLDOWN_MS);
 
-  let price: number;
-  let error: string;
-  // first attempt
-  ({ price, error } = await getZecPrice());
-  // 0 initial · -1 Gemini/zingolib · -2 RPCModule · >0 real value
-  if (price <= 0) {
-    // second attempt
-    ({ price, error } = await getZecPrice());
-  }
-
-  if (price === -1) {
-    d.addLastSnackbar(
-      `${d.translate('info.errorgemini') as string} - ${error}`,
-    );
-  } else if (price === -2) {
-    d.addLastSnackbar(
-      `${d.translate('info.errorrpcmodule') as string} - ${error}`,
-    );
-  } else if (price <= 0) {
-    d.addLastSnackbar(
-      `${d.translate('info.errorgemini') as string} - ${error}`,
-    );
-    d.setZecPrice(price, 0);
+  const outcome = await getZecPrice();
+  if (outcome.kind === 'error') {
+    // A failed refresh leaves the last good price on screen. Overwriting it
+    // would trade a stale number for no number at all.
+    const detail = outcome.param === undefined ? '' : ` - ${outcome.param}`;
+    d.addLastSnackbar(`${d.translate(outcome.errorKey) as string}${detail}`);
   } else {
-    d.setZecPrice(price, Date.now());
+    d.setZecPrice(outcome.usd, Date.now());
     started = true;
   }
 


### PR DESCRIPTION
## What this changes

`getZecPrice` returned one number that carried both the price and the failure.
Zero, minus one and minus two each named a different outcome. A prose string
travelled beside the number.

`callFfi` already gives this function a discriminated `FfiResult`. Its `code`
is a `ZingolibError` variant name. The sentinels discarded that typing.

The function now returns a `ZecPriceOutcome`. One arm is `zecPrice` and holds
the quote. The other arm is `ErrorKeyed` and holds a catalog key with the
diagnostic detail. ADR 0002 and ADR 0003 ask this of every module boundary.
The file's own header already claimed it.

## What the sentinels were hiding

Three defects go away with them.

- `NaN` is falsy. The guard above the `isNaN` arm therefore always won, and
  that arm was unreachable. A malformed number reported as "no price yet".
- The payload's `error` field is dead. `zec_price` returns only
  `current_price`. It signals every failure by rejecting.
- The store retried every non-positive answer. A deliberate mixnet-off refusal
  under ADR 0011 therefore cost two failing calls, not one clear answer.

A quote must now be a positive finite number. An absent, null or non-positive
value fails as a malformed payload. It cannot pass as a price.

## Behaviour change

A failed refresh now always leaves the last good price on screen. Two of the
three old failure arms did that. The third overwrote the price with zero. The
same fetch failing two ways therefore produced opposite displays.

## Scope

This is a mobile backend change. The snackbar copy is untouched, and the two
translation keys keep their present wording. Those two strings read almost
identically, so a reader cannot tell the two failures apart. That is a
user-facing concern and belongs in its own change.

## Verification

- `npm run typecheck` passes.
- `npx eslint` reports nothing on the four changed files.
- `npx prettier --check` passes.
- The `walletUtils` unit suite passes with 24 tests. Its price cases now
  assert the error key rather than a sentinel, and they cover a null price and
  a non-positive price, which the old shape could not express.
- The `PriceFetcher` snapshot passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
