### PR TITLE
refactor(biometrics): name every lock decision, and type the non-answer

### DIFF
--- a/__tests__/simpleBiometrics.gate.tsx
+++ b/__tests__/simpleBiometrics.gate.tsx
@@ -512,7 +512,7 @@ test('a stalled security probe reports stalled, not no-security', async () => {
   // Settings must be able to tell "the probe did not answer" from "no
   // device lock is enrolled" instead of disabling the toggles on a stall.
   await expect(probe).resolves.toMatchObject({
-    secure: false,
+    kind: 'insecure',
     failure: { errorKey: 'biometrics-failure-stalled' },
   });
 });

--- a/__tests__/useBiometricGate.hook.tsx
+++ b/__tests__/useBiometricGate.hook.tsx
@@ -51,6 +51,24 @@ test('a decline surfaces the failure, not only the generic sentence', async () =
   );
 });
 
+test('a decline is a named refused state, not a bare false', async () => {
+  gate.mockResolvedValue({
+    kind: 'declined',
+    failure: {
+      kind: 'error',
+      errorKey: 'biometrics-failure-declined',
+      param: '-128 boom',
+    },
+  });
+  const props = gateArgs();
+  const { result } = renderHook((p: GateProps) => useBiometricGate(p), {
+    initialProps: props,
+  });
+
+  await waitFor(() => expect(props.onCancel).toHaveBeenCalled());
+  expect(result.current).toMatchObject({ kind: 'refused' });
+});
+
 test('flipping needsAuth on re-gates a mounted screen', async () => {
   gate.mockResolvedValue({ kind: 'authenticated' });
   const { result, rerender } = renderHook(
@@ -59,12 +77,12 @@ test('flipping needsAuth on re-gates a mounted screen', async () => {
       initialProps: gateArgs({ needsAuth: false }),
     },
   );
-  expect(result.current).toBe(true);
+  expect(result.current).toMatchObject({ kind: 'passed' });
   expect(gate).not.toHaveBeenCalled();
 
   rerender(gateArgs({ needsAuth: true }));
   await waitFor(() => expect(gate).toHaveBeenCalledTimes(1));
-  await waitFor(() => expect(result.current).toBe(true));
+  await waitFor(() => expect(result.current).toMatchObject({ kind: 'passed' }));
 });
 
 test('an unanswered shared verdict leaves the screen gated, no re-ask', async () => {
@@ -83,7 +101,7 @@ test('an unanswered shared verdict leaves the screen gated, no re-ask', async ()
   await waitFor(() => expect(gate).toHaveBeenCalledTimes(1));
   await new Promise(resolve => setTimeout(resolve, 0));
   expect(gate).toHaveBeenCalledTimes(1);
-  expect(result.current).toBe(false);
+  expect(result.current).toMatchObject({ kind: 'checking' });
   expect(props.onCancel).not.toHaveBeenCalled();
 });
 
@@ -137,7 +155,7 @@ test('a stalled fail-open tells the user the check did not respond', async () =>
     initialProps: props,
   });
 
-  await waitFor(() => expect(result.current).toBe(true));
+  await waitFor(() => expect(result.current).toMatchObject({ kind: 'passed' }));
   expect(props.addLastSnackbar).toHaveBeenCalledWith(
     expect.stringContaining('biometrics-failure-stalled'),
   );

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -652,7 +652,7 @@ export default function LoadedApp(props: LoadedAppProps) {
       <Launching
         translate={translate}
         firstLaunchingMessage={LaunchingModeEnum.opening}
-        biometricsFailed={false}
+        biometricGate={{ kind: 'passed' }}
       />
     );
   } else {

--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -431,7 +431,7 @@ export default function LoadingApp(props: LoadingAppProps) {
       <Launching
         translate={translate}
         firstLaunchingMessage={LaunchingModeEnum.opening}
-        biometricsFailed={false}
+        biometricGate={{ kind: 'passed' }}
       />
     );
   } else {
@@ -2211,15 +2211,7 @@ export class LoadingAppClass extends Component<
                 <Launching
                   translate={translate}
                   firstLaunchingMessage={firstLaunchingMessage}
-                  biometricsFailed={biometricGate.kind === 'declined'}
-                  message={
-                    biometricGate.kind === 'declined'
-                      ? Utils.renderGateFailure(
-                          biometricGate.failure,
-                          translate,
-                        )
-                      : undefined
-                  }
+                  biometricGate={biometricGate}
                   tryAgain={() => {
                     this.setState({ biometricGate: { kind: 'passed' } }, () =>
                       this.componentDidMount(),

--- a/app/LoadingApp/components/Launching.tsx
+++ b/app/LoadingApp/components/Launching.tsx
@@ -5,22 +5,28 @@ import { Text, View, ActivityIndicator } from 'react-native';
 import { useTheme } from '../../theme';
 
 import {
+  BiometricGateOutcome,
   ButtonTypeEnum,
   LaunchingModeEnum,
   TranslateType,
 } from '../../AppState';
 import Button from '../../../components/Components/Button';
 import { getZingoName, getZingoVersion } from '../../utils/ZingoAppData';
+import Utils from '../../utils';
 
 type LaunchingProps = {
   translate: (key: string) => TranslateType;
   firstLaunchingMessage: LaunchingModeEnum;
-  biometricsFailed: boolean;
+  biometricGate: BiometricGateOutcome;
   tryAgain?: () => void;
-  message?: string;
 };
 
 const Launching: React.FunctionComponent<LaunchingProps> = props => {
+  const biometricsFailed = props.biometricGate.kind === 'declined';
+  const message =
+    props.biometricGate.kind === 'declined'
+      ? Utils.renderGateFailure(props.biometricGate.failure, props.translate)
+      : undefined;
   const { colors } = useTheme();
 
   return (
@@ -72,7 +78,7 @@ const Launching: React.FunctionComponent<LaunchingProps> = props => {
             padding: 10,
           }}
         >
-          {!!props.message && (
+          {!!message && (
             <Text
               style={{
                 color: colors.fgAccentDisabled,
@@ -81,10 +87,10 @@ const Launching: React.FunctionComponent<LaunchingProps> = props => {
               }}
               selectable
             >
-              {props.message}
+              {message}
             </Text>
           )}
-          {props.biometricsFailed ? (
+          {biometricsFailed ? (
             <>
               <Text
                 style={{
@@ -150,7 +156,7 @@ const Launching: React.FunctionComponent<LaunchingProps> = props => {
                       LaunchingModeEnum.updating ||
                       props.firstLaunchingMessage ===
                         LaunchingModeEnum.installing) &&
-                    !props.biometricsFailed
+                    !biometricsFailed
                       ? 1
                       : 0,
                   textAlign: 'center',
@@ -176,7 +182,7 @@ const Launching: React.FunctionComponent<LaunchingProps> = props => {
                       LaunchingModeEnum.updating ||
                       props.firstLaunchingMessage ===
                         LaunchingModeEnum.installing) &&
-                    !props.biometricsFailed
+                    !biometricsFailed
                       ? 1
                       : 0,
                   textAlign: 'center',
@@ -203,7 +209,7 @@ const Launching: React.FunctionComponent<LaunchingProps> = props => {
                       LaunchingModeEnum.updating ||
                       props.firstLaunchingMessage ===
                         LaunchingModeEnum.installing) &&
-                    !props.biometricsFailed
+                    !biometricsFailed
                       ? 1
                       : 0,
                   textAlign: 'center',

--- a/app/hooks/useBiometricGate.ts
+++ b/app/hooks/useBiometricGate.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import simpleBiometrics from '../simpleBiometrics';
+import simpleBiometrics, { AnsweredVerdict } from '../simpleBiometrics';
 import { SnackbarDurationEnum, TranslateType } from '../AppState';
 import Utils from '../utils';
 
@@ -12,6 +12,10 @@ type UseBiometricGateArgs = {
   foregroundAppEnabled: boolean;
   foregroundEpoch: number;
 };
+
+/** The screen gate's named states, so callers never read a bare boolean. */
+export type ScreenGateState =
+  { kind: 'checking' } | { kind: 'passed' } | { kind: 'refused' };
 
 /**
  * Audit Issue D — single source of truth for the screen-level biometric
@@ -26,14 +30,15 @@ type UseBiometricGateArgs = {
  *   - On a stalled fail-open: passes, and tells the user the check did not
  *     respond.
  *   - On `unanswered` (a shared appEntry run declined, locking the app):
- *     stays gated and never re-asks, so no prompt is ever raised on
- *     behalf of a component being torn down.
+ *     stays in `checking` and never re-asks, so no prompt is ever raised
+ *     on behalf of a component being torn down. The type enforces the
+ *     no-action rule: only an AnsweredVerdict reaches the acting code.
  *   - On background → active (foregroundEpoch bumps): re-fires the gate
  *     only when `foregroundAppEnabled` is false. LoadedApp's own
  *     foreground gate already covers the enabled case.
  *
- * Returns the boolean `authPassed`. Callers render a placeholder until
- * it flips to true so sensitive content is never visible while a prompt
+ * Returns a ScreenGateState. Callers render a placeholder until it
+ * reaches `passed`, so sensitive content is never visible while a prompt
  * is in flight.
  */
 export const useBiometricGate = ({
@@ -43,8 +48,39 @@ export const useBiometricGate = ({
   onCancel,
   foregroundAppEnabled,
   foregroundEpoch,
-}: UseBiometricGateArgs): boolean => {
-  const [authPassed, setAuthPassed] = useState<boolean>(!needsAuth);
+}: UseBiometricGateArgs): ScreenGateState => {
+  const [screenGate, setScreenGate] = useState<ScreenGateState>(
+    needsAuth ? { kind: 'checking' } : { kind: 'passed' },
+  );
+
+  // Only an answered verdict may act; `unanswered` cannot reach this code.
+  const enactScreenVerdict = (verdict: AnsweredVerdict) => {
+    if (verdict.kind === 'declined') {
+      setScreenGate({ kind: 'refused' });
+      // The raw diagnostic is bug-report data. Only the stalled key earns
+      // a place in user copy, because there the sentence is the sole
+      // trace the wedged-queue class leaves.
+      addLastSnackbar(
+        verdict.failure.errorKey === 'biometrics-failure-stalled'
+          ? `${translate('biometrics-error') as string} ${Utils.renderGateFailure(
+              verdict.failure,
+              translate,
+            )}`
+          : (translate('biometrics-error') as string),
+      );
+      onCancel();
+      return;
+    }
+    if (
+      verdict.kind === 'unavailable' &&
+      verdict.failure.errorKey === 'biometrics-failure-stalled'
+    ) {
+      // Passing is the fail-open policy for a gate that could not run,
+      // and the user should hear that the check did not respond.
+      addLastSnackbar(Utils.renderGateFailure(verdict.failure, translate));
+    }
+    setScreenGate({ kind: 'passed' });
+  };
 
   // The one gate body both effects run: returns the effect cleanup that
   // cancels it, so an unmounted or re-gated screen never acts on a stale
@@ -58,36 +94,12 @@ export const useBiometricGate = ({
       });
       // 'unanswered' means an appEntry run declined while this screen
       // shared it, and an appEntry decline locks the whole app: this
-      // screen is being torn down, so it stays gated and never re-asks (a
-      // re-ask raced the teardown into a stray prompt over the locked
-      // screen).
+      // screen is being torn down, so it stays in `checking` and never
+      // re-asks.
       if (cancelled || verdict.kind === 'unanswered') {
         return;
       }
-      if (verdict.kind === 'declined') {
-        // The raw diagnostic is bug-report data. Only the stalled key
-        // earns a place in user copy, because there the sentence is the
-        // sole trace the wedged-queue class leaves.
-        addLastSnackbar(
-          verdict.failure.errorKey === 'biometrics-failure-stalled'
-            ? `${translate('biometrics-error') as string} ${Utils.renderGateFailure(
-                verdict.failure,
-                translate,
-              )}`
-            : (translate('biometrics-error') as string),
-        );
-        onCancel();
-        return;
-      }
-      if (
-        verdict.kind === 'unavailable' &&
-        verdict.failure.errorKey === 'biometrics-failure-stalled'
-      ) {
-        // Passing is the fail-open policy for a gate that could not run,
-        // and the user should hear that the check did not respond.
-        addLastSnackbar(Utils.renderGateFailure(verdict.failure, translate));
-      }
-      setAuthPassed(true);
+      enactScreenVerdict(verdict);
     })();
     return () => {
       cancelled = true;
@@ -99,10 +111,10 @@ export const useBiometricGate = ({
   // screen stays mounted; both paths re-gate here.
   useEffect(() => {
     if (!needsAuth) {
-      setAuthPassed(true);
+      setScreenGate({ kind: 'passed' });
       return;
     }
-    setAuthPassed(false);
+    setScreenGate({ kind: 'checking' });
     return runScreenGate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [needsAuth]);
@@ -118,10 +130,10 @@ export const useBiometricGate = ({
     if (!needsAuth || foregroundAppEnabled) {
       return;
     }
-    setAuthPassed(false);
+    setScreenGate({ kind: 'checking' });
     return runScreenGate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [foregroundEpoch]);
 
-  return authPassed;
+  return screenGate;
 };

--- a/app/simpleBiometrics.ts
+++ b/app/simpleBiometrics.ts
@@ -73,12 +73,17 @@ export type AttemptOutcome =
 // re-asks if it still exists. The module must not re-ask on its behalf,
 // because that raised prompts for components already unmounted.
 
-/** Every way the gate as a whole can answer. */
-export type GateVerdict =
+/** Every answer the gate gives a caller that must act on it. */
+export type AnsweredVerdict =
   | { kind: 'authenticated' }
   | { kind: 'declined'; failure: GateFailure }
-  | { kind: 'unavailable'; failure: GateFailure }
-  | { kind: 'unanswered' };
+  | { kind: 'unavailable'; failure: GateFailure };
+
+/** The non-answer: the shared run's decline addressed another purpose, and the holder must do nothing. */
+export type Unanswered = { kind: 'unanswered' };
+
+/** Every way the gate as a whole can answer. */
+export type GateVerdict = AnsweredVerdict | Unanswered;
 
 // The iOS bridge rejects with the OSStatus as the error code.
 //
@@ -472,7 +477,7 @@ const runGate = async (props: simpleBiometricsProps): Promise<GateVerdict> => {
   // passcode), short-circuit so the caller can decide whether to allow the
   // operation rather than blocking on an impossible prompt.
   const security = await probeDeviceSecurity();
-  if (!security.secure) {
+  if (security.kind === 'insecure') {
     // A stalled probe proves nothing about a live prompt, so it settles by
     // the platform's stall policy like every other stall. A retry's probe
     // queues behind the very call that stalled its parent, and answering
@@ -650,10 +655,10 @@ const simpleBiometrics = (
 
 /** The device-security probe's answer, carrying the reason when it cannot secure. */
 export type DeviceSecurityProbe =
-  { secure: true } | { secure: false; failure: GateFailure };
+  { kind: 'secured' } | { kind: 'insecure'; failure: GateFailure };
 
 const insecure = (failure: GateFailure): DeviceSecurityProbe => ({
-  secure: false,
+  kind: 'insecure',
   failure,
 });
 
@@ -678,7 +683,7 @@ export const probeDeviceSecurity = async (): Promise<DeviceSecurityProbe> => {
       if (can.kind === 'stalled') {
         return insecure(can.failure);
       }
-      return can.value ? { secure: true } : insecure(NO_DEVICE_SECURITY);
+      return can.value ? { kind: 'secured' } : insecure(NO_DEVICE_SECURITY);
     }
     const biometry = await guarded('getSupportedBiometryType', () =>
       Keychain.getSupportedBiometryType(),
@@ -687,7 +692,7 @@ export const probeDeviceSecurity = async (): Promise<DeviceSecurityProbe> => {
       return insecure(biometry.failure);
     }
     if (biometry.value !== null) {
-      return { secure: true };
+      return { kind: 'secured' };
     }
     const passcode = await guarded('isPasscodeAuthAvailable', () =>
       Keychain.isPasscodeAuthAvailable(),
@@ -695,7 +700,7 @@ export const probeDeviceSecurity = async (): Promise<DeviceSecurityProbe> => {
     if (passcode.kind === 'stalled') {
       return insecure(passcode.failure);
     }
-    return passcode.value ? { secure: true } : insecure(NO_DEVICE_SECURITY);
+    return passcode.value ? { kind: 'secured' } : insecure(NO_DEVICE_SECURITY);
   } catch (e) {
     return insecure(
       gateFailure('biometrics-failure-notserved', describeFailure(e)),
@@ -732,7 +737,7 @@ const untilProvablyActive = (): Promise<void> => {
 /** Runs the gate for an app-level caller, re-asking on `unanswered` once the app is back in the foreground. */
 export const gateUntilAnswered = async (
   props: simpleBiometricsProps,
-): Promise<Exclude<GateVerdict, { kind: 'unanswered' }>> => {
+): Promise<AnsweredVerdict> => {
   let verdict = await simpleBiometrics(props);
   while (verdict.kind === 'unanswered') {
     await untilProvablyActive();

--- a/components/Rescan/Rescan.tsx
+++ b/components/Rescan/Rescan.tsx
@@ -54,7 +54,7 @@ const Rescan: React.FunctionComponent<RescanProps> = ({
   const screenName = ScreenEnum.Rescan;
 
   // Audit Issue D — single source of truth for security.rescanScreen.
-  const authPassed = useBiometricGate({
+  const screenGate = useBiometricGate({
     needsAuth: !!security?.rescanScreen,
     translate,
     addLastSnackbar,
@@ -62,6 +62,7 @@ const Rescan: React.FunctionComponent<RescanProps> = ({
     foregroundAppEnabled: !!security?.foregroundApp,
     foregroundEpoch,
   });
+  const authPassed = screenGate.kind === 'passed';
 
   const [containerH, setContainerH] = useState<number>(0);
   const [headerH, setHeaderH] = useState<number>(0);

--- a/components/Seed/Seed.tsx
+++ b/components/Seed/Seed.tsx
@@ -126,7 +126,7 @@ const Seed: React.FunctionComponent<SeedProps> = ({
     (initialAction === SeedActionEnum.backup &&
       (!!security?.seedUfvkScreen || !!security?.restoreWalletBackupScreen)) ||
     (initialAction === SeedActionEnum.server && !!security?.seedUfvkScreen);
-  const authPassed = useBiometricGate({
+  const screenGate = useBiometricGate({
     needsAuth,
     translate,
     addLastSnackbar,
@@ -134,6 +134,7 @@ const Seed: React.FunctionComponent<SeedProps> = ({
     foregroundAppEnabled: !!security?.foregroundApp,
     foregroundEpoch,
   });
+  const authPassed = screenGate.kind === 'passed';
 
   const [times, setTimes] = useState<number>(0);
   const [texts, setTexts] = useState<TextsType>({} as TextsType);

--- a/components/Send/components/Confirm.tsx
+++ b/components/Send/components/Confirm.tsx
@@ -103,7 +103,7 @@ const Confirm: React.FunctionComponent<ConfirmProps> = ({
   // brief window after auth where the Confirm button can be pressed
   // without re-authenticating. Native stack remounts the screen on each
   // navigation, so leaving and coming back forces a fresh prompt.
-  const authPassed = useBiometricGate({
+  const screenGate = useBiometricGate({
     needsAuth: !!security?.sendConfirm,
     translate,
     addLastSnackbar,
@@ -111,6 +111,7 @@ const Confirm: React.FunctionComponent<ConfirmProps> = ({
     foregroundAppEnabled: !!security?.foregroundApp,
     foregroundEpoch,
   });
+  const authPassed = screenGate.kind === 'passed';
 
   const [sendingTotal, setSendingTotal] = useState<number>(0);
 

--- a/components/Settings/Settings.tsx
+++ b/components/Settings/Settings.tsx
@@ -74,7 +74,10 @@ import { getLatestBlockServerInfo } from '../../app/walletBackend';
 import { isEqual } from 'lodash';
 import ChainTypeToggle from '../Components/ChainTypeToggle';
 import BouncyCheckbox from 'react-native-bouncy-checkbox';
-import { probeDeviceSecurity } from '../../app/simpleBiometrics';
+import {
+  DeviceSecurityProbe,
+  probeDeviceSecurity,
+} from '../../app/simpleBiometrics';
 import { useBiometricGate } from '../../app/hooks/useBiometricGate';
 import SelectBottomSheet from '../Components/SelectBottomSheet';
 import BottomSheet, {
@@ -247,7 +250,7 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
   if (!savingSettingsRef.current) {
     gateRequirementRef.current = liveNeedsAuth;
   }
-  const authPassed = useBiometricGate({
+  const screenGate = useBiometricGate({
     needsAuth: gateRequirementRef.current,
     translate,
     addLastSnackbar,
@@ -255,6 +258,7 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
     foregroundAppEnabled: !!securityContext.foregroundApp,
     foregroundEpoch,
   });
+  const authPassed = screenGate.kind === 'passed';
 
   const [autoServerUri, setAutoServerUri] = useState<string>('');
   const [autoServerChainName, setAutoServerChainName] = useState<string>('');
@@ -345,7 +349,11 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
   const [showDeveloperOptions, setShowDeveloperOptions] =
     useState<boolean>(false);
   const [openInfoSection, setOpenInfoSection] = useState<string | null>(null);
-  const [deviceHasSecurity, setDeviceHasSecurity] = useState<boolean>(true);
+  // Seeded optimistically; the union names the probe's answer instead of
+  // collapsing it to a bit at this edge.
+  const [deviceSecurity, setDeviceSecurity] = useState<DeviceSecurityProbe>({
+    kind: 'secured',
+  });
 
   // Bottom-sheet measurements — Settings has no balance area, so the sheet
   // uses a single snap at the maximum height (just below the screen Header).
@@ -411,10 +419,11 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
     }
     (async () => {
       const probe = await probeDeviceSecurity();
-      if (probe.secure) {
-        setDeviceHasSecurity(true);
-      } else if (probe.failure.errorKey !== 'biometrics-failure-stalled') {
-        setDeviceHasSecurity(false);
+      if (
+        probe.kind === 'secured' ||
+        probe.failure.errorKey !== 'biometrics-failure-stalled'
+      ) {
+        setDeviceSecurity(probe);
       }
     })();
   }, [authPassed]);
@@ -1965,7 +1974,7 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
                       </View>
                     </TouchableOpacity>
                   </View>
-                  {!deviceHasSecurity && (
+                  {deviceSecurity.kind === 'insecure' && (
                     <FadeText style={{ marginTop: 6 }}>
                       {
                         translate(

--- a/components/Ufvk/ShowUfvk.tsx
+++ b/components/Ufvk/ShowUfvk.tsx
@@ -117,7 +117,7 @@ const ShowUfvk: React.FunctionComponent<ShowUfvkProps> = ({
     (initialAction === UfvkActionEnum.backup &&
       (!!security?.seedUfvkScreen || !!security?.restoreWalletBackupScreen)) ||
     (initialAction === UfvkActionEnum.server && !!security?.seedUfvkScreen);
-  const authPassed = useBiometricGate({
+  const screenGate = useBiometricGate({
     needsAuth,
     translate,
     addLastSnackbar,
@@ -125,6 +125,7 @@ const ShowUfvk: React.FunctionComponent<ShowUfvkProps> = ({
     foregroundAppEnabled: !!security?.foregroundApp,
     foregroundEpoch,
   });
+  const authPassed = screenGate.kind === 'passed';
 
   const [times, setTimes] = useState<number>(0);
   const [texts, setTexts] = useState<TextsType>({} as TextsType);


### PR DESCRIPTION
Stacked on #1336. An audit asked whether every lock-or-unlock decision is carried by a discriminated union that names its states. Three edges degraded to booleans, and the unanswered-means-no-action rule lived in caller discipline. This PR closes all four, tests first (the probe-shape test and four hook-state tests went red before the change).

**The non-answer is a type.** `GateVerdict = AnsweredVerdict | Unanswered`. Everything that acts on a verdict takes `AnsweredVerdict`: `gateUntilAnswered` returns it outright, and the screen hook routes verdicts through an enact function typed to it, with the `unanswered` case peeled off before it. The compiler now enforces what was caller discipline.

**Named states at the three degraded edges.** `DeviceSecurityProbe` is `secured | insecure` instead of a boolean discriminant. The screen hook returns `ScreenGateState` (`checking | passed | refused`) instead of a bare boolean; the five gated screens derive their placeholder boolean locally, and the transient `refused` state is visible and pinned by a test. `Launching` takes the `BiometricGateOutcome` whole and derives its former `biometricsFailed`/`message` props inside the display edge; Settings holds the probe union itself, so the no-device-lock hint reads the named `insecure` state.

Verification: `tsc` clean, `eslint` clean, prettier clean, 55 of 55 tests pass across the gate, hook, render-policy, and snapshot suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
