### PR TITLE
fix(biometrics): bound the foreground hold and single-flight its actors

### DIFF
--- a/__tests__/simpleBiometrics.gate.tsx
+++ b/__tests__/simpleBiometrics.gate.tsx
@@ -395,6 +395,33 @@ test('a resign-active event landing just after the fire still vetoes the stall',
   expect(verdict).toMatchObject({ kind: 'authenticated' });
 });
 
+test('a throwing cancelAnimationFrame never hangs the frame yield', async () => {
+  jest.useFakeTimers();
+  rn.Platform.OS = 'android';
+  const realFrame = globalThis.requestAnimationFrame;
+  const realCancel = globalThis.cancelAnimationFrame;
+  globalThis.requestAnimationFrame = (() =>
+    7) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {
+    throw new Error('no cancel here');
+  }) as typeof globalThis.cancelAnimationFrame;
+  try {
+    kc.getSupportedBiometryType.mockResolvedValue('Fingerprint');
+    kc.hasGenericPassword.mockResolvedValue(true);
+    kc.getGenericPassword.mockResolvedValue({ password: '1' });
+
+    let verdict: GateVerdict | undefined;
+    simpleBiometrics({ translate, purpose: 'appEntry' }).then(v => {
+      verdict = v;
+    });
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(verdict).toMatchObject({ kind: 'authenticated' });
+  } finally {
+    globalThis.requestAnimationFrame = realFrame;
+    globalThis.cancelAnimationFrame = realCancel;
+  }
+});
+
 test('an android launch with no frames still settles the gate', async () => {
   jest.useFakeTimers();
   rn.Platform.OS = 'android';
@@ -932,6 +959,50 @@ test('a stale inactive read does not refuse a live re-ask', async () => {
   setAppState('active'); // the in-flight event lands
   await expect(appGate).resolves.toMatchObject({ kind: 'authenticated' });
   expect(kc.getGenericPassword).toHaveBeenCalledTimes(2);
+});
+
+test('a hold that never sees the return settles by the stall policy', async () => {
+  // A stale away-read whose 'active' event was already delivered parks
+  // the hold; the policy window must settle it like every other stall,
+  // never wedge the gate for good.
+  jest.useFakeTimers();
+  rn.Platform.OS = 'android';
+  kc.getSupportedBiometryType.mockResolvedValue('Fingerprint');
+  kc.hasGenericPassword.mockResolvedValue(true);
+  let refuse: (e: Error) => void = () => {};
+  kc.getGenericPassword.mockReturnValueOnce(
+    new Promise((_serve, reject) => {
+      refuse = reject;
+    }),
+  );
+
+  let screenVerdict: GateVerdict | undefined;
+  simpleBiometrics({ translate, purpose: 'screenEntry' }).then(v => {
+    screenVerdict = v;
+  });
+  let held: GateVerdict | undefined;
+  gateUntilAnswered({ translate, purpose: 'appEntry' }).then(v => {
+    held = v;
+  });
+  rn.__appState.currentState = 'background'; // stale, no event ever comes
+  await jest.advanceTimersByTimeAsync(2000); // let the paint yield pass
+  refuse(
+    Object.assign(new Error('code: 10, msg: Canceled by user'), {
+      code: 'E_CRYPTO_FAILED',
+    }),
+  );
+  await jest.advanceTimersByTimeAsync(0);
+  expect(screenVerdict).toMatchObject({ kind: 'declined' });
+
+  await jest.advanceTimersByTimeAsync(60 * 1000);
+  expect(held).toMatchObject({
+    kind: 'declined',
+    failure: {
+      errorKey: 'biometrics-failure-stalled',
+      param: 'returnToForeground',
+    },
+  });
+  expect(kc.getGenericPassword).toHaveBeenCalledTimes(1);
 });
 
 test('an unknown app state proves nothing and never parks the re-ask', async () => {

--- a/__tests__/useBiometricGate.hook.tsx
+++ b/__tests__/useBiometricGate.hook.tsx
@@ -6,6 +6,7 @@
 jest.mock('../app/simpleBiometrics', () => ({
   __esModule: true,
   default: jest.fn(),
+  returnedToForeground: jest.fn(() => Promise.resolve(true)),
 }));
 
 import { renderHook, waitFor } from '@testing-library/react-native';
@@ -85,24 +86,19 @@ test('flipping needsAuth on re-gates a mounted screen', async () => {
   await waitFor(() => expect(result.current).toMatchObject({ kind: 'passed' }));
 });
 
-test('an unanswered shared verdict leaves the screen gated, no re-ask', async () => {
-  // 'unanswered' means an appEntry run declined while this screen shared
-  // it, and an appEntry decline locks the whole app: the screen is being
-  // torn down, and a re-ask from here raced that teardown into a stray
-  // prompt over the locked screen.
+test('a parked screen gate re-asks after the bounded wait', async () => {
+  // An appEntry decline usually tears this screen down; the bounded wait
+  // gives that teardown time to cancel. Where no teardown comes, the
+  // re-ask restores the screen's own gate instead of parking it blank.
   gate
     .mockResolvedValueOnce({ kind: 'unanswered' })
     .mockResolvedValue({ kind: 'authenticated' });
-  const props = gateArgs();
   const { result } = renderHook((p: GateProps) => useBiometricGate(p), {
-    initialProps: props,
+    initialProps: gateArgs(),
   });
 
-  await waitFor(() => expect(gate).toHaveBeenCalledTimes(1));
-  await new Promise(resolve => setTimeout(resolve, 0));
-  expect(gate).toHaveBeenCalledTimes(1);
-  expect(result.current).toMatchObject({ kind: 'checking' });
-  expect(props.onCancel).not.toHaveBeenCalled();
+  await waitFor(() => expect(gate).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(result.current).toMatchObject({ kind: 'passed' }));
 });
 
 test('an ordinary cancel shows only the standard sentence', async () => {

--- a/app/LoadedApp/LoadedApp.tsx
+++ b/app/LoadedApp/LoadedApp.tsx
@@ -94,7 +94,7 @@ import { RPCSeedType } from '../walletBackend/types/RPCSeedType';
 import { Launching } from '../LoadingApp';
 import { AddressBook } from '../../components/AddressBook';
 import { AddressBookFileImpl } from '../../components/AddressBook';
-import { gateUntilAnswered, GateVerdict } from '../simpleBiometrics';
+import { AnsweredVerdict, gateUntilAnswered } from '../simpleBiometrics';
 import ShowAddressAlertAsync from '../../components/Send/components/ShowAddressAlertAsync';
 import {
   createUpdateRecoveryWalletInfo,
@@ -989,46 +989,17 @@ export class LoadedAppClass extends Component<
           this.setState(state => ({
             foregroundEpoch: state.foregroundEpoch + 1,
           }));
-          // (PIN or TouchID or FaceID). Only a decline locks; an
-          // 'unavailable' gate passes because it guards nothing and
-          // blocking locks the user out of the wallet.
-          const foregroundGate = this.state.security.foregroundApp
-            ? await gateUntilAnswered({
-                translate: this.state.translate,
-                purpose: 'appEntry',
-              })
-            : ({ kind: 'authenticated' } satisfies GateVerdict);
-          if (foregroundGate.kind === 'declined') {
-            // The gate outcome travels with the navigation whole, so the
-            // locked screen never reads mutable module state.
-            this.navigateToLoadingApp({
-              startingApp: true,
-              biometricGate: {
-                kind: 'declined',
-                failure: foregroundGate.failure,
-              },
-            });
-          } else {
-            // reading background task info
-            await this.fetchBackgroundSyncInfo();
-            // setting value for background task Android
-            await AsyncStorage.setItem(GlobalConst.background, GlobalConst.no);
-            // needs this because when the App go from back to fore
-            // it have to re-launch all the tasks.
-            await this.rpc.clearTimers();
-            await this.rpc.configure();
-            if (
-              this.state.backgroundError &&
-              (this.state.backgroundError.title ||
-                this.state.backgroundError.error)
-            ) {
-              showConfirm({
-                title: this.state.backgroundError.title,
-                message: this.state.backgroundError.error,
-                buttons: [{ text: this.state.translate('close') as string }],
-              });
-              this.setBackgroundError('', '');
-            }
+          // A parked earlier pass resumes with this same event and acts
+          // once; a second concurrent actor would double-run the restore
+          // work or the navigation reset.
+          if (this.foregroundGateBusy) {
+            return;
+          }
+          this.foregroundGateBusy = true;
+          try {
+            await this.runForegroundGate();
+          } finally {
+            this.foregroundGateBusy = false;
           }
         } else if (
           priorAppState === AppStateStatusEnum.active &&
@@ -1125,6 +1096,48 @@ export class LoadedAppClass extends Component<
   componentDidUpdate = (prevProps: LoadedAppClassProps) => {
     if (prevProps.translate !== this.props.translate) {
       this.setState({ translate: this.props.translate });
+    }
+  };
+
+  foregroundGateBusy = false;
+
+  // (PIN or TouchID or FaceID). Only a decline locks; an 'unavailable'
+  // gate passes because it guards nothing and blocking locks the user out
+  // of the wallet.
+  runForegroundGate = async () => {
+    const foregroundGate: AnsweredVerdict = this.state.security.foregroundApp
+      ? await gateUntilAnswered({
+          translate: this.state.translate,
+          purpose: 'appEntry',
+        })
+      : { kind: 'authenticated' };
+    if (foregroundGate.kind === 'declined') {
+      // The narrowed verdict is the gate outcome, whole; the locked
+      // screen never reads mutable module state.
+      this.navigateToLoadingApp({
+        startingApp: true,
+        biometricGate: foregroundGate,
+      });
+      return;
+    }
+    // reading background task info
+    await this.fetchBackgroundSyncInfo();
+    // setting value for background task Android
+    await AsyncStorage.setItem(GlobalConst.background, GlobalConst.no);
+    // needs this because when the App go from back to fore
+    // it have to re-launch all the tasks.
+    await this.rpc.clearTimers();
+    await this.rpc.configure();
+    if (
+      this.state.backgroundError &&
+      (this.state.backgroundError.title || this.state.backgroundError.error)
+    ) {
+      showConfirm({
+        title: this.state.backgroundError.title,
+        message: this.state.backgroundError.error,
+        buttons: [{ text: this.state.translate('close') as string }],
+      });
+      this.setBackgroundError('', '');
     }
   };
 

--- a/app/LoadingApp/LoadingApp.tsx
+++ b/app/LoadingApp/LoadingApp.tsx
@@ -92,7 +92,7 @@ import Toast from 'react-native-toast-message';
 import { toastConfig } from '../toastConfig';
 import { RPCSeedType } from '../walletBackend/types/RPCSeedType';
 import Launching from './components/Launching';
-import { gateUntilAnswered, GateVerdict } from '../simpleBiometrics';
+import { AnsweredVerdict, gateUntilAnswered } from '../simpleBiometrics';
 import selectingServer from '../selectingServer';
 import { isEqual } from 'lodash';
 import {
@@ -593,16 +593,15 @@ export class LoadingAppClass extends Component<
       // (PIN or TouchID or FaceID). Only a decline locks; an
       // 'unavailable' gate passes because it guards nothing and
       // blocking locks the user out of the wallet.
-      const startGate = this.state.security.startApp
+      const startGate: AnsweredVerdict = this.state.security.startApp
         ? await gateUntilAnswered({
             translate: this.state.translate,
             purpose: 'appEntry',
           })
-        : ({ kind: 'authenticated' } satisfies GateVerdict);
+        : { kind: 'authenticated' };
       if (startGate.kind === 'declined') {
-        this.setState({
-          biometricGate: { kind: 'declined', failure: startGate.failure },
-        });
+        // The narrowed verdict is the gate outcome, whole.
+        this.setState({ biometricGate: startGate });
         return;
       }
     }
@@ -705,6 +704,11 @@ export class LoadingAppClass extends Component<
       }
     }
 
+    if (this.unmounted) {
+      // The boot chain outlived this instance; attaching listeners here
+      // would subscribe a dead component forever.
+      return;
+    }
     // Re-entry via the locked screen's tryAgain must not stack another
     // subscription pair on the one this mount already holds.
     this.detachListeners();
@@ -806,7 +810,10 @@ export class LoadingAppClass extends Component<
     this.unsubscribeNetInfo = undefined;
   };
 
+  unmounted = false;
+
   componentWillUnmount = () => {
+    this.unmounted = true;
     this.detachListeners();
   };
 

--- a/app/hooks/useBiometricGate.ts
+++ b/app/hooks/useBiometricGate.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 
-import simpleBiometrics, { AnsweredVerdict } from '../simpleBiometrics';
+import simpleBiometrics, {
+  AnsweredVerdict,
+  returnedToForeground,
+} from '../simpleBiometrics';
 import { SnackbarDurationEnum, TranslateType } from '../AppState';
 import Utils from '../utils';
 
@@ -30,9 +33,10 @@ export type ScreenGateState =
  *   - On a stalled fail-open: passes, and tells the user the check did not
  *     respond.
  *   - On `unanswered` (a shared appEntry run declined, locking the app):
- *     stays in `checking` and never re-asks, so no prompt is ever raised
- *     on behalf of a component being torn down. The type enforces the
- *     no-action rule: only an AnsweredVerdict reaches the acting code.
+ *     waits out the bounded return-to-foreground hold, then re-asks only
+ *     if this screen still exists, so no prompt is ever raised on behalf
+ *     of a component being torn down. The type enforces the no-action
+ *     rule: only an AnsweredVerdict reaches the acting code.
  *   - On background → active (foregroundEpoch bumps): re-fires the gate
  *     only when `foregroundAppEnabled` is false. LoadedApp's own
  *     foreground gate already covers the enabled case.
@@ -88,14 +92,24 @@ export const useBiometricGate = ({
   const runScreenGate = () => {
     let cancelled = false;
     (async () => {
-      const verdict = await simpleBiometrics({
+      let verdict = await simpleBiometrics({
         translate,
         purpose: 'screenEntry',
       });
-      // 'unanswered' means an appEntry run declined while this screen
-      // shared it, and an appEntry decline locks the whole app: this
-      // screen is being torn down, so it stays in `checking` and never
-      // re-asks.
+      // 'unanswered' means an appEntry decline is locking the app, which
+      // usually tears this screen down; the bounded wait gives that
+      // teardown time to cancel this run. Where no teardown comes, the
+      // re-ask restores the screen's own gate instead of parking it.
+      while (verdict.kind === 'unanswered' && !cancelled) {
+        await returnedToForeground();
+        if (cancelled) {
+          return;
+        }
+        verdict = await simpleBiometrics({
+          translate,
+          purpose: 'screenEntry',
+        });
+      }
       if (cancelled || verdict.kind === 'unanswered') {
         return;
       }

--- a/app/simpleBiometrics.ts
+++ b/app/simpleBiometrics.ts
@@ -178,6 +178,12 @@ const interactiveStallPolicy = (): InteractiveStallPolicy =>
         settleAs: 'declined',
       };
 
+// Only 'inactive' and 'background' prove absence. An 'unknown' seed
+// proves nothing and must never park a wait.
+const provablyAway = (): boolean =>
+  AppState.currentState === 'inactive' ||
+  AppState.currentState === 'background';
+
 const STALLED = Symbol('keychain-stalled');
 
 // The countdown for an interactive call runs only while the app is observed
@@ -208,12 +214,7 @@ const stallGuard = <T>(
       timer = undefined;
     };
     const fire = () => {
-      if (
-        interactive &&
-        policy.vetoOffActive &&
-        (AppState.currentState === 'inactive' ||
-          AppState.currentState === 'background')
-      ) {
+      if (interactive && policy.vetoOffActive && provablyAway()) {
         // The change event that would have paused the countdown can lose
         // the race against the timer. The veto reads the state that event
         // was carrying, and the handler below re-arms on the way back.
@@ -502,8 +503,12 @@ const runGate = async (props: simpleBiometricsProps): Promise<GateVerdict> => {
       await new Promise<void>(resolve => {
         let frame: number | undefined;
         const frameBudget = setTimeout(() => {
-          if (frame !== undefined) {
-            cancelAnimationFrame(frame);
+          try {
+            if (frame !== undefined) {
+              cancelAnimationFrame(frame);
+            }
+          } catch {
+            // The cancel is best-effort; the resolve below must run.
           }
           resolve();
         }, PAINT_BUDGET_MS);
@@ -708,31 +713,32 @@ export const probeDeviceSecurity = async (): Promise<DeviceSecurityProbe> => {
   }
 };
 
-// The re-ask loop for app-level callers. A re-ask for a backgrounded
-// activity is answered ERROR_CANCELED, which classifies as a decline and
-// locks, so the loop holds while the app is provably away and asks again
-// the moment it returns. An 'inactive' read right after the shared sheet
-// closes is stale, and the pending active event releases the hold moments
-// later; an 'unknown' seed proves nothing and never parks the loop. A
-// concurrent run started by the caller's own re-entry shares, so the hold
-// can never stack prompts.
-
-const untilProvablyActive = (): Promise<void> => {
-  if (
-    AppState.currentState !== 'inactive' &&
-    AppState.currentState !== 'background'
-  ) {
-    return Promise.resolve();
+/** Resolves true when the app returns to 'active', false when the stall policy's window expires first. */
+export const returnedToForeground = (): Promise<boolean> => {
+  if (!provablyAway()) {
+    return Promise.resolve(true);
   }
   return new Promise(resolve => {
+    let expiry: ReturnType<typeof setTimeout> | undefined;
     const subscription = AppState.addEventListener('change', next => {
       if (next === 'active') {
+        clearTimeout(expiry);
         subscription.remove();
-        resolve();
+        resolve(true);
       }
     });
+    expiry = setTimeout(() => {
+      subscription.remove();
+      resolve(false);
+    }, interactiveStallPolicy().windowMs);
   });
 };
+
+// The re-ask loop for app-level callers. A re-ask for a backgrounded
+// activity is answered ERROR_CANCELED and would lock, so the loop holds
+// while the app is provably away, re-asks the moment it returns, and on
+// an expired hold settles by the stall policy like every other bounded
+// wait in this module.
 
 /** Runs the gate for an app-level caller, re-asking on `unanswered` once the app is back in the foreground. */
 export const gateUntilAnswered = async (
@@ -740,7 +746,15 @@ export const gateUntilAnswered = async (
 ): Promise<AnsweredVerdict> => {
   let verdict = await simpleBiometrics(props);
   while (verdict.kind === 'unanswered') {
-    await untilProvablyActive();
+    if (!(await returnedToForeground())) {
+      return {
+        kind: interactiveStallPolicy().settleAs,
+        failure: gateFailure(
+          'biometrics-failure-stalled',
+          'returnToForeground',
+        ),
+      };
+    }
     verdict = await simpleBiometrics(props);
   }
   return verdict;

--- a/components/Settings/Settings.tsx
+++ b/components/Settings/Settings.tsx
@@ -240,18 +240,20 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
   const screenName = ScreenEnum.Settings;
 
   // Audit Issue D — single source of truth for security.settingsScreen.
-  // The requirement is live (a toggle flip re-gates, and the
-  // background-return re-gate keeps working) except while this screen's
-  // own save rewrites the security context: re-gating the screen that is
-  // saving blanked the form under an unrequested prompt.
-  const savingSettingsRef = useRef<boolean>(false);
+  // The requirement follows the live context except while this screen's
+  // own save rewrites it. The sync runs in an effect, so the thaw is a
+  // rendered state change at a deterministic moment, never a stale ref.
+  const [savingSettings, setSavingSettings] = useState<boolean>(false);
   const liveNeedsAuth = !!securityContext.settingsScreen;
-  const gateRequirementRef = useRef<boolean>(liveNeedsAuth);
-  if (!savingSettingsRef.current) {
-    gateRequirementRef.current = liveNeedsAuth;
-  }
+  const [gateRequirement, setGateRequirement] =
+    useState<boolean>(liveNeedsAuth);
+  useEffect(() => {
+    if (!savingSettings) {
+      setGateRequirement(liveNeedsAuth);
+    }
+  }, [savingSettings, liveNeedsAuth]);
   const screenGate = useBiometricGate({
-    needsAuth: gateRequirementRef.current,
+    needsAuth: gateRequirement,
     translate,
     addLastSnackbar,
     onCancel: () => navigation.goBack(),
@@ -349,7 +351,7 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
   const [showDeveloperOptions, setShowDeveloperOptions] =
     useState<boolean>(false);
   const [openInfoSection, setOpenInfoSection] = useState<string | null>(null);
-  // Seeded optimistically; the union names the probe's answer instead of
+  // Seeded optimistically. The union names the probe's answer instead of
   // collapsing it to a bit at this edge.
   const [deviceSecurity, setDeviceSecurity] = useState<DeviceSecurityProbe>({
     kind: 'secured',
@@ -409,16 +411,22 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
 
   const settingsSnapPoints = useFullSheetSnapPoints(containerH, headerH);
 
+  const probedRef = useRef<boolean>(false);
   useEffect(() => {
-    // Probe only once the gate has settled: the probe queues behind this
-    // screen's own gate prompt on the serialized keychain queue, and a
-    // stalled probe answers nothing, so keep the current answer rather
-    // than claiming no device lock is enrolled.
-    if (!authPassed) {
+    // Probe once, after the gate first settles: the probe queues behind
+    // this screen's own gate prompt on the serialized keychain queue, a
+    // stalled probe answers nothing, and the enrolled-lock answer cannot
+    // change while the user stays in this app.
+    if (!authPassed || probedRef.current) {
       return;
     }
+    probedRef.current = true;
+    let cancelled = false;
     (async () => {
       const probe = await probeDeviceSecurity();
+      if (cancelled) {
+        return;
+      }
       if (
         probe.kind === 'secured' ||
         probe.failure.errorKey !== 'biometrics-failure-stalled'
@@ -426,6 +434,9 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
         setDeviceSecurity(probe);
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [authPassed]);
 
   useEffect(() => {
@@ -1095,11 +1106,11 @@ const Settings: React.FunctionComponent<SettingsProps> = ({
     }
   };
   const saveSettings = async () => {
-    savingSettingsRef.current = true;
+    setSavingSettings(true);
     try {
       await doSaveSettings();
     } finally {
-      savingSettingsRef.current = false;
+      setSavingSettings(false);
     }
   };
   saveSettingsRef.current = saveSettings;


### PR DESCRIPTION
Stacked on #1337. Juanky's second review of #1336 and an eight-angle
re-review converged on the same faults, and all of them land here, three red
tests first.

### the park finding

A hold with no bound could park a verdict forever. `returnedToForeground`
now waits for a provable return to `active`, capped at the stall policy's
window, and removes its listener on both paths. An expired hold settles
`gateUntilAnswered` by the policy record (token `returnToForeground`), like
every other bounded wait in the module. The watchdog's veto and the hold
share one `provablyAway` predicate.

### the double-resume finding

The event that released a parked pass could also start a second actor.
LoadedApp's gate-and-act block moved into `runForegroundGate` behind a busy
flag. `clearTimers`, `configure`, and the navigation reset each run once.

### the thaw finding

Settings' save freeze thawed at an arbitrary later render. The freeze is
now state synced by an effect, so the thaw is a rendered change at a
deterministic moment. That closes both failure directions: the deferred
prompt and the stranded, ungated screen.

### Re-review: the blank re-ask

On `unanswered` the hook re-asked at once and could park the screen blank.
It now waits out the bounded hold and re-asks only if its cleanup has not
cancelled it, so the usual teardown gets its window to cancel. The paths
where no teardown comes restore the screen's own gate.

### Re-review: the probe's re-runs

The probe ran never-while-checking and again per re-gate. It now runs once
after the gate settles, with cancellation.

### Re-review: the throwing cancel

A throwing `cancelAnimationFrame` could hang the paint yield. The call is
wrapped, so a throwing cancel proceeds.

### Re-review: the late listener attach

LoadingApp could attach listeners after unmount, past the boot awaits. It
now checks an unmounted flag first.

### The tail

Declined branches pass the narrowed verdict whole, and both apps annotate
`AnsweredVerdict`.

Verification: `tsc` clean, `eslint` clean, prettier clean, 57 of 57 tests
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
