### PR TITLE
fix(biometrics): answer cross-purpose declines to the caller, not for it

### DIFF
--- a/__tests__/simpleBiometrics.gate.tsx
+++ b/__tests__/simpleBiometrics.gate.tsx
@@ -149,6 +149,36 @@ test('a wedged native queue is unavailable instead of hanging', async () => {
   });
 });
 
+test('a stalled pre-flight settles by the platform policy, not fail-open', async () => {
+  jest.useFakeTimers();
+  rn.Platform.OS = 'android';
+  kc.getSupportedBiometryType
+    .mockResolvedValueOnce('Fingerprint')
+    .mockReturnValue(new Promise(() => {}));
+  kc.hasGenericPassword.mockResolvedValue(true);
+  kc.getGenericPassword.mockReturnValue(new Promise(() => {}));
+
+  let first: GateVerdict | undefined;
+  simpleBiometrics({ translate, purpose: 'appEntry' }).then(v => {
+    first = v;
+  });
+  await jest.advanceTimersByTimeAsync(60 * 1000);
+  expect(first).toMatchObject({ kind: 'declined' });
+
+  // Try Again: the probe queues behind the wedged call and stalls. Nothing
+  // proves the prompt is off screen, so Android locks again instead of
+  // opening the wallet to whoever waits out the retry.
+  let second: GateVerdict | undefined;
+  simpleBiometrics({ translate, purpose: 'appEntry' }).then(v => {
+    second = v;
+  });
+  await jest.advanceTimersByTimeAsync(10 * 1000);
+  expect(second).toMatchObject({
+    kind: 'declined',
+    failure: { errorKey: 'biometrics-failure-stalled' },
+  });
+});
+
 test('a wedged capability probe is unavailable too', async () => {
   jest.useFakeTimers();
   kc.canImplyAuthentication.mockReturnValue(new Promise(() => {}));

--- a/__tests__/simpleBiometrics.gate.tsx
+++ b/__tests__/simpleBiometrics.gate.tsx
@@ -50,6 +50,7 @@ type RnMock = {
 
 let simpleBiometrics: GateModule['default'];
 let getLastGateFailure: GateModule['getLastGateFailure'];
+let probeDeviceSecurity: GateModule['probeDeviceSecurity'];
 let blankingEvent: GateModule['BIOMETRIC_BLANKING_EVENT'];
 let kc: Record<string, jest.Mock>;
 let rn: RnMock;
@@ -71,6 +72,7 @@ beforeEach(() => {
   const gate: GateModule = require('../app/simpleBiometrics');
   simpleBiometrics = gate.default;
   getLastGateFailure = gate.getLastGateFailure;
+  probeDeviceSecurity = gate.probeDeviceSecurity;
   blankingEvent = gate.BIOMETRIC_BLANKING_EVENT;
   kc.canImplyAuthentication.mockResolvedValue(true);
   kc.resetGenericPassword.mockResolvedValue(true);
@@ -378,8 +380,9 @@ test('an android launch with no frames still settles the gate', async () => {
     simpleBiometrics({ translate, purpose: 'appEntry' }).then(v => {
       verdict = v;
     });
-    await jest.advanceTimersByTimeAsync(10 * 1000);
-    await jest.advanceTimersByTimeAsync(0);
+    // The paint is cosmetic: a frameless launch costs one frame budget,
+    // never the native stall window.
+    await jest.advanceTimersByTimeAsync(1000);
     expect(verdict).toMatchObject({ kind: 'authenticated' });
   } finally {
     globalThis.requestAnimationFrame = realFrame;
@@ -456,10 +459,70 @@ test('a cancelled screen prompt does not relock the app gate', async () => {
   const appGate = simpleBiometrics({ translate, purpose: 'appEntry' });
   refuse(osError('-128')); // the user cancels, meaning 'leave this screen'
   await expect(screenGate).resolves.toMatchObject({ kind: 'declined' });
-  // The decline answers only the purpose the user was shown; the app gate
-  // runs its own prompt instead of relocking the wallet on it.
-  await expect(appGate).resolves.toMatchObject({ kind: 'authenticated' });
+  // The decline answers only the purpose the user was shown. The module no
+  // longer re-runs on behalf of the parked caller (that raised prompts for
+  // components that may no longer exist); it answers 'unanswered' and the
+  // caller decides.
+  await expect(appGate).resolves.toMatchObject({ kind: 'unanswered' });
+  expect(kc.getGenericPassword).toHaveBeenCalledTimes(1);
+  // A live caller re-asks and gets its own prompt.
+  await expect(
+    simpleBiometrics({ translate, purpose: 'appEntry' }),
+  ).resolves.toMatchObject({ kind: 'authenticated' });
   expect(kc.getGenericPassword).toHaveBeenCalledTimes(2);
+});
+
+test('a stalled security probe reports stalled, not no-security', async () => {
+  jest.useFakeTimers();
+  kc.canImplyAuthentication.mockReturnValue(new Promise(() => {}));
+
+  const probe = probeDeviceSecurity();
+  await Promise.resolve();
+  await jest.advanceTimersByTimeAsync(10 * 1000);
+  // Settings must be able to tell "the probe did not answer" from "no
+  // device lock is enrolled" instead of disabling the toggles on a stall.
+  await expect(probe).resolves.toMatchObject({
+    secure: false,
+    failure: { errorKey: 'biometrics-failure-stalled' },
+  });
+});
+
+test('a late rejection of a stalled call stays swallowed', async () => {
+  jest.useFakeTimers();
+  rn.Platform.OS = 'android';
+  kc.getSupportedBiometryType.mockResolvedValue('Fingerprint');
+  kc.hasGenericPassword.mockResolvedValue(true);
+  let refuseLate: (e: Error) => void = () => {};
+  kc.getGenericPassword
+    .mockReturnValueOnce(
+      new Promise((_serve, reject) => {
+        refuseLate = reject;
+      }),
+    )
+    .mockResolvedValue({ password: '1' });
+
+  let first: GateVerdict | undefined;
+  simpleBiometrics({ translate, purpose: 'appEntry' }).then(v => {
+    first = v;
+  });
+  await jest.advanceTimersByTimeAsync(60 * 1000);
+  expect(first).toMatchObject({ kind: 'declined' });
+
+  // The OS answers the stranded call after the verdict is out; the losing
+  // arm must hold a handler so this never surfaces as an unhandled
+  // rejection, and the next gate is undisturbed.
+  refuseLate(
+    Object.assign(new Error('code: 5, msg: Canceled'), {
+      code: 'E_CRYPTO_FAILED',
+    }),
+  );
+  await jest.advanceTimersByTimeAsync(1000);
+  let second: GateVerdict | undefined;
+  simpleBiometrics({ translate, purpose: 'appEntry' }).then(v => {
+    second = v;
+  });
+  await jest.advanceTimersByTimeAsync(1000);
+  expect(second).toMatchObject({ kind: 'authenticated' });
 });
 
 test('a wedge starting at the v1 cleanup settles unavailable in the probe window', async () => {
@@ -647,6 +710,25 @@ test('a fresh sentinel the platform will not serve fails open, not locked', asyn
   expect(kc.setGenericPassword).toHaveBeenCalledTimes(1); // one rebuild try
 });
 
+test('an android error outside E_CRYPTO_FAILED never reads as a decline', async () => {
+  // The prompt-code scrape must stay anchored to E_CRYPTO_FAILED: a
+  // keystore error whose text happens to contain 'code: 5' is a platform
+  // failure nobody was asked about, not a user decline.
+  rn.Platform.OS = 'android';
+  kc.getSupportedBiometryType.mockResolvedValue('Fingerprint');
+  kc.hasGenericPassword.mockResolvedValue(true);
+  kc.getGenericPassword.mockRejectedValue(
+    Object.assign(new Error('keystore init failed with code: 5 inside'), {
+      code: 'E_KEYSTORE',
+    }),
+  );
+
+  await expect(
+    simpleBiometrics({ translate, purpose: 'appEntry' }),
+  ).resolves.toMatchObject({ kind: 'unavailable' });
+  expect(kc.setGenericPassword).toHaveBeenCalledTimes(1); // one rebuild try
+});
+
 test('an android hardware error on a fresh sentinel fails open, not locked', async () => {
   rn.Platform.OS = 'android';
   kc.getSupportedBiometryType.mockResolvedValue('Fingerprint');
@@ -685,10 +767,9 @@ test('a preflight refusal reports its own reason, not a previous decline', async
   });
 });
 
-test('a failure before the attempt still settles and drops the overlay', async () => {
-  // The overlay must be raised inside the try whose finally lowers it: a
-  // rejection between the raise and the try would otherwise leave an
-  // unclearable black Modal with no external hatch.
+test('a throwing frame yield neither denies the gate nor pins the overlay', async () => {
+  // The paint yield is best-effort: a JS context without frames proceeds
+  // to the prompt, and the finally still drops the overlay.
   jest.useFakeTimers();
   rn.Platform.OS = 'android';
   const realFrame = globalThis.requestAnimationFrame;
@@ -705,7 +786,7 @@ test('a failure before the attempt still settles and drops the overlay', async (
       verdict = v;
     });
     await jest.advanceTimersByTimeAsync(1000);
-    expect(verdict).toMatchObject({ kind: 'unavailable' });
+    expect(verdict).toMatchObject({ kind: 'authenticated' });
     expect(rn.DeviceEventEmitter.emit).toHaveBeenCalledWith(
       blankingEvent,
       false,

--- a/__tests__/useBiometricGate.hook.tsx
+++ b/__tests__/useBiometricGate.hook.tsx
@@ -1,0 +1,118 @@
+/**
+ * The shared screen-level gate: one body for the mount and foreground
+ * effects, reactive to needsAuth, and a faithful reporter of what the
+ * platform said instead of a fixed blame-the-user sentence.
+ */
+jest.mock('../app/simpleBiometrics', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import simpleBiometrics from '../app/simpleBiometrics';
+import type { GateVerdict } from '../app/simpleBiometrics';
+import { useBiometricGate } from '../app/hooks/useBiometricGate';
+import type { TranslateType } from '../app/AppState';
+
+const gate = simpleBiometrics as jest.MockedFunction<typeof simpleBiometrics>;
+const translate = (k: string): TranslateType => k;
+
+type GateProps = Parameters<typeof useBiometricGate>[0];
+
+const gateArgs = (over?: { needsAuth?: boolean }) => ({
+  needsAuth: true,
+  translate,
+  addLastSnackbar: jest.fn(),
+  onCancel: jest.fn(),
+  foregroundAppEnabled: true,
+  foregroundEpoch: 0,
+  ...over,
+});
+
+beforeEach(() => {
+  gate.mockReset();
+});
+
+test('a decline surfaces the failure, not only the generic sentence', async () => {
+  gate.mockResolvedValue({
+    kind: 'declined',
+    failure: {
+      kind: 'error',
+      errorKey: 'biometrics-failure-stalled',
+      param: 'getGenericPassword',
+    },
+  });
+  const props = gateArgs();
+  renderHook((p: GateProps) => useBiometricGate(p), { initialProps: props });
+
+  await waitFor(() => expect(props.onCancel).toHaveBeenCalled());
+  expect(props.addLastSnackbar).toHaveBeenCalledWith(
+    expect.stringContaining('getGenericPassword'),
+  );
+});
+
+test('flipping needsAuth on re-gates a mounted screen', async () => {
+  gate.mockResolvedValue({ kind: 'authenticated' });
+  const { result, rerender } = renderHook(
+    (p: GateProps) => useBiometricGate(p),
+    {
+      initialProps: gateArgs({ needsAuth: false }),
+    },
+  );
+  expect(result.current).toBe(true);
+  expect(gate).not.toHaveBeenCalled();
+
+  rerender(gateArgs({ needsAuth: true }));
+  await waitFor(() => expect(gate).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(result.current).toBe(true));
+});
+
+test('an unanswered shared verdict re-asks while the screen lives', async () => {
+  gate
+    .mockResolvedValueOnce({ kind: 'unanswered' })
+    .mockResolvedValue({ kind: 'authenticated' });
+  const { result } = renderHook((p: GateProps) => useBiometricGate(p), {
+    initialProps: gateArgs(),
+  });
+
+  await waitFor(() => expect(result.current).toBe(true));
+  expect(gate).toHaveBeenCalledTimes(2);
+});
+
+test('an unmounted screen never re-asks on an unanswered verdict', async () => {
+  let handVerdict: (v: GateVerdict) => void = () => {};
+  gate.mockReturnValueOnce(
+    new Promise(resolve => {
+      handVerdict = resolve;
+    }),
+  );
+  const { unmount } = renderHook((p: GateProps) => useBiometricGate(p), {
+    initialProps: gateArgs(),
+  });
+  await waitFor(() => expect(gate).toHaveBeenCalledTimes(1));
+
+  unmount();
+  handVerdict({ kind: 'unanswered' });
+  await new Promise(resolve => setTimeout(resolve, 0));
+  expect(gate).toHaveBeenCalledTimes(1); // no stray prompt from a dead screen
+});
+
+test('a stalled fail-open tells the user the check did not respond', async () => {
+  gate.mockResolvedValue({
+    kind: 'unavailable',
+    failure: {
+      kind: 'error',
+      errorKey: 'biometrics-failure-stalled',
+      param: 'canImplyAuthentication',
+    },
+  });
+  const props = gateArgs();
+  const { result } = renderHook((p: GateProps) => useBiometricGate(p), {
+    initialProps: props,
+  });
+
+  await waitFor(() => expect(result.current).toBe(true));
+  expect(props.addLastSnackbar).toHaveBeenCalledWith(
+    expect.stringContaining('biometrics-failure-stalled'),
+  );
+});

--- a/app/AppState/AppStateLoading.ts
+++ b/app/AppState/AppStateLoading.ts
@@ -3,7 +3,11 @@ import { AppStateStatus } from 'react-native';
 import { LaunchingModeEnum } from './enums/LaunchingModeEnum';
 import { RouteEnum } from './enums/RouteEnum';
 import WalletType from './types/WalletType';
-import type { GateFailure } from '../simpleBiometrics';
+import { ErrorKeyed } from './types/Result';
+
+/** The launch gate's outcome, carried whole so the locked screen renders the reason it was locked for. */
+export type BiometricGateOutcome =
+  { kind: 'passed' } | { kind: 'declined'; failure?: ErrorKeyed<string> };
 
 export default interface AppStateLoading {
   wallet: WalletType;
@@ -18,10 +22,9 @@ export default interface AppStateLoading {
   customServerOffline: boolean;
   customServerAuto: boolean;
   customServerCustom: boolean;
-  biometricsFailed: boolean;
-  // Snapshotted at decline time so the locked screen's message cannot be
-  // rewritten or wiped by a later gate run mutating the module global.
-  gateFailure?: GateFailure;
+  // One field for one outcome: `declined` and its failure travel together,
+  // so a locked screen without a reason is unrepresentable.
+  biometricGate: BiometricGateOutcome;
   startingApp: boolean;
   serverErrorTries: number;
   donationAlert: boolean;

--- a/app/AppState/index.ts
+++ b/app/AppState/index.ts
@@ -20,7 +20,7 @@ import type SecurityType from './types/SecurityType';
 import type ServerUrisType from './types/ServerUrisType';
 import type { SetServerResult } from './types/SetServerResult';
 import type { ErrorKeyed, Done } from './types/Result';
-import { DONE } from './types/Result';
+import { DONE, errorKeyed } from './types/Result';
 import type ValueTransferType from './types/ValueTransferType';
 import type ProposalPoolsType from './types/ProposalPoolsType';
 import type TransactionType from './types/TransactionType';
@@ -82,6 +82,7 @@ export {
   TotalBalanceClass,
   AddressBookFileClassObsolete,
   DONE,
+  errorKeyed,
   AddressBookActionEnum,
   MenuItemEnum,
   LanguageEnum,

--- a/app/AppState/types/Result.ts
+++ b/app/AppState/types/Result.ts
@@ -14,3 +14,9 @@ export type ErrorKeyed<K extends string> = {
 
 export type Done = { kind: 'done' };
 export const DONE: Done = { kind: 'done' };
+
+/** Builds an ErrorKeyed failure, the one constructor for the shape. */
+export const errorKeyed = <K extends string>(
+  errorKey: K,
+  param?: string,
+): ErrorKeyed<K> => ({ kind: 'error', errorKey, param });

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -992,16 +992,27 @@ export class LoadedAppClass extends Component<
           // (PIN or TouchID or FaceID). Only a decline locks; an
           // 'unavailable' gate passes because it guards nothing and
           // blocking locks the user out of the wallet.
-          const foregroundGate: GateVerdict = this.state.security.foregroundApp
+          let foregroundGate: GateVerdict = this.state.security.foregroundApp
             ? await simpleBiometrics({
                 translate: this.state.translate,
                 purpose: 'appEntry',
               })
             : { kind: 'authenticated' };
+          while (foregroundGate.kind === 'unanswered') {
+            // A shared run's decline answered a screen gate, not app
+            // entry; this caller is alive, so it asks for its own verdict.
+            foregroundGate = await simpleBiometrics({
+              translate: this.state.translate,
+              purpose: 'appEntry',
+            });
+          }
           if (foregroundGate.kind === 'declined') {
+            // The failure travels with the navigation, so the locked
+            // screen never reads the mutable module global.
             this.navigateToLoadingApp({
               startingApp: true,
               biometricsFailed: true,
+              gateFailure: foregroundGate.failure,
             });
           } else {
             // reading background task info

--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -89,10 +89,7 @@ import Toast from 'react-native-toast-message';
 import { toastConfig } from '../toastConfig';
 import { RPCSeedType } from '../walletBackend/types/RPCSeedType';
 import Launching from './components/Launching';
-import simpleBiometrics, {
-  GateVerdict,
-  getLastGateFailure,
-} from '../simpleBiometrics';
+import simpleBiometrics, { GateVerdict } from '../simpleBiometrics';
 import selectingServer from '../selectingServer';
 import { isEqual } from 'lodash';
 import {
@@ -553,18 +550,12 @@ export class LoadingAppClass extends Component<
       customServerOffline: false,
       customServerAuto: false,
       customServerCustom: false,
-      biometricsFailed:
-        !!props.route.params &&
-        props.route.params.biometricsFailed !== undefined
-          ? props.route.params.biometricsFailed
-          : false,
-      // One-time snapshot for the arrived-already-declined path (the
-      // foreground gate navigated here); the startGate path snapshots its
-      // own verdict's failure below.
-      gateFailure:
+      // A decline's failure arrives with the navigation (see
+      // LoadingAppNavigationState), never from module state.
+      biometricGate:
         !!props.route.params && props.route.params.biometricsFailed
-          ? getLastGateFailure()
-          : undefined,
+          ? { kind: 'declined', failure: props.route.params.gateFailure }
+          : { kind: 'passed' },
       startingApp:
         !!props.route.params && props.route.params.startingApp !== undefined
           ? props.route.params.startingApp
@@ -598,30 +589,35 @@ export class LoadingAppClass extends Component<
     // to start the App the first time in this session
     // the user have to pass the security of the device
     if (this.state.startingApp) {
-      if (!this.state.biometricsFailed) {
-        // (PIN or TouchID or FaceID). Only a decline locks; an
-        // 'unavailable' gate passes because it guards nothing and
-        // blocking locks the user out of the wallet.
-        this.setState({ biometricsFailed: false });
-        const startGate: GateVerdict = this.state.security.startApp
-          ? await simpleBiometrics({
-              translate: this.state.translate,
-              purpose: 'appEntry',
-            })
-          : { kind: 'authenticated' };
-        if (startGate.kind === 'declined') {
-          this.setState({
-            biometricsFailed: true,
-            gateFailure: startGate.failure,
-          });
-          return;
-        } else {
-          this.setState({ biometricsFailed: false });
-        }
-      } else {
-        // if there is a biometric Fail, likely from the foreground check
-        // keep the App in the first screen because the user needs to try again.
+      if (this.state.biometricGate.kind === 'declined') {
+        // A biometric fail, likely from the foreground check: keep the App
+        // on the first screen so the user can try again.
         return;
+      }
+      // (PIN or TouchID or FaceID). Only a decline locks; an
+      // 'unavailable' gate passes because it guards nothing and
+      // blocking locks the user out of the wallet.
+      let startGate: GateVerdict = this.state.security.startApp
+        ? await simpleBiometrics({
+            translate: this.state.translate,
+            purpose: 'appEntry',
+          })
+        : { kind: 'authenticated' };
+      while (startGate.kind === 'unanswered') {
+        // A shared run's decline answered a screen gate, not app entry;
+        // this caller is alive, so it asks for its own verdict.
+        startGate = await simpleBiometrics({
+          translate: this.state.translate,
+          purpose: 'appEntry',
+        });
+      }
+      if (startGate.kind === 'declined') {
+        this.setState({
+          biometricGate: { kind: 'declined', failure: startGate.failure },
+        });
+        return;
+      } else {
+        this.setState({ biometricGate: { kind: 'passed' } });
       }
     }
 
@@ -723,6 +719,11 @@ export class LoadingAppClass extends Component<
       }
     }
 
+    // Re-entry via the locked screen's tryAgain must not stack another
+    // subscription on the one this mount already holds.
+    if (typeof this.appstate.remove === 'function') {
+      this.appstate.remove();
+    }
     this.appstate = AppState.addEventListener(
       EventListenerEnum.change,
       async nextAppState => {
@@ -763,6 +764,9 @@ export class LoadingAppClass extends Component<
       },
     );
 
+    if (typeof this.unsubscribeNetInfo === 'function') {
+      this.unsubscribeNetInfo();
+    }
     this.unsubscribeNetInfo = NetInfo.addEventListener(
       (state: NetInfoState) => {
         const { screen } = this.state;
@@ -2123,7 +2127,7 @@ export class LoadingAppClass extends Component<
       customServerOffline,
       customServerAuto,
       firstLaunchingMessage,
-      biometricsFailed,
+      biometricGate,
       translate,
       hasRecoveryWalletInfoSaved,
       readOnly,
@@ -2164,8 +2168,6 @@ export class LoadingAppClass extends Component<
       blockExplorer: this.state.blockExplorer,
     };
 
-    const { gateFailure } = this.state;
-
     return (
       <>
         <ContextAppLoadingProvider value={context}>
@@ -2177,14 +2179,14 @@ export class LoadingAppClass extends Component<
                 <Launching
                   translate={translate}
                   firstLaunchingMessage={firstLaunchingMessage}
-                  biometricsFailed={biometricsFailed}
+                  biometricsFailed={biometricGate.kind === 'declined'}
                   message={
-                    biometricsFailed && gateFailure
-                      ? Utils.renderErrorKeyed(gateFailure, translate)
+                    biometricGate.kind === 'declined' && biometricGate.failure
+                      ? Utils.renderErrorKeyed(biometricGate.failure, translate)
                       : undefined
                   }
                   tryAgain={() => {
-                    this.setState({ biometricsFailed: false }, () =>
+                    this.setState({ biometricGate: { kind: 'passed' } }, () =>
                       this.componentDidMount(),
                     );
                   }}

--- a/app/hooks/useBiometricGate.ts
+++ b/app/hooks/useBiometricGate.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import simpleBiometrics from '../simpleBiometrics';
 import { SnackbarDurationEnum, TranslateType } from '../AppState';
+import Utils from '../utils';
 
 type UseBiometricGateArgs = {
   needsAuth: boolean;
@@ -17,14 +18,19 @@ type UseBiometricGateArgs = {
  * gate used by Seed, ShowUfvk, Settings, Rescan and Confirm.
  *
  * Behaviour:
- *   - On mount: triggers simpleBiometrics when `needsAuth` is true.
- *   - On user cancel / fail: emits the standard snackbar via the
- *     supplied `addLastSnackbar` and calls `onCancel` (typically
+ *   - When `needsAuth` holds (at mount, or when a settings toggle flips it
+ *     on while the screen stays mounted): triggers simpleBiometrics.
+ *   - On decline: reports what the platform said (the rendered failure,
+ *     appended to the standard sentence) and calls `onCancel` (typically
  *     `navigation.goBack()`).
+ *   - On a stalled fail-open: passes, and tells the user the check did not
+ *     respond.
+ *   - On `unanswered` (a shared run's decline answered another purpose):
+ *     re-asks, but only while this screen is still mounted, so no prompt
+ *     is ever raised on behalf of a dead component.
  *   - On background → active (foregroundEpoch bumps): re-fires the gate
  *     only when `foregroundAppEnabled` is false. LoadedApp's own
- *     foreground gate already covers the enabled case, so re-firing
- *     here would just stack a second prompt on top of it.
+ *     foreground gate already covers the enabled case.
  *
  * Returns the boolean `authPassed`. Callers render a placeholder until
  * it flips to true so sensitive content is never visible while a prompt
@@ -40,39 +46,62 @@ export const useBiometricGate = ({
 }: UseBiometricGateArgs): boolean => {
   const [authPassed, setAuthPassed] = useState<boolean>(!needsAuth);
 
-  // Mount-only initial prompt. Native stack remounts the screen on
-  // every navigation, so a single check at mount enforces the gate on
-  // each visit.
-  useEffect(() => {
-    if (!needsAuth) {
-      return;
-    }
+  // The one gate body both effects run: returns the effect cleanup that
+  // cancels it, so an unmounted or re-gated screen never acts on a stale
+  // verdict and never re-asks for one.
+  const runScreenGate = () => {
     let cancelled = false;
     (async () => {
-      const verdict = await simpleBiometrics({
+      let verdict = await simpleBiometrics({
         translate,
         purpose: 'screenEntry',
       });
-      if (cancelled) {
+      while (verdict.kind === 'unanswered' && !cancelled) {
+        verdict = await simpleBiometrics({ translate, purpose: 'screenEntry' });
+      }
+      if (cancelled || verdict.kind === 'unanswered') {
         return;
       }
       if (verdict.kind === 'declined') {
-        addLastSnackbar(translate('biometrics-error') as string);
+        addLastSnackbar(
+          `${translate('biometrics-error') as string} ${Utils.renderErrorKeyed(
+            verdict.failure,
+            translate,
+          )}`,
+        );
         onCancel();
-      } else {
-        // 'unavailable' passes: the gate guards nothing, and blocking here
-        // would lock the user out of their own wallet.
-        setAuthPassed(true);
+        return;
       }
+      if (
+        verdict.kind === 'unavailable' &&
+        verdict.failure.errorKey === 'biometrics-failure-stalled'
+      ) {
+        // Passing is the fail-open policy for a gate that could not run,
+        // and the user should hear that the check did not respond.
+        addLastSnackbar(Utils.renderErrorKeyed(verdict.failure, translate));
+      }
+      setAuthPassed(true);
     })();
     return () => {
       cancelled = true;
     };
+  };
+
+  // Reactive to needsAuth: the native stack remounts screens per
+  // navigation, and a settings toggle can flip the requirement while the
+  // screen stays mounted; both paths re-gate here.
+  useEffect(() => {
+    if (!needsAuth) {
+      setAuthPassed(true);
+      return;
+    }
+    setAuthPassed(false);
+    return runScreenGate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [needsAuth]);
 
   // Re-fire on background → active. Skips the initial render so the
-  // mount effect above isn't duplicated.
+  // effect above isn't duplicated.
   const isFirstEpochRef = useRef(true);
   useEffect(() => {
     if (isFirstEpochRef.current) {
@@ -83,27 +112,7 @@ export const useBiometricGate = ({
       return;
     }
     setAuthPassed(false);
-    let cancelled = false;
-    (async () => {
-      const verdict = await simpleBiometrics({
-        translate,
-        purpose: 'screenEntry',
-      });
-      if (cancelled) {
-        return;
-      }
-      if (verdict.kind === 'declined') {
-        addLastSnackbar(translate('biometrics-error') as string);
-        onCancel();
-      } else {
-        // 'unavailable' passes: the gate guards nothing, and blocking here
-        // would lock the user out of their own wallet.
-        setAuthPassed(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    return runScreenGate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [foregroundEpoch]);
 

--- a/app/simpleBiometrics.ts
+++ b/app/simpleBiometrics.ts
@@ -506,7 +506,17 @@ const runGate = async (props: simpleBiometricsProps): Promise<GateVerdict> => {
   // operation rather than blocking on an impossible prompt.
   const security = await probeDeviceSecurity();
   if (!security.secure) {
-    return recordVerdict({ kind: 'unavailable', failure: security.failure });
+    // A stalled probe proves nothing about a live prompt, so it settles by
+    // the platform's stall policy like every other stall. A retry's probe
+    // queues behind the very call that stalled its parent, and answering
+    // it 'unavailable' would open on Android the lock the parent held.
+    // Only a genuine no-security answer fails open, because no lock could
+    // ever open it.
+    const kind =
+      security.failure.errorKey === 'biometrics-failure-stalled'
+        ? interactiveStallPolicy().settleAs
+        : 'unavailable';
+    return recordVerdict({ kind, failure: security.failure });
   }
 
   try {

--- a/app/simpleBiometrics.ts
+++ b/app/simpleBiometrics.ts
@@ -4,7 +4,7 @@ import * as Keychain from 'react-native-keychain';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { GlobalConst, TranslateType } from './AppState';
-import { ErrorKeyed } from './AppState/types/Result';
+import { ErrorKeyed, errorKeyed } from './AppState/types/Result';
 import {
   buildBaseOptions,
   buildGetOptions,
@@ -38,9 +38,9 @@ const SENTINEL_SERVICE_V1 = 'zingo-biometric-sentinel';
 // apart is what allows a bad entry to be rebuilt instead of retried forever.
 //
 // `stalled` is the fourth way an attempt can end: the native call never came
-// back at all. It must not trigger the rebuild — see NATIVE_STALL_MS below.
+// back at all. It must not trigger the rebuild (see NATIVE_STALL_MS below).
 // What a stall settles as differs by platform, and the outcome carries that
-// answer in `settleAs` — see interactiveStall for the policy.
+// answer in `settleAs`, per interactiveStall.
 
 /** The translation-catalog keys a gate failure can carry. */
 export type GateFailureKey =
@@ -49,7 +49,7 @@ export type GateFailureKey =
   | 'biometrics-failure-notserved'
   | 'biometrics-failure-nosecurity';
 
-// The error channel carries a catalog key, never prose; `param` is the
+// The error channel carries a catalog key, never prose. `param` is the
 // untranslated platform diagnostic (an OSStatus, a prompt code, the machine
 // token of the native call that stalled) so a bug report still names the
 // mechanism. The shape is the repo-wide ErrorKeyed convention, so the
@@ -59,10 +59,8 @@ export type GateFailureKey =
 /** A gate failure in the repo-canonical ErrorKeyed shape. */
 export type GateFailure = ErrorKeyed<GateFailureKey>;
 
-const gateFailure = (
-  errorKey: GateFailureKey,
-  param?: string,
-): GateFailure => ({ kind: 'error', errorKey, param });
+const gateFailure = (errorKey: GateFailureKey, param?: string): GateFailure =>
+  errorKeyed(errorKey, param);
 
 /** The stalled attempt outcome, carrying the platform's settlement policy. */
 export type StalledOutcome = {
@@ -86,11 +84,17 @@ export type AttemptOutcome =
 // error nobody was prompted for. Callers proceed on it, because the entry
 // guards nothing and blocking would lock the user out of the wallet.
 
+// `unanswered` reaches only a caller whose purpose differs from the run it
+// shared: the decline it saw answered somebody else's prompt. The caller
+// re-asks if it still exists. The module must not re-ask on its behalf,
+// because that raised prompts for components already unmounted.
+
 /** Every way the gate as a whole can answer. */
 export type GateVerdict =
   | { kind: 'authenticated' }
   | { kind: 'declined'; failure: GateFailure }
-  | { kind: 'unavailable'; failure: GateFailure };
+  | { kind: 'unavailable'; failure: GateFailure }
+  | { kind: 'unanswered' };
 
 // The iOS bridge rejects with the OSStatus as the error code.
 //
@@ -138,8 +142,8 @@ export const BIOMETRIC_BLANKING_EVENT = 'biometric-blanking';
 // up — so one call that never settles silently swallows every call queued
 // behind it. The awaits below would stay pending forever and the locked
 // screen's only action would do literally nothing, with no error to report.
-// A guarded call reports a stall instead; what a stall settles as is
-// per-platform — see interactiveStall.
+// A guarded call reports a stall instead. What a stall settles as is
+// per-platform, per interactiveStall.
 const NATIVE_STALL_MS = 10 * 1000;
 
 // Android cannot veto a fire the way iOS can (the BiometricPrompt sheet need
@@ -152,6 +156,10 @@ const ANDROID_PROMPT_STALL_MS = 60 * 1000;
 // still be in flight when the window closes and the veto would read a stale
 // 'active'. A veto-capable fire waits this long for it to land first.
 const VETO_GRACE_MS = 1000;
+
+// One frame at 60Hz is ~17ms. The budget covers a slow first frame without
+// ever holding the gate for a stall window.
+const PAINT_BUDGET_MS = 100;
 
 // The interactive stall policy's three axes move together, so one record
 // answers all of them: how long the window runs, whether a fire can be
@@ -181,13 +189,15 @@ const interactiveStallPolicy = (): InteractiveStallPolicy =>
 
 const STALLED = Symbol('keychain-stalled');
 
+const swallow = () => undefined;
+
 // The countdown for an interactive call runs only while the app is observed
 // 'active'. Leaving 'active' pauses it and returning re-arms it in full, so
 // time the OS parks on a human never counts toward a stall, and a queue
 // that is still wedged when the app comes back is caught by the fresh
 // window. Where the policy record allows a veto, a fire is vetoed while the
-// current state is 'inactive' or 'background' — the two states that prove a
-// live auth sheet or a backgrounded app — so a live prompt can never be
+// current state is 'inactive' or 'background', the two states that prove a
+// live auth sheet or a backgrounded app, so a live prompt can never be
 // declared a stall. An 'unknown' seed proves nothing (RN can seed it at
 // launch and never replay the missed transition), so it does not veto:
 // parking a wedged call on it would leave the gate pending forever. Calls
@@ -216,18 +226,22 @@ const stallGuard = <T>(
           AppState.currentState === 'background')
       ) {
         // The change event that would have paused the countdown can lose
-        // the race against the timer; the veto reads the state that event
+        // the race against the timer. The veto reads the state that event
         // was carrying, and the handler below re-arms on the way back.
         pause();
         return;
       }
+      // The losing arm keeps running. It holds a handler from here on, so
+      // a late rejection (the OS answering a stranded call ERROR_CANCELED)
+      // never surfaces as an unhandled rejection.
+      op.then(swallow, swallow);
       resolve(STALLED);
     };
     const arm = () => {
       timer = setTimeout(() => {
         if (interactive && policy.vetoOffActive) {
           // Give an in-flight resign-active event the grace to land before
-          // the veto reads the state; the change handler clears this timer
+          // the veto reads the state. The change handler clears this timer
           // like any other.
           timer = setTimeout(fire, VETO_GRACE_MS);
           return;
@@ -272,7 +286,6 @@ type GuardedOp =
   | 'resetGenericPassword:rebuild'
   | 'setGenericPassword'
   | 'getGenericPassword'
-  | 'requestAnimationFrame'
   | 'AsyncStorage.setItem';
 
 type Guarded<T> =
@@ -291,7 +304,6 @@ const OP_INTERACTIVITY: Record<GuardedOp, boolean> = {
   'resetGenericPassword:rebuild': false,
   setGenericPassword: true,
   getGenericPassword: true,
-  requestAnimationFrame: false,
   'AsyncStorage.setItem': false,
 };
 
@@ -337,15 +349,19 @@ const describeFailure = (e: unknown): string => {
 
 // errSecAuthFailed is the one broken-entry code that follows a human
 // actually failing the prompt (Android's equivalent, lockout, is already a
-// decline); every other code reaches brokenEntry without anyone being asked.
+// decline). Every other code reaches brokenEntry without anyone asked.
 const IOS_AUTH_FAILED = '-25293';
 
 const classifyFailure = (e: unknown): AttemptOutcome => {
   const detail = describeFailure(e);
+  // The prompt-code scrape stays anchored to E_CRYPTO_FAILED. Any other
+  // error whose text happens to contain "code: N" is a platform failure
+  // nobody was asked about, never a decline.
   const declined =
     Platform.OS === 'ios'
       ? IOS_DECLINED.includes(failureCode(e))
-      : ANDROID_DECLINED.includes(
+      : failureCode(e) === 'E_CRYPTO_FAILED' &&
+        ANDROID_DECLINED.includes(
           Number(/code:\s*(-?\d+)/.exec(failureMessage(e))?.[1]),
         );
   if (declined) {
@@ -373,7 +389,7 @@ const classifyFailure = (e: unknown): AttemptOutcome => {
 // The rebuild decision needs one bit the outcome alone cannot carry: whether
 // the entry the attempt ran against predates this gate run. A pre-existing
 // entry that misbehaves may be the stale entry of issue #1266 and earns one
-// rebuild; an entry written seconds ago under the current access control
+// rebuild. An entry written seconds ago under the current access control
 // cannot be stale, so a failure against it is the user failing to
 // authenticate. Collapsing the two is what let two failed prompts in a row
 // open the gate.
@@ -388,7 +404,7 @@ const settled = (verdict: GateVerdict): SettledPhase => ({
 
 // Pure and total: every (phase, outcome) pair maps to exactly one next
 // phase, and the annotated types make the compiler hold the table
-// exhaustive — the driver's loop condition proves the settled phase never
+// exhaustive. The driver's loop condition proves the settled phase never
 // reaches this function.
 const advance = (
   state: Exclude<GatePhase, SettledPhase>,
@@ -408,7 +424,7 @@ const advance = (
         return { phase: 'freshEntry' };
       }
       // Against an entry written seconds ago, only a failure the user was
-      // actually asked about is a decline; an entry the platform would not
+      // actually asked about is a decline. An entry the platform would not
       // serve is a gate that cannot run, and locking on it would re-open
       // the issue #1266 trap.
       return outcome.cause === 'authFailed'
@@ -423,7 +439,10 @@ let lastFailure: GateFailure | undefined;
 export const getLastGateFailure = (): GateFailure | undefined => lastFailure;
 
 const recordVerdict = (verdict: GateVerdict): GateVerdict => {
-  lastFailure = verdict.kind === 'authenticated' ? undefined : verdict.failure;
+  lastFailure =
+    verdict.kind === 'declined' || verdict.kind === 'unavailable'
+      ? verdict.failure
+      : undefined;
   return verdict;
 };
 
@@ -496,14 +515,20 @@ const runGate = async (props: simpleBiometricsProps): Promise<GateVerdict> => {
       // rejection anywhere past this line still drops the overlay.
       DeviceEventEmitter.emit(BIOMETRIC_BLANKING_EVENT, true);
       // Yield one frame so the overlay paints before the system prompt
-      // opens. A backgrounded launch delivers no frames, so the wait is
-      // guarded: the prompt then opens without the paint rather than
-      // parking the gate.
-      await guarded(
-        'requestAnimationFrame',
-        () =>
-          new Promise<void>(resolve => requestAnimationFrame(() => resolve())),
-      );
+      // opens. The paint is cosmetic, so the wait is bounded by a frame
+      // budget and a frameless or throwing yield never denies the gate.
+      await new Promise<void>(resolve => {
+        const frameBudget = setTimeout(resolve, PAINT_BUDGET_MS);
+        try {
+          requestAnimationFrame(() => {
+            clearTimeout(frameBudget);
+            resolve();
+          });
+        } catch {
+          clearTimeout(frameBudget);
+          resolve();
+        }
+      });
     }
     // hasGenericPassword answers "an entry exists", never "an entry works".
     // The iOS bridge resolves it to true on errSecInteractionNotAllowed, so
@@ -538,7 +563,7 @@ const runGate = async (props: simpleBiometricsProps): Promise<GateVerdict> => {
     let state: GatePhase = has.value
       ? { phase: 'trustedEntry' }
       : { phase: 'freshEntry' };
-    // A first-run create writes into an empty service; only the
+    // A first-run create writes into an empty service. Only the
     // trustedEntry -> freshEntry rebuild must clear the stale entry first.
     let clearBeforeAttempt = false;
     while (state.phase !== 'settled') {
@@ -572,11 +597,8 @@ const runGate = async (props: simpleBiometricsProps): Promise<GateVerdict> => {
     });
   } finally {
     if (Platform.OS === 'android') {
-      // Dropped at the verdict even though a call from this run may still
-      // hold its prompt on screen: the bounded exposure behind that prompt
-      // costs less than the capped but minute-long black overlay the
-      // deferred hide put over every screen while a call pended (Audit
-      // Issue C accepted the trade).
+      // Dropped at the verdict, accepting the bounded exposure behind a
+      // still-live prompt over a black overlay that outlives its purpose.
       DeviceEventEmitter.emit(BIOMETRIC_BLANKING_EVENT, false);
     }
     // iOS treats the auth prompt as the app going to background; restore the
@@ -595,13 +617,10 @@ const runGate = async (props: simpleBiometricsProps): Promise<GateVerdict> => {
 
 // The gate's process-wide lifecycle. `running` shares the run in flight so
 // concurrent callers never stack prompts. A settled verdict always returns
-// to `idle`: a retry starts a fresh run with a fresh prompt, even while a
-// call from an earlier run is still pending inside the native module. The
-// collision can answer the fresh prompt ERROR_CANCELED, one bounded and
-// retriable decline. Blocking the retry proved worse: it answered Try
-// Again by policy after the probe window without ever prompting, so while
-// a call never settled (a lost Android callback) no retry could succeed —
-// the issue #1266 trap this module exists to keep unreachable.
+// to `idle`, and a retry runs fresh even while an earlier call is still
+// pending in the native module. The collision costs at most one immediate,
+// retriable ERROR_CANCELED decline. Blocking retries instead made a
+// never-settling call unrecoverable, the issue #1266 trap.
 type GateLifecycle =
   | { stage: 'idle' }
   | {
@@ -633,12 +652,12 @@ const simpleBiometrics = (
       if (running.purpose === props.purpose) {
         return running.verdictOut;
       }
-      // A pass authenticates the person for any purpose; a decline answers
-      // only the purpose the user was actually shown. A cross-purpose
-      // caller therefore adopts everything but a decline, and on one runs
-      // its own gate once the shared run has settled.
-      return running.verdictOut.then(verdict =>
-        verdict.kind === 'declined' ? simpleBiometrics(props) : verdict,
+      // A pass authenticates the person for any purpose. A decline answers
+      // only the purpose the user was actually shown, so a cross-purpose
+      // caller receives `unanswered` and decides for itself whether to
+      // re-ask.
+      return running.verdictOut.then((verdict): GateVerdict =>
+        verdict.kind === 'declined' ? { kind: 'unanswered' } : verdict,
       );
     }
     case 'idle':
@@ -646,7 +665,8 @@ const simpleBiometrics = (
   }
 };
 
-type DeviceSecurityProbe =
+/** The device-security probe's answer, carrying the reason when it cannot secure. */
+export type DeviceSecurityProbe =
   { secure: true } | { secure: false; failure: GateFailure };
 
 const insecure = (failure: GateFailure): DeviceSecurityProbe => ({
@@ -662,11 +682,11 @@ const NO_DEVICE_SECURITY: GateFailure = gateFailure(
 // returns false on Android, so the Android answer is composed from the
 // biometry-type query plus the device passcode probe. These probes are the
 // first keychain calls of the flow, which makes them the ones that queue
-// behind a wedged predecessor; each refusal carries its own reason, so the
+// behind a wedged predecessor. Each refusal carries its own reason, so the
 // pre-flight verdict never inherits a stale one.
 
 /** Answers whether the device can authenticate its user, with the reason when it cannot. */
-const probeDeviceSecurity = async (): Promise<DeviceSecurityProbe> => {
+export const probeDeviceSecurity = async (): Promise<DeviceSecurityProbe> => {
   try {
     if (Platform.OS === 'ios') {
       const can = await guarded('canImplyAuthentication', () =>
@@ -699,12 +719,5 @@ const probeDeviceSecurity = async (): Promise<DeviceSecurityProbe> => {
     );
   }
 };
-
-// Settings uses the boolean wrapper to enable the per-screen bio toggles;
-// it replaces the react-native-biometrics isSensorAvailable() check.
-
-/** True when the device can authenticate the user via biometry or device credential. */
-export const hasDeviceSecurity = async (): Promise<boolean> =>
-  (await probeDeviceSecurity()).secure;
 
 export default simpleBiometrics;

--- a/app/types/NavigationTypes.ts
+++ b/app/types/NavigationTypes.ts
@@ -1,6 +1,7 @@
 import {
   AddressKindEnum,
   ChainNameEnum,
+  ErrorKeyed,
   LaunchingModeEnum,
   RouteEnum,
   SeedActionEnum,
@@ -35,6 +36,9 @@ export type LoadingAppNavigationState = {
   screen?: RouteEnum;
   startingApp?: boolean;
   biometricsFailed?: boolean;
+  // The decline's failure rides with the navigation, so the locked screen
+  // renders the reason it was locked for instead of reading module state.
+  gateFailure?: ErrorKeyed<string>;
   newWallet?: boolean;
 };
 /**

--- a/app/uris/parseZcashURI.ts
+++ b/app/uris/parseZcashURI.ts
@@ -4,6 +4,7 @@ import ZcashURITargetClass from './classes/ZcashURITargetClass';
 import {
   ServerType,
   ErrorKeyed,
+  errorKeyed,
   GlobalConst,
   ZcashUriFieldEnum,
 } from '../AppState';
@@ -32,7 +33,7 @@ export type ParseZcashUriResult =
 const err = (
   errorKey: ZcashUriErrorKey,
   param?: string,
-): ErrorKeyed<ZcashUriErrorKey> => ({ kind: 'error', errorKey, param });
+): ErrorKeyed<ZcashUriErrorKey> => errorKeyed(errorKey, param);
 
 const parseZcashURI = async (
   uri: string,

--- a/app/walletBackend/modules/WalletLifecycleService.ts
+++ b/app/walletBackend/modules/WalletLifecycleService.ts
@@ -6,7 +6,13 @@
  * return DONE on success or an ErrorKeyed failure the display edge
  * translates (docs/adr/0002-error-keys-not-prose.md).
  */
-import { GlobalConst, Done, DONE, ErrorKeyed } from '../../AppState';
+import {
+  GlobalConst,
+  Done,
+  DONE,
+  ErrorKeyed,
+  errorKeyed,
+} from '../../AppState';
 import RPCModule from '../../RPCModule';
 import { SyncCoordinator } from './SyncCoordinator';
 import { doSaveBackup } from '../utils/walletUtils';
@@ -21,7 +27,7 @@ export type WalletLifecycleResult = Done | ErrorKeyed<WalletLifecycleErrorKey>;
 
 const err = (
   errorKey: WalletLifecycleErrorKey,
-): ErrorKeyed<WalletLifecycleErrorKey> => ({ kind: 'error', errorKey });
+): ErrorKeyed<WalletLifecycleErrorKey> => errorKeyed(errorKey);
 
 export class WalletLifecycleService {
   syncCoordinator: SyncCoordinator;

--- a/components/Settings/Settings.tsx
+++ b/components/Settings/Settings.tsx
@@ -74,7 +74,7 @@ import { getLatestBlockServerInfo } from '../../app/walletBackend';
 import { isEqual } from 'lodash';
 import ChainTypeToggle from '../Components/ChainTypeToggle';
 import BouncyCheckbox from 'react-native-bouncy-checkbox';
-import { hasDeviceSecurity } from '../../app/simpleBiometrics';
+import { probeDeviceSecurity } from '../../app/simpleBiometrics';
 import { useBiometricGate } from '../../app/hooks/useBiometricGate';
 import SelectBottomSheet from '../Components/SelectBottomSheet';
 import BottomSheet, {
@@ -393,7 +393,15 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
 
   useEffect(() => {
     (async () => {
-      setDeviceHasSecurity(await hasDeviceSecurity());
+      const probe = await probeDeviceSecurity();
+      if (probe.secure) {
+        setDeviceHasSecurity(true);
+      } else if (probe.failure.errorKey !== 'biometrics-failure-stalled') {
+        setDeviceHasSecurity(false);
+      }
+      // A stalled probe answers nothing (the keychain queue was busy,
+      // often behind this screen's own gate prompt); keep the last known
+      // answer rather than claiming no device lock is enrolled.
     })();
   }, []);
 


### PR DESCRIPTION
Stacked on #1328. The final full-stack review confirmed ten correctness findings and five standing cleanups; this PR takes all fifteen, tests first (six module reds, four reds in a new `renderHook` suite for the screen gate).

**The stray-prompt fix.** The verdict union gains `unanswered`: a shared run's decline answered somebody else's prompt, and the caller re-asks only if it still exists. The module no longer re-runs the gate for a parked cross-purpose caller, which raised prompts from unmounted components over the locked screen. LoadedApp and LoadingApp loop while unanswered; the hook re-asks only while mounted.

**The screen hook.** One gate body serves both effects, reactive to `needsAuth` (a settings toggle flipping the requirement re-gates a mounted screen). A decline's rendered failure rides the snackbar, so an Android stall no longer masquerades as a user cancel, and a stalled fail-open tells the user the check did not respond — the first surface the wedged-queue class has had.

**Correctness on the edges.** `probeDeviceSecurity` is exported and Settings consumes the union, so a probe stalled behind this screen's own prompt keeps the last known answer instead of disabling the toggles. The Android prompt-code scrape is anchored to `E_CRYPTO_FAILED`. The paint yield gets a real frame budget (100 ms) in place of the 10 s stall window, and a throwing yield proceeds. The stall guard's losing arm holds a handler, so a late `ERROR_CANCELED` never surfaces as an unhandled rejection.

**The locked screen.** The failure travels inside `LoadingAppNavigationState.gateFailure` and lands in a `BiometricGateOutcome` union replacing the boolean-plus-optional pair, so a locked screen without a reason is unrepresentable and nothing reads the mutable module global. `tryAgain` re-entry removes the previous AppState/NetInfo subscriptions before re-registering, closing the listener leak.

**Cleanups.** `Result.ts` gains the shared `errorKeyed` constructor (adopted by the gate, `parseZcashURI`, and `WalletLifecycleService`), the `AppStateLoading` layering import of `simpleBiometrics` is gone, and the stack's comment prose sheds its em dashes, semicolon chains, and paragraph-length justifications.

Deliberately unchanged: the fail-open verdict while a wedge holds the iOS queue is the standing platform policy, now surfaced through the hook's stall notice rather than silent.

Verification: `tsc` clean, `eslint` clean, prettier clean on every touched file, 46 of 46 tests pass (35 gate, 5 hook, 6 snapshot including Settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
