### PR TITLE
fix(ci): bundle nym proxy shim in release APKs

### DIFF
--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -137,11 +137,39 @@ jobs:
         working-directory: ./rust/target/${{ env.TARGET }}/release
         run: mv ./libzingo.so ./libuniffi_zingo.so
 
+      - name: Cargo build nym proxy shim
+        working-directory: ./rust/nym-proxy-ffi
+        run: |
+          cargo ndk \
+          --target ${{ env.TARGET }} build \
+          --release
+        env:
+          AR: llvm-ar
+          LD: ld
+          RANLIB: llvm-ranlib
+          CC: ${{ env.CC }}26-clang
+          CARGO_FEATURE_STD: ${{ env.CARGO_FEATURE_STD }}
+          LIBCLANG_PATH: /usr/lib/llvm-18/lib
+          CARGO_NDK_PLATFORM: 26
+          CARGO_NDK_ANDROID_PLATFORM: 26
+
+      - name: LLVM Strip nym proxy shim
+        working-directory: ./rust/nym-proxy-ffi/target
+        run: |
+          llvm-strip --strip-all ./${{ env.TARGET }}/release/libzingo_nym_proxy_ffi.so
+          llvm-objcopy --remove-section .comment ./${{ env.TARGET }}/release/libzingo_nym_proxy_ffi.so
+
+      - name: Stage native libraries
+        run: |
+          mkdir -p rust/native-out
+          cp rust/target/${{ env.TARGET }}/release/libuniffi_zingo.so rust/native-out/
+          cp rust/nym-proxy-ffi/target/${{ env.TARGET }}/release/libzingo_nym_proxy_ffi.so rust/native-out/
+
       - name: Upload native rust
         uses: actions/upload-artifact@v7
         with:
           name: native-rust-${{ matrix.arch }}
-          path: rust/target/${{ env.TARGET }}/release/libuniffi_zingo.so
+          path: rust/native-out/
 
   android-release:
     name: Assemble APKs and create GitHub Release
@@ -241,6 +269,16 @@ jobs:
         with:
           name: uniffi-kotlin
           path: android/app/build/generated/source/uniffi/release/java/uniffi
+
+      - name: Verify native and uniffi inputs present
+        run: |
+          set -eu
+          for abi in armeabi-v7a arm64-v8a x86 x86_64; do
+            test -f "android/app/src/main/jniLibs/${abi}/libuniffi_zingo.so"
+            test -f "android/app/src/main/jniLibs/${abi}/libzingo_nym_proxy_ffi.so"
+          done
+          test -f "android/app/build/generated/source/uniffi/release/java/uniffi/zingo/zingo.kt"
+          test -f "android/app/build/generated/source/uniffi/release/java/uniffi/zingo_nym_proxy_ffi/zingo_nym_proxy_ffi.kt"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
- Builds rust/nym-proxy-ffi with cargo ndk per ABI in the native-rust job, mirroring android-build.yaml.
- Strips the shim and stages both libraries into the native-rust-<abi> artifact.
- Verifies both .so files for all 4 ABIs and both Kotlin bindings before assembly, the same gate as android-apk-build.yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)