### PR TITLE
chore(deps): bump zingolib to zingolib_nym_rc0

### DIFF
--- a/.github/workflows/android-ubuntu-integration-test-ci.yaml
+++ b/.github/workflows/android-ubuntu-integration-test-ci.yaml
@@ -312,7 +312,8 @@ jobs:
               url="$(echo "$line" | grep -oE 'git[[:space:]]*=[[:space:]]*"[^"]+"' | sed -E 's/.*"([^"]+)".*/\1/')"
               ref="$(echo "$line" | grep -oE '(branch|tag)[[:space:]]*=[[:space:]]*"[^"]+"' | sed -E 's/.*"([^"]+)".*/\1/')"
               echo "Resolving zingolib ${ref} from ${url} via git ls-remote"
-              REV="$(git ls-remote "$url" "$ref" | awk 'NR==1{print $1}')"
+              # For an annotated tag the peeled "$ref^{}" line lists last.
+              REV="$(git ls-remote "$url" "$ref" "${ref}^{}" | awk 'END{print $1}')"
             fi
           fi
           test -n "$REV"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -808,35 +808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "log",
- "publicsuffix",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "pepper-sync"
 version = "0.5.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "bip32",
  "byteorder",
@@ -2595,22 +2566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
-]
-
-[[package]]
-name = "psl-types"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
-name = "publicsuffix"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
-dependencies = [
- "idna",
- "psl-types",
 ]
 
 [[package]]
@@ -2873,8 +2828,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "cookie",
- "cookie_store",
  "futures-core",
  "http",
  "http-body",
@@ -5076,7 +5029,7 @@ source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b22
 [[package]]
 name = "zingo-memo"
 version = "0.1.1"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "zcash_address",
  "zcash_encoding",
@@ -5087,7 +5040,7 @@ dependencies = [
 [[package]]
 name = "zingo-net-diag"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "serde",
 ]
@@ -5095,12 +5048,13 @@ dependencies = [
 [[package]]
 name = "zingo-netutils"
 version = "5.0.1"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "http",
  "hyper-util",
  "lightwallet-protocol",
  "rand 0.8.7",
+ "reqwest",
  "rustls 0.23.42",
  "serde",
  "thiserror 2.0.19",
@@ -5116,12 +5070,9 @@ dependencies = [
 [[package]]
 name = "zingo-price"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "byteorder",
- "futures",
- "reqwest",
- "rustls 0.23.42",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -5133,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "zingo-status"
 version = "0.2.1"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "byteorder",
  "zcash_protocol",
@@ -5164,7 +5115,7 @@ source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b22
 [[package]]
 name = "zingolib"
 version = "5.0.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "append-only-vec",
  "bech32",
@@ -5224,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "zingolib_testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "http",
  "nonempty",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,12 +14,12 @@ exclude = ["nym-proxy-ffi"]
 resolver = "2"
 
 [workspace.dependencies]
-zingolib = { git = "https://github.com/zingolabs/zingolib", branch = "dev", features = [
+zingolib = { git = "https://github.com/zingolabs/zingolib", tag = "zingolib_nym_rc0", features = [
     "nym",
     "perspective",
 ] }
-pepper-sync = { git = "https://github.com/zingolabs/zingolib", branch = "dev" }
-zingolib_testutils = { git = "https://github.com/zingolabs/zingolib", branch = "dev" }
+pepper-sync = { git = "https://github.com/zingolabs/zingolib", tag = "zingolib_nym_rc0" }
+zingolib_testutils = { git = "https://github.com/zingolabs/zingolib", tag = "zingolib_nym_rc0" }
 regchest_utils = { git = "https://github.com/zingolabs/zingo-regchest", branch = "dev" }
 zingomobile_utils = { path = "zingomobile_utils" }
 

--- a/rust/nym-proxy-ffi/Cargo.lock
+++ b/rust/nym-proxy-ffi/Cargo.lock
@@ -6315,7 +6315,7 @@ dependencies = [
 [[package]]
 name = "rustls-platform-verifier"
 version = "0.7.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "log",
  "rustls 0.23.43",
@@ -7319,7 +7319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -9105,12 +9105,12 @@ dependencies = [
 [[package]]
 name = "zingo-net-diag"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 
 [[package]]
 name = "zingo-netutils"
 version = "5.0.1"
-source = "git+https://github.com/zingolabs/zingolib?branch=dev#009505350768a251e39ceba6abd5377fc778d896"
+source = "git+https://github.com/zingolabs/zingolib?tag=zingolib_nym_rc0#f65251c5648ebdb96f00d3f2a9de92b11e139abb"
 dependencies = [
  "http 1.5.0",
  "hyper-util",

--- a/rust/nym-proxy-ffi/Cargo.toml
+++ b/rust/nym-proxy-ffi/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 # NymProxy lives here, behind the nym feature; this shim always needs it.
-zingo-netutils = { git = "https://github.com/zingolabs/zingolib", branch = "dev", features = [
+zingo-netutils = { git = "https://github.com/zingolabs/zingolib", tag = "zingolib_nym_rc0", features = [
     "nym",
 ] }
 # Proc-macro scaffolding (setup_scaffolding! + #[uniffi::export]); no build.rs
@@ -31,7 +31,7 @@ live-mixnet = []
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 # The tests read their temporal parameters from `time::test`.
-zingo-netutils = { git = "https://github.com/zingolabs/zingolib", branch = "dev", features = [
+zingo-netutils = { git = "https://github.com/zingolabs/zingolib", tag = "zingolib_nym_rc0", features = [
     "testutils",
 ] }
 
@@ -53,4 +53,4 @@ members = []
 # mixnet never starts. This restates zingolib ADR 0021 here: verification is
 # the compiled-in Mozilla bundle, identically on every platform.
 [patch.crates-io]
-rustls-platform-verifier = { git = "https://github.com/zingolabs/zingolib", branch = "dev" }
+rustls-platform-verifier = { git = "https://github.com/zingolabs/zingolib", tag = "zingolib_nym_rc0" }


### PR DESCRIPTION
- `rust/Cargo.toml`, `rust/nym-proxy-ffi/Cargo.toml`: zingolib git deps and `rustls-platform-verifier` patch pinned to tag `zingolib_nym_rc0` (`f65251c5`).
- Lockfiles re-resolved.
- `android-ubuntu-integration-test-ci.yaml`: `Resolve zingolib rev` now peels annotated tags to the commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
