### PR TITLE
docs: rename "Correspondent" to "Destination" in comments

### DIFF
--- a/app/walletBackend/utils/walletUtils.ts
+++ b/app/walletBackend/utils/walletUtils.ts
@@ -81,7 +81,7 @@ export async function walletExists(): Promise<boolean> {
 
 // Runs before every wallet init. A custom (off-registry) server pins migration
 // transmission to itself, since no registry pool applies. A registry server
-// leaves it unset so the library's curated Correspondent pool, which excludes
+// leaves it unset so the library's curated Destination pool, which excludes
 // the sync operator, routes instead.
 async function applyBroadcastCandidates(
   serverUri: string,

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -167,7 +167,7 @@ fn ffi_error(e: LightClientError) -> ZingolibError {
         LightClientError::MixnetNotReady(_) | LightClientError::ProbeRequiresMixnet => {
             ZingolibError::Mixnet(text)
         }
-        // A deliberate verdict (#1229): exhausting the eligible Correspondents
+        // A deliberate verdict (#1229): exhausting the eligible Destinations
         // is a server-topology problem, not a mixnet refusal — switching the
         // synchronization endpoint changes eligibility, so the app's
         // switch-and-retry routing can genuinely help. Mapping it to Mixnet
@@ -350,7 +350,7 @@ lazy_static! {
 }
 
 // An optional dedicated migration-transmission endpoint, read at every client
-// construction. The library owns the curated Correspondent pool and always
+// construction. The library owns the curated Destination pool and always
 // excludes the synchronization operator (ADR 0022), so a mixnet migration works
 // without any app input. `Some` names one dedicated endpoint distinct from the
 // sync operator; `None` (the default) lets the library draw its curated pool.
@@ -610,7 +610,7 @@ fn build_client_config(
         None => builder,
     };
     // Point migration transmission at a dedicated endpoint when the app set
-    // one. Absent it, the library draws its curated Correspondent pool.
+    // one. Absent it, the library draws its curated Destination pool.
     let migration_uri = MIGRATION_TRANSMISSION_URI
         .read()
         .ok()
@@ -626,7 +626,7 @@ fn build_client_config(
 /// client construction — `{ transmissionUri: "<uri>" }` names one endpoint
 /// distinct from the sync operator, while `null`, `{}`, or the legacy
 /// `{ candidates, allowSyncEndpoint }` shape clears it so the library's
-/// embedded curated Correspondent pool, which always excludes the
+/// embedded curated Destination pool, which always excludes the
 /// synchronization operator, routes instead.
 pub fn set_broadcast_candidates(candidates_json: String) -> Result<String, ZingolibError> {
     let parsed = json::parse(&candidates_json)


### PR DESCRIPTION
This change renames the term "Correspondent" to "Destination" in prose. It touches five comment lines in `rust/lib/src/lib.rs` and `app/walletBackend/utils/walletUtils.ts`. No code behavior changes.

Three symbol references keep the old name. They are `LightClientError::NoEligibleCorrespondent` and `zingolib::correspondent::NoEligibleCorrespondents`. The zingolib crate at tag `zingolib_nym_rc0` defines these symbols. A rename there must land before this repo can drop them.

No ADR or other document contains the term. No file name contains the term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
