### PR TITLE
fix(price): read the lightclient rather than hold it exclusively

### DIFF
--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2162,7 +2162,7 @@ pub fn zec_price() -> Result<String, ZingolibError> {
     // deliberate switch-off included: a price oracle learns the IP that asked
     // it and when, which is a profile of when this wallet is awake, and no
     // phone should hand that over as the cost of showing a number.
-    let usd = with_initialized_lightclient(|lightclient| {
+    let usd = with_initialized_lightclient_read(|lightclient| {
         RT.block_on(async move {
             lightclient
                 .update_current_price()


### PR DESCRIPTION
One line. `zec_price` now takes the read accessor instead of the write one.

## The problem

The wallet lives behind one global lock.

```rust
lazy_static! {
    static ref LIGHTCLIENT: RwLock<Option<LightClient>> = RwLock::new(None);
}
```

`zec_price` took `with_initialized_lightclient`, which calls `LIGHTCLIENT.write()`.
It then held that exclusive lock across the whole `RT.block_on` of a mixnet
price race.

On an `x86_64` emulator the winning quote arrived about 0.7 seconds after the
tap. The race drained in under seven seconds. For that whole span no other FFI
call touching the lightclient could proceed. This app polls sync every five
seconds, so a slow price tap stalls the poll.

## Why the exclusivity bought nothing

`update_current_price` takes `&self`.

```rust
    pub async fn update_current_price(&self) -> Result<MixnetPriceFetch, LightClientError> {
```

Its body uses `&self` three times. It reads the mixnet route, it clones the
correspondent pools handle, and it asks whether an acquirer exists. It records
no price into the wallet. It mutates nothing the lightclient owns.

The read accessor therefore serves it. Read locks admit each other, so a price
tap now blocks writers alone rather than everyone.

## Why a lock is still needed

The client cannot be borrowed without taking the lock that guards it. Removing
the lock entirely would mean holding a cloned correspondent-pools handle in a
side channel, the shape `DRAIN_PROGRESS` already uses for drain progress. That
is a zingolib-shaped change and is not attempted here.

This narrows one of the residual write-hold windows that #1239 tracks.

## Verification

- `cargo check -p zingo --all-targets` passes.
- `cargo clippy -p zingo --all-targets` reports no warning and no error.
- `cargo fmt --check -p zingo` passes.
- `cargo nextest run -p zingo --lib` passes with 57 tests.

The branch is cut from `dev`, so it compiles against the pin `dev` carries
today. It does not depend on #1297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
