### PR TITLE
Issue with BS (Android) - new sync ironwood fields added

### DIFF
--- a/__mocks__/dataMocks/mockSyncingStatus.ts
+++ b/__mocks__/dataMocks/mockSyncingStatus.ts
@@ -19,7 +19,11 @@ mockSyncingStatus.session_sapling_outputs_scanned = 0;
 mockSyncingStatus.total_sapling_outputs_scanned = 0;
 mockSyncingStatus.session_orchard_outputs_scanned = 0;
 mockSyncingStatus.total_orchard_outputs_scanned = 0;
+mockSyncingStatus.session_ironwood_outputs_scanned = 0;
+mockSyncingStatus.total_ironwood_outputs_scanned = 0;
 mockSyncingStatus.percentage_session_outputs_scanned = 0;
 mockSyncingStatus.percentage_total_outputs_scanned = 100;
+mockSyncingStatus.total_outputs_scanned = 0;
+mockSyncingStatus.total_outputs = 0;
 
 export default mockSyncingStatus;

--- a/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
+++ b/android/app/src/androidTest/java/org/ZingoLabs/Zingo/RustFFITest.kt
@@ -113,8 +113,12 @@ data class SyncStatus (
     var total_sapling_outputs_scanned : Long = 0L,
     var session_orchard_outputs_scanned : Long = 0L,
     var total_orchard_outputs_scanned : Long = 0L,
+    var session_ironwood_outputs_scanned : Long = 0L,
+    var total_ironwood_outputs_scanned : Long = 0L,
     var percentage_session_outputs_scanned : Double = 0.0,
-    var percentage_total_outputs_scanned : Double = 0.0
+    var percentage_total_outputs_scanned : Double = 0.0,
+    var total_outputs_scanned : Long = 0L,
+    var total_outputs : Long = 0L
 )
 
 data class Balance (

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/BackgroundSyncWorker.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/BackgroundSyncWorker.kt
@@ -32,6 +32,7 @@ import kotlin.time.toDuration
 import kotlin.time.toJavaDuration
 import org.ZingoLabs.Zingo.Constants.*
 import java.io.FileInputStream
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 
@@ -52,8 +53,12 @@ data class SyncStatus (
     val total_sapling_outputs_scanned : Long = 0L,
     val session_orchard_outputs_scanned : Long = 0L,
     val total_orchard_outputs_scanned : Long = 0L,
+    val session_ironwood_outputs_scanned : Long = 0L,
+    val total_ironwood_outputs_scanned : Long = 0L,
     val percentage_session_outputs_scanned : Double = 0.0,
-    val percentage_total_outputs_scanned : Double = 0.0
+    val percentage_total_outputs_scanned : Double = 0.0,
+    val total_outputs_scanned : Long = 0L,
+    val total_outputs : Long = 0L
 )
 
 class BackgroundSyncWorker(private val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
@@ -79,7 +84,10 @@ class BackgroundSyncWorker(private val context: Context, workerParams: WorkerPar
 
         Log.i("SCHEDULED_TASK_RUN", "Task running")
 
+        // zingolib adds sync-status fields as new pools land; an unknown field
+        // is not a reason to fail the background sync.
         val mapper = jacksonObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
         // save the background JSON file
         val timeStampStart = Date().time / 1000

--- a/app/walletBackend/types/RPCSyncStatusType.ts
+++ b/app/walletBackend/types/RPCSyncStatusType.ts
@@ -11,6 +11,10 @@ export type RPCSyncStatusType = {
   total_sapling_outputs_scanned?: number;
   session_orchard_outputs_scanned?: number;
   total_orchard_outputs_scanned?: number;
+  session_ironwood_outputs_scanned?: number;
+  total_ironwood_outputs_scanned?: number;
   percentage_session_outputs_scanned?: number;
   percentage_total_outputs_scanned?: number;
+  total_outputs_scanned?: number;
+  total_outputs?: number;
 };

--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -29,8 +29,12 @@ struct SyncStatus: Decodable {
     let total_sapling_outputs_scanned: Int64?
     let session_orchard_outputs_scanned: Int64?
     let total_orchard_outputs_scanned: Int64?
+    let session_ironwood_outputs_scanned: Int64?
+    let total_ironwood_outputs_scanned: Int64?
     let percentage_session_outputs_scanned: Double?
     let percentage_total_outputs_scanned: Double?
+    let total_outputs_scanned: Int64?
+    let total_outputs: Int64?
 }
 
 private struct BackgroundTaskResult: Encodable {

--- a/ios/ZingoTests/ZingoTest.swift
+++ b/ios/ZingoTests/ZingoTest.swift
@@ -86,8 +86,12 @@ struct SyncStatus: Codable {
     let total_sapling_outputs_scanned: UInt64?
     let session_orchard_outputs_scanned: UInt64?
     let total_orchard_outputs_scanned: UInt64?
+    let session_ironwood_outputs_scanned: UInt64?
+    let total_ironwood_outputs_scanned: UInt64?
     let percentage_session_outputs_scanned: Double?
     let percentage_total_outputs_scanned: Double?
+    let total_outputs_scanned: UInt64?
+    let total_outputs: UInt64?
 }
 
 struct Balance: Codable {


### PR DESCRIPTION
zingolib added the ironwood pool and the exact output ratio to `SyncStatus`,
so `statusSync()` now returns 16 fields. The worker's data class knew 12 and
its mapper defaults to failing on unknown ones, so background sync died on
every tick:

    Status sync parsing process KO. Unrecognized field
    "session_ironwood_outputs_scanned" (class org.ZingoLabs.Zingo.SyncStatus),
    not marked as ignorable

Two changes:

- Add the four missing fields (`session_ironwood_outputs_scanned`,
  `total_ironwood_outputs_scanned`, `total_outputs_scanned`, `total_outputs`)
  to every mirror of the type: the worker, the FFI test, both Swift structs,
  the TS type and its mock.
- Configure the production mapper with `FAIL_ON_UNKNOWN_PROPERTIES = false`,
  as the test mapper already does. The field list will keep growing as pools
  land; an unknown field is not a reason to fail a sync.

iOS and the JS side never crashed here — `Decodable` and TS ignore unknown
keys — but their types were just as stale.
