### PR TITLE
feat(native): add the DeviceAuth module behind the privacy shutter

### DIFF
--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -54,6 +54,13 @@ jest.mock('react-native', () => {
     confirmProcess: jest.fn(() => '{}'),
     getZenniesDonationAddress: jest.fn(() => '{}'),
   };
+  RN.NativeModules.DeviceAuth = {
+    canAuthenticate: jest.fn(async () => ({ available: true, code: '' })),
+    authenticate: jest.fn(async () => ({
+      outcome: 'authenticated',
+      code: '',
+    })),
+  };
   RN.View = jest.fn();
   RN.RefreshControl = jest.fn(() => null);
 

--- a/__tests__/deviceAuthModule.unit.ts
+++ b/__tests__/deviceAuthModule.unit.ts
@@ -1,39 +1,53 @@
 /**
  * The DeviceAuth binding's contract: the typed surface the gate
  * controller will build on (ADR 0007). The native halves are exercised on
- * device; this pins the JS shape and the pass-through.
+ * device; what this file can pin is the seam between them and JS.
+ *
+ * The binding is a lookup, not a wrapper, so there is no pass-through to
+ * assert — asserting one would only compare a mock against itself. What
+ * can break here, and what these tests hold, is the name: the binding must
+ * resolve the module Android registers as `getName() = "DeviceAuth"` and
+ * iOS as `RCT_EXTERN_MODULE(DeviceAuth, …)`, and it must expose both
+ * methods of the API the controller calls. The stub lives in the repo's
+ * manual mock (`__mocks__/react-native.js`), so this suite sees the same
+ * registry every other consumer does instead of a private one.
  */
-jest.mock('react-native', () => ({
-  __esModule: true,
-  NativeModules: {
-    DeviceAuth: {
-      authenticate: jest.fn(async () => ({
-        outcome: 'authenticated',
-        code: '',
-      })),
-      canAuthenticate: jest.fn(async () => ({ available: true, code: '' })),
-    },
-  },
-}));
+// Side-effect import, and it must come first: `__mocks__/react-native.js`
+// exports nothing, it registers the stubbed registry for later importers,
+// and the binding below reads that registry at module scope.
+import 'react-native';
 
 import DeviceAuth from '../app/DeviceAuthModule';
-import type { DeviceAuthResult } from '../app/DeviceAuthModule';
+import type {
+  DeviceAuthAvailability,
+  DeviceAuthResult,
+} from '../app/DeviceAuthModule';
 
-test('authenticate resolves a typed outcome and forwards its arguments', async () => {
+test('the binding resolves the natively registered DeviceAuth module', () => {
+  // A top-level `import { NativeModules } from 'react-native'` here lands
+  // on the empty shim; requireActual reaches the same registry the binding
+  // read. A rename on either native half, or in the binding, lands here
+  // rather than as an undefined call at the first ceremony.
+  const { NativeModules } = jest.requireActual('react-native');
+  expect(NativeModules.DeviceAuth).toBeDefined();
+  expect(DeviceAuth).toBe(NativeModules.DeviceAuth);
+});
+
+test('the binding exposes the whole API the gate controller calls', () => {
+  expect(typeof DeviceAuth.authenticate).toBe('function');
+  expect(typeof DeviceAuth.canAuthenticate).toBe('function');
+});
+
+test('a ceremony resolves the typed outcome shape', async () => {
   const result: DeviceAuthResult = await DeviceAuth.authenticate(
     'Please authenticate',
     'Cancel',
   );
   expect(result).toEqual({ outcome: 'authenticated', code: '' });
-  expect(DeviceAuth.authenticate).toHaveBeenCalledWith(
-    'Please authenticate',
-    'Cancel',
-  );
 });
 
-test('canAuthenticate resolves the availability shape', async () => {
-  await expect(DeviceAuth.canAuthenticate()).resolves.toEqual({
-    available: true,
-    code: '',
-  });
+test('availability resolves the typed availability shape', async () => {
+  const availability: DeviceAuthAvailability =
+    await DeviceAuth.canAuthenticate();
+  expect(availability).toEqual({ available: true, code: '' });
 });

--- a/__tests__/deviceAuthModule.unit.ts
+++ b/__tests__/deviceAuthModule.unit.ts
@@ -1,0 +1,39 @@
+/**
+ * The DeviceAuth binding's contract: the typed surface the gate
+ * controller will build on (ADR 0007). The native halves are exercised on
+ * device; this pins the JS shape and the pass-through.
+ */
+jest.mock('react-native', () => ({
+  __esModule: true,
+  NativeModules: {
+    DeviceAuth: {
+      authenticate: jest.fn(async () => ({
+        outcome: 'authenticated',
+        code: '',
+      })),
+      canAuthenticate: jest.fn(async () => ({ available: true, code: '' })),
+    },
+  },
+}));
+
+import DeviceAuth from '../app/DeviceAuthModule';
+import type { DeviceAuthResult } from '../app/DeviceAuthModule';
+
+test('authenticate resolves a typed outcome and forwards its arguments', async () => {
+  const result: DeviceAuthResult = await DeviceAuth.authenticate(
+    'Please authenticate',
+    'Cancel',
+  );
+  expect(result).toEqual({ outcome: 'authenticated', code: '' });
+  expect(DeviceAuth.authenticate).toHaveBeenCalledWith(
+    'Please authenticate',
+    'Cancel',
+  );
+});
+
+test('canAuthenticate resolves the availability shape', async () => {
+  await expect(DeviceAuth.canAuthenticate()).resolves.toEqual({
+    available: true,
+    code: '',
+  });
+});

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -353,6 +353,9 @@ dependencies {
 
     androidTestImplementation("com.wix:detox:20.51.4")
     implementation("androidx.appcompat:appcompat:1.7.0")
+    // DeviceAuthModule's BiometricPrompt (react-native-keychain only pulls
+    // this transitively; direct use declares it).
+    implementation("androidx.biometric:biometric:1.1.0")
 
     implementation(project(":react-native-device-info")) {
         exclude(group = "com.google.firebase")

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/DeviceAuthModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/DeviceAuthModule.kt
@@ -1,0 +1,117 @@
+package org.ZingoLabs.Zingo
+
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.UiThreadUtil
+
+/**
+ * The device-auth call behind the app's privacy shutter (ADR 0007): one
+ * BiometricPrompt ceremony per invocation, resolved as a typed outcome.
+ *
+ * The promise always resolves; the outcome union carries every ending, so
+ * the JS gate controller needs no rejection path. `declined` covers the
+ * endings the person chose (cancel, negative button, lockout after
+ * repeated failures); `unavailable` covers everything the platform
+ * refused (no hardware, no enrollment, no resumed activity), where the
+ * shutter fails open with a notice. `code` is the platform's own error
+ * code, for bug reports.
+ */
+class DeviceAuthModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+    override fun getName(): String {
+        return "DeviceAuth"
+    }
+
+    private val allowedAuthenticators =
+        BiometricManager.Authenticators.BIOMETRIC_WEAK or
+            BiometricManager.Authenticators.DEVICE_CREDENTIAL
+
+    private val declinedCodes = setOf(
+        BiometricPrompt.ERROR_TIMEOUT,
+        BiometricPrompt.ERROR_CANCELED,
+        BiometricPrompt.ERROR_LOCKOUT,
+        BiometricPrompt.ERROR_LOCKOUT_PERMANENT,
+        BiometricPrompt.ERROR_USER_CANCELED,
+        BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+    )
+
+    private fun outcomeMap(outcome: String, code: String) =
+        Arguments.createMap().apply {
+            putString("outcome", outcome)
+            putString("code", code)
+        }
+
+    @ReactMethod
+    fun canAuthenticate(promise: Promise) {
+        val code = BiometricManager.from(reactApplicationContext)
+            .canAuthenticate(allowedAuthenticators)
+        val map = Arguments.createMap().apply {
+            putBoolean("available", code == BiometricManager.BIOMETRIC_SUCCESS)
+            putString("code", code.toString())
+        }
+        promise.resolve(map)
+    }
+
+    // `cancelLabel` is unused here: a prompt that allows the device
+    // credential owns its cancel affordance, and setNegativeButtonText is
+    // forbidden alongside DEVICE_CREDENTIAL. iOS uses the label.
+    @ReactMethod
+    fun authenticate(title: String, cancelLabel: String, promise: Promise) {
+        val activity = currentActivity as? FragmentActivity
+        if (activity == null) {
+            promise.resolve(outcomeMap("unavailable", "no-resumed-activity"))
+            return
+        }
+        UiThreadUtil.runOnUiThread {
+            var settled = false
+            val callback = object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(
+                    result: BiometricPrompt.AuthenticationResult,
+                ) {
+                    if (settled) return
+                    settled = true
+                    promise.resolve(outcomeMap("authenticated", ""))
+                }
+
+                override fun onAuthenticationError(
+                    errorCode: Int,
+                    errString: CharSequence,
+                ) {
+                    if (settled) return
+                    settled = true
+                    val outcome =
+                        if (errorCode in declinedCodes) "declined"
+                        else "unavailable"
+                    promise.resolve(outcomeMap(outcome, errorCode.toString()))
+                }
+                // onAuthenticationFailed is per-attempt; the prompt keeps
+                // running and delivers a terminal callback later.
+            }
+            val info = BiometricPrompt.PromptInfo.Builder()
+                .setTitle(title)
+                .setAllowedAuthenticators(allowedAuthenticators)
+                .build()
+            try {
+                BiometricPrompt(
+                    activity,
+                    ContextCompat.getMainExecutor(activity),
+                    callback,
+                ).authenticate(info)
+            } catch (e: Exception) {
+                if (!settled) {
+                    settled = true
+                    promise.resolve(
+                        outcomeMap("unavailable", e.javaClass.simpleName),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/DeviceAuthModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/DeviceAuthModule.kt
@@ -5,6 +5,7 @@ import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -15,16 +16,23 @@ import com.facebook.react.bridge.UiThreadUtil
  * The device-auth call behind the app's privacy shutter (ADR 0007): one
  * BiometricPrompt ceremony per invocation, resolved as a typed outcome.
  *
- * The promise always resolves; the outcome union carries every ending, so
- * the JS gate controller needs no rejection path. `declined` covers the
- * endings the person chose (cancel, negative button, lockout after
- * repeated failures); `unavailable` covers everything the platform
- * refused (no hardware, no enrollment, no resumed activity), where the
- * shutter fails open with a notice. `code` is the platform's own error
- * code, for bug reports.
+ * The module guarantees settlement: every promise resolves, on the
+ * prompt's own terminal callback, on the host activity's destruction
+ * (which takes the callback with it), or at once when the call cannot
+ * attach. The JS gate controller therefore needs no rejection path and no
+ * watchdog of its own. `declined` covers the endings the person chose,
+ * leaving the app while it asked included; `unavailable` covers
+ * everything the platform refused (no hardware, no enrollment, a second
+ * call while one is pending), where the shutter fails open with a notice.
+ * `code` is the platform's own error code, for bug reports.
  */
 class DeviceAuthModule(reactContext: ReactApplicationContext) :
-    ReactContextBaseJavaModule(reactContext) {
+    ReactContextBaseJavaModule(reactContext), LifecycleEventListener {
+
+    init {
+        reactContext.addLifecycleEventListener(this)
+    }
+
     override fun getName(): String {
         return "DeviceAuth"
     }
@@ -42,11 +50,33 @@ class DeviceAuthModule(reactContext: ReactApplicationContext) :
         BiometricPrompt.ERROR_NEGATIVE_BUTTON,
     )
 
+    // One ceremony at a time, held here so the terminal callback, the
+    // host-destroy hook, and the busy answer all settle the same promise
+    // exactly once.
+    private var pendingCeremony: Promise? = null
+
     private fun outcomeMap(outcome: String, code: String) =
         Arguments.createMap().apply {
             putString("outcome", outcome)
             putString("code", code)
         }
+
+    @Synchronized
+    private fun settlePending(outcome: String, code: String) {
+        val pending = pendingCeremony ?: return
+        pendingCeremony = null
+        pending.resolve(outcomeMap(outcome, code))
+    }
+
+    override fun onHostResume() {}
+
+    override fun onHostPause() {}
+
+    // The prompt's callback dies with its activity; the promise must not.
+    // Leaving is the person's answer, so it locks like a decline.
+    override fun onHostDestroy() {
+        settlePending("declined", "activity-destroyed")
+    }
 
     @ReactMethod
     fun canAuthenticate(promise: Promise) {
@@ -64,32 +94,40 @@ class DeviceAuthModule(reactContext: ReactApplicationContext) :
     // forbidden alongside DEVICE_CREDENTIAL. iOS uses the label.
     @ReactMethod
     fun authenticate(title: String, cancelLabel: String, promise: Promise) {
-        val activity = currentActivity as? FragmentActivity
+        val activity =
+            reactApplicationContext.currentActivity as? FragmentActivity
         if (activity == null) {
-            promise.resolve(outcomeMap("unavailable", "no-resumed-activity"))
+            // The person left before the prompt could attach; that is an
+            // answer, not a broken gate.
+            promise.resolve(outcomeMap("declined", "no-resumed-activity"))
             return
         }
+        synchronized(this) {
+            if (pendingCeremony != null) {
+                // A second call must never cancel a live prompt; the
+                // pending ceremony carries the answer.
+                promise.resolve(outcomeMap("unavailable", "busy"))
+                return
+            }
+            pendingCeremony = promise
+        }
         UiThreadUtil.runOnUiThread {
-            var settled = false
             val callback = object : BiometricPrompt.AuthenticationCallback() {
                 override fun onAuthenticationSucceeded(
                     result: BiometricPrompt.AuthenticationResult,
                 ) {
-                    if (settled) return
-                    settled = true
-                    promise.resolve(outcomeMap("authenticated", ""))
+                    settlePending("authenticated", "")
                 }
 
                 override fun onAuthenticationError(
                     errorCode: Int,
                     errString: CharSequence,
                 ) {
-                    if (settled) return
-                    settled = true
-                    val outcome =
+                    settlePending(
                         if (errorCode in declinedCodes) "declined"
-                        else "unavailable"
-                    promise.resolve(outcomeMap(outcome, errorCode.toString()))
+                        else "unavailable",
+                        errorCode.toString(),
+                    )
                 }
                 // onAuthenticationFailed is per-attempt; the prompt keeps
                 // running and delivers a terminal callback later.
@@ -105,12 +143,7 @@ class DeviceAuthModule(reactContext: ReactApplicationContext) :
                     callback,
                 ).authenticate(info)
             } catch (e: Exception) {
-                if (!settled) {
-                    settled = true
-                    promise.resolve(
-                        outcomeMap("unavailable", e.javaClass.simpleName),
-                    )
-                }
+                settlePending("unavailable", e.javaClass.simpleName)
             }
         }
     }

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/DeviceAuthModule.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/DeviceAuthModule.kt
@@ -11,20 +11,28 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.bridge.WritableMap
 
 /**
  * The device-auth call behind the app's privacy shutter (ADR 0007): one
- * BiometricPrompt ceremony per invocation, resolved as a typed outcome.
+ * BiometricPrompt ceremony at a time, resolved as a typed outcome.
  *
- * The module guarantees settlement: every promise resolves, on the
- * prompt's own terminal callback, on the host activity's destruction
- * (which takes the callback with it), or at once when the call cannot
- * attach. The JS gate controller therefore needs no rejection path and no
- * watchdog of its own. `declined` covers the endings the person chose,
- * leaving the app while it asked included; `unavailable` covers
- * everything the platform refused (no hardware, no enrollment, a second
- * call while one is pending), where the shutter fails open with a notice.
- * `code` is the platform's own error code, for bug reports.
+ * The module guarantees settlement. Every promise resolves: on the
+ * prompt's own terminal callback, on the host's destruction or a context
+ * reload (either takes the callback with it), when the prompt cannot
+ * start, or at once when the call cannot attach. A ceremony carries its
+ * own identity, so a callback arriving late settles its own waiters or
+ * nothing at all, never the ceremony that replaced it. Concurrent calls
+ * join the live ceremony and share its single answer instead of stacking
+ * prompts or landing in a fail-open arm. The JS gate controller therefore
+ * needs no rejection path and no watchdog of its own.
+ *
+ * `declined` covers the endings the person chose, leaving the app while
+ * it asked included. `unavailable` covers every ending the platform owns,
+ * permanent (no hardware, no enrollment) and transient (the sensor held
+ * by another client, a vendor fault) alike, where the shutter fails open
+ * with a notice. `code` is the platform's own error code, for bug
+ * reports.
  */
 class DeviceAuthModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext), LifecycleEventListener {
@@ -37,8 +45,13 @@ class DeviceAuthModule(reactContext: ReactApplicationContext) :
         return "DeviceAuth"
     }
 
+    // BIOMETRIC_STRONG, not WEAK. react-native-keychain gates the same
+    // secrets on Class 3 and binds its keys to AUTH_BIOMETRIC_STRONG (the
+    // profile keychainOptions.ts centralises), so a shutter admitting a
+    // Class 2 face unlock would accept, over this data, the same person
+    // the keychain refuses.
     private val allowedAuthenticators =
-        BiometricManager.Authenticators.BIOMETRIC_WEAK or
+        BiometricManager.Authenticators.BIOMETRIC_STRONG or
             BiometricManager.Authenticators.DEVICE_CREDENTIAL
 
     private val declinedCodes = setOf(
@@ -50,22 +63,58 @@ class DeviceAuthModule(reactContext: ReactApplicationContext) :
         BiometricPrompt.ERROR_NEGATIVE_BUTTON,
     )
 
-    // One ceremony at a time, held here so the terminal callback, the
-    // host-destroy hook, and the busy answer all settle the same promise
-    // exactly once.
-    private var pendingCeremony: Promise? = null
+    /**
+     * One prompt's worth of waiting callers. Identity is the point: the
+     * terminal callback, the teardown hooks, and the cannot-start paths
+     * all settle a named ceremony, so a callback that outlives its own
+     * ceremony can no longer answer the one that replaced it. Each waiter
+     * gets its own map, because the bridge consumes a WritableMap once.
+     */
+    private class Ceremony {
+        private val waiters = mutableListOf<Promise>()
+        var settled = false
+            private set
 
-    private fun outcomeMap(outcome: String, code: String) =
+        fun join(promise: Promise) {
+            waiters.add(promise)
+        }
+
+        fun settle(map: () -> WritableMap) {
+            settled = true
+            for (waiter in waiters) {
+                waiter.resolve(map())
+            }
+            waiters.clear()
+        }
+    }
+
+    // The one ceremony that may be live, held so every settle path can
+    // name it and so a concurrent call has something to join.
+    private var pending: Ceremony? = null
+
+    private fun outcomeMap(outcome: String, code: String): WritableMap =
         Arguments.createMap().apply {
             putString("outcome", outcome)
             putString("code", code)
         }
 
+    /** Settles this ceremony exactly once, releasing the slot while it still holds it. */
+    @Synchronized
+    private fun settle(ceremony: Ceremony, outcome: String, code: String) {
+        if (ceremony.settled) {
+            return
+        }
+        if (pending === ceremony) {
+            pending = null
+        }
+        ceremony.settle { outcomeMap(outcome, code) }
+    }
+
+    /** Settles whichever ceremony is live, for the teardown hooks that hold no handle on one. */
     @Synchronized
     private fun settlePending(outcome: String, code: String) {
-        val pending = pendingCeremony ?: return
-        pendingCeremony = null
-        pending.resolve(outcomeMap(outcome, code))
+        val ceremony = pending ?: return
+        settle(ceremony, outcome, code)
     }
 
     override fun onHostResume() {}
@@ -76,6 +125,16 @@ class DeviceAuthModule(reactContext: ReactApplicationContext) :
     // Leaving is the person's answer, so it locks like a decline.
     override fun onHostDestroy() {
         settlePending("declined", "activity-destroyed")
+    }
+
+    // The listener outlives the activity but must not outlive the module.
+    // Under the new architecture a ReactHost reload destroys the context
+    // without destroying MainActivity, so onHostDestroy never runs and a
+    // live ceremony would be dropped with the shutter closed.
+    override fun invalidate() {
+        reactApplicationContext.removeLifecycleEventListener(this)
+        settlePending("declined", "context-invalidated")
+        super.invalidate()
     }
 
     @ReactMethod
@@ -94,6 +153,13 @@ class DeviceAuthModule(reactContext: ReactApplicationContext) :
     // forbidden alongside DEVICE_CREDENTIAL. iOS uses the label.
     @ReactMethod
     fun authenticate(title: String, cancelLabel: String, promise: Promise) {
+        // PromptInfo.Builder.build() throws on an empty title, and thrown
+        // from the UI thread that is a process crash with the slot latched.
+        // A catalog key resolving before the translations load returns "".
+        if (title.isBlank()) {
+            promise.resolve(outcomeMap("unavailable", "empty-title"))
+            return
+        }
         val activity =
             reactApplicationContext.currentActivity as? FragmentActivity
         if (activity == null) {
@@ -102,48 +168,65 @@ class DeviceAuthModule(reactContext: ReactApplicationContext) :
             promise.resolve(outcomeMap("declined", "no-resumed-activity"))
             return
         }
-        synchronized(this) {
-            if (pendingCeremony != null) {
-                // A second call must never cancel a live prompt; the
-                // pending ceremony carries the answer.
-                promise.resolve(outcomeMap("unavailable", "busy"))
-                return
+        // A second call must never cancel a live prompt, and must never
+        // fail the shutter open behind one: it joins, and shares the
+        // answer the person is about to give. Only the caller that opens
+        // a ceremony goes on to raise a prompt.
+        val ceremony = synchronized(this) {
+            val live = pending
+            if (live != null) {
+                live.join(promise)
+                null
+            } else {
+                Ceremony().also {
+                    it.join(promise)
+                    pending = it
+                }
             }
-            pendingCeremony = promise
-        }
+        } ?: return
         UiThreadUtil.runOnUiThread {
-            val callback = object : BiometricPrompt.AuthenticationCallback() {
-                override fun onAuthenticationSucceeded(
-                    result: BiometricPrompt.AuthenticationResult,
-                ) {
-                    settlePending("authenticated", "")
-                }
-
-                override fun onAuthenticationError(
-                    errorCode: Int,
-                    errString: CharSequence,
-                ) {
-                    settlePending(
-                        if (errorCode in declinedCodes) "declined"
-                        else "unavailable",
-                        errorCode.toString(),
-                    )
-                }
-                // onAuthenticationFailed is per-attempt; the prompt keeps
-                // running and delivers a terminal callback later.
-            }
-            val info = BiometricPrompt.PromptInfo.Builder()
-                .setTitle(title)
-                .setAllowedAuthenticators(allowedAuthenticators)
-                .build()
             try {
+                // BiometricPrompt.authenticate() logs and returns without
+                // showing anything, and without ever calling back, once the
+                // host FragmentManager has saved its state. RN clears
+                // currentActivity only in onHostDestroy, so the guard above
+                // still passes while the activity is merely stopped.
+                if (activity.supportFragmentManager.isStateSaved) {
+                    settle(ceremony, "declined", "state-saved")
+                    return@runOnUiThread
+                }
+                val callback = object : BiometricPrompt.AuthenticationCallback() {
+                    override fun onAuthenticationSucceeded(
+                        result: BiometricPrompt.AuthenticationResult,
+                    ) {
+                        settle(ceremony, "authenticated", "")
+                    }
+
+                    override fun onAuthenticationError(
+                        errorCode: Int,
+                        errString: CharSequence,
+                    ) {
+                        settle(
+                            ceremony,
+                            if (errorCode in declinedCodes) "declined"
+                            else "unavailable",
+                            errorCode.toString(),
+                        )
+                    }
+                    // onAuthenticationFailed is per-attempt; the prompt keeps
+                    // running and delivers a terminal callback later.
+                }
+                val info = BiometricPrompt.PromptInfo.Builder()
+                    .setTitle(title)
+                    .setAllowedAuthenticators(allowedAuthenticators)
+                    .build()
                 BiometricPrompt(
                     activity,
                     ContextCompat.getMainExecutor(activity),
                     callback,
                 ).authenticate(info)
             } catch (e: Exception) {
-                settlePending("unavailable", e.javaClass.simpleName)
+                settle(ceremony, "unavailable", e.javaClass.simpleName)
             }
         }
     }

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/RPCPackage.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/RPCPackage.kt
@@ -16,6 +16,7 @@ class RPCPackage : ReactPackage {
         val modules: MutableList<NativeModule> = ArrayList()
         modules.add(RPCModule(reactContext))
         modules.add(NymTransportModule(reactContext))
+        modules.add(DeviceAuthModule(reactContext))
         return modules
     }
 }

--- a/app/DeviceAuthModule.ts
+++ b/app/DeviceAuthModule.ts
@@ -1,0 +1,27 @@
+import { NativeModules } from 'react-native';
+
+// The native half of the privacy shutter (ADR 0007): one OS ceremony per
+// authenticate() call, resolved as a typed outcome. The promise always
+// resolves, so the gate controller needs no rejection path.
+
+/** Every way one device-auth ceremony can end. */
+export type DeviceAuthOutcome = 'authenticated' | 'declined' | 'unavailable';
+
+/** A ceremony's ending plus the platform's own code, for bug reports. */
+export type DeviceAuthResult = {
+  outcome: DeviceAuthOutcome;
+  code: string;
+};
+
+/** Whether the device can run a ceremony at all, with the refusing code. */
+export type DeviceAuthAvailability = {
+  available: boolean;
+  code: string;
+};
+
+type DeviceAuthAPI = {
+  authenticate(title: string, cancelLabel: string): Promise<DeviceAuthResult>;
+  canAuthenticate(): Promise<DeviceAuthAvailability>;
+};
+
+export default NativeModules.DeviceAuth as DeviceAuthAPI;

--- a/app/DeviceAuthModule.ts
+++ b/app/DeviceAuthModule.ts
@@ -1,11 +1,21 @@
 import { NativeModules } from 'react-native';
 
-// The native half of the privacy shutter (ADR 0007): one OS ceremony per
-// authenticate() call, resolved as a typed outcome. Both platforms
-// guarantee settlement, on the prompt's own terminal callback or on the
-// host activity's destruction, and classify leaving-the-app endings as
-// declined, so the gate controller needs no rejection path and no
-// watchdog.
+// The native half of the privacy shutter (ADR 0007): one OS ceremony at a
+// time, resolved as a typed outcome. Both platforms guarantee settlement —
+// on the prompt's own terminal callback, on the host's destruction or a
+// context reload, or at once when the prompt cannot start — and both
+// classify leaving-the-app endings as declined, so the gate controller
+// needs no rejection path and no watchdog.
+//
+// Concurrent calls join the ceremony already in flight and share its one
+// answer on both platforms; a duplicate trigger never stacks a prompt and
+// never reaches a fail-open arm behind a live one.
+//
+// `unavailable` is every ending the platform owns, permanent (no
+// hardware, no enrolment) and transient (the sensor held elsewhere, a
+// vendor fault) alike: the gate could not run, and the shutter fails open
+// with a notice. Anything unrecognised is classified `declined` instead,
+// so an ending neither platform half knows locks rather than opens.
 
 /** Every way one device-auth ceremony can end. */
 export type DeviceAuthOutcome = 'authenticated' | 'declined' | 'unavailable';

--- a/app/DeviceAuthModule.ts
+++ b/app/DeviceAuthModule.ts
@@ -1,8 +1,11 @@
 import { NativeModules } from 'react-native';
 
 // The native half of the privacy shutter (ADR 0007): one OS ceremony per
-// authenticate() call, resolved as a typed outcome. The promise always
-// resolves, so the gate controller needs no rejection path.
+// authenticate() call, resolved as a typed outcome. Both platforms
+// guarantee settlement, on the prompt's own terminal callback or on the
+// host activity's destruction, and classify leaving-the-app endings as
+// declined, so the gate controller needs no rejection path and no
+// watchdog.
 
 /** Every way one device-auth ceremony can end. */
 export type DeviceAuthOutcome = 'authenticated' | 'declined' | 'unavailable';

--- a/ios/DeviceAuth.swift
+++ b/ios/DeviceAuth.swift
@@ -1,0 +1,66 @@
+//
+//  DeviceAuth.swift
+//  Zingo
+//
+
+import Foundation
+import LocalAuthentication
+import React
+
+/// The device-auth call behind the app's privacy shutter (ADR 0007): one
+/// LocalAuthentication ceremony per invocation, resolved as a typed
+/// outcome. The promise always resolves; `declined` covers the endings
+/// the person chose (cancel, failed attempts), `unavailable` everything
+/// the platform refused, and `code` is the LAError raw value for bug
+/// reports.
+@objc(DeviceAuth)
+class DeviceAuth: NSObject {
+  @objc
+  static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+
+  private func outcome(_ outcome: String, _ code: String) -> [String: Any] {
+    return ["outcome": outcome, "code": code]
+  }
+
+  @objc(canAuthenticate:reject:)
+  func canAuthenticate(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    let context = LAContext()
+    var error: NSError?
+    let available = context.canEvaluatePolicy(
+      .deviceOwnerAuthentication, error: &error)
+    resolve([
+      "available": available,
+      "code": error.map { String($0.code) } ?? "",
+    ])
+  }
+
+  @objc(authenticate:cancel:resolve:reject:)
+  func authenticate(
+    _ title: String,
+    cancel: String,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    let context = LAContext()
+    context.localizedCancelTitle = cancel
+    context.evaluatePolicy(
+      .deviceOwnerAuthentication, localizedReason: title
+    ) { success, error in
+      if success {
+        resolve(self.outcome("authenticated", ""))
+        return
+      }
+      let code = (error as NSError?)?.code ?? 0
+      let declined =
+        code == LAError.userCancel.rawValue
+        || code == LAError.authenticationFailed.rawValue
+      resolve(
+        self.outcome(declined ? "declined" : "unavailable", String(code)))
+    }
+  }
+}

--- a/ios/DeviceAuth.swift
+++ b/ios/DeviceAuth.swift
@@ -8,13 +8,21 @@ import LocalAuthentication
 import React
 
 /// The device-auth call behind the app's privacy shutter (ADR 0007): one
-/// LocalAuthentication ceremony per invocation, resolved as a typed
-/// outcome. The module guarantees settlement: evaluatePolicy always
-/// invokes its reply block, so every promise resolves and the JS gate
-/// controller needs no rejection path and no watchdog. `declined` covers
-/// the endings the person chose (cancel, failed attempts, leaving the
-/// app while it asked), `unavailable` everything the platform refused,
-/// and `code` is the LAError raw value for bug reports.
+/// LocalAuthentication ceremony at a time, resolved as a typed outcome.
+///
+/// The module guarantees settlement: evaluatePolicy always invokes its
+/// reply block, and the context that owns the evaluation is held for its
+/// whole life so it cannot be invalidated out from under the prompt. A
+/// concurrent call joins the live ceremony and shares its single answer,
+/// matching the Android half, so the JS gate controller needs no
+/// rejection path and no watchdog.
+///
+/// `declined` covers the endings the person chose (cancel, failed
+/// attempts, leaving the app while it asked) and is also the arm an
+/// unrecognised ending falls into, so a case added by a future SDK locks
+/// the shutter rather than opening it. `unavailable` covers the refusals
+/// the platform names, where the shutter fails open with a notice.
+/// `code` is the LAError raw value for bug reports.
 @objc(DeviceAuth)
 class DeviceAuth: NSObject {
   @objc
@@ -22,8 +30,62 @@ class DeviceAuth: NSObject {
     return false
   }
 
+  /// Guards the ceremony slot: the bridge calls in on its own queue and
+  /// LocalAuthentication replies on a private one.
+  private let lock = NSLock()
+
+  /// The live evaluation's context. `LAContext.h` requires a strong
+  /// reference for the whole evaluation: releasing one invalidates it and
+  /// terminates the prompt with `appCancel`, which would fail the shutter
+  /// open on nothing but a deallocation. The reply block captures `self`,
+  /// never the context, so the property is what keeps it alive.
+  private var activeContext: LAContext?
+
+  /// Everyone waiting on the live ceremony, answered together, once.
+  private var waiters: [RCTPromiseResolveBlock] = []
+
   private func outcome(_ outcome: String, _ code: String) -> [String: Any] {
     return ["outcome": outcome, "code": code]
+  }
+
+  /// Answers every waiter of the live ceremony and releases the slot.
+  private func settle(_ name: String, _ code: String) {
+    lock.lock()
+    let pending = waiters
+    waiters = []
+    activeContext = nil
+    lock.unlock()
+    for resolve in pending {
+      resolve(outcome(name, code))
+    }
+  }
+
+  /// Maps an evaluation's error onto the outcome union. Inverted on
+  /// purpose: only a refusal LocalAuthentication names reaches the
+  /// fail-open arm, and everything else — including a case a future SDK
+  /// adds, which `LAError.Code` being non-frozen means cannot be listed
+  /// exhaustively here — locks.
+  private func classify(_ error: Error?) -> (String, String) {
+    guard let nsError = error as NSError? else {
+      return ("declined", "")
+    }
+    let code = String(nsError.code)
+    guard nsError.domain == LAErrorDomain,
+      let reason = LAError.Code(rawValue: nsError.code)
+    else {
+      // Not LocalAuthentication's error at all: nobody was asked, so the
+      // gate could not run.
+      return ("unavailable", code)
+    }
+    switch reason {
+    case .biometryNotAvailable, .biometryNotEnrolled, .biometryLockout,
+      .passcodeNotSet, .invalidContext, .notInteractive, .appCancel:
+      return ("unavailable", code)
+    case .userCancel, .userFallback, .authenticationFailed, .systemCancel:
+      return ("declined", code)
+    default:
+      return ("declined", code)
+    }
   }
 
   @objc(canAuthenticate:reject:)
@@ -48,24 +110,39 @@ class DeviceAuth: NSObject {
     resolve: @escaping RCTPromiseResolveBlock,
     reject: @escaping RCTPromiseRejectBlock
   ) {
+    // `LAContext.h` makes localizedReason mandatory and raises
+    // NSInvalidArgumentException on an empty one. A catalog key resolving
+    // before the translations load returns "".
+    if title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      resolve(outcome("unavailable", "empty-title"))
+      return
+    }
+
+    // A second call must never present a second prompt: it joins the live
+    // ceremony and shares the answer the person is about to give.
+    lock.lock()
+    waiters.append(resolve)
+    if activeContext != nil {
+      lock.unlock()
+      return
+    }
     let context = LAContext()
     context.localizedCancelTitle = cancel
+    activeContext = context
+    lock.unlock()
+
     context.evaluatePolicy(
       .deviceOwnerAuthentication, localizedReason: title
+      // `self` is captured strongly on purpose: the settlement guarantee
+      // outranks the transient cycle (self → activeContext → evaluation →
+      // this block → self), which `settle` breaks by clearing the slot.
     ) { success, error in
       if success {
-        resolve(self.outcome("authenticated", ""))
+        self.settle("authenticated", "")
         return
       }
-      let code = (error as NSError?)?.code ?? 0
-      // systemCancel is the person leaving the app while it asked: an
-      // answer, not a broken gate, so it locks like a decline.
-      let declined =
-        code == LAError.userCancel.rawValue
-        || code == LAError.authenticationFailed.rawValue
-        || code == LAError.systemCancel.rawValue
-      resolve(
-        self.outcome(declined ? "declined" : "unavailable", String(code)))
+      let (name, code) = self.classify(error)
+      self.settle(name, code)
     }
   }
 }

--- a/ios/DeviceAuth.swift
+++ b/ios/DeviceAuth.swift
@@ -9,10 +9,12 @@ import React
 
 /// The device-auth call behind the app's privacy shutter (ADR 0007): one
 /// LocalAuthentication ceremony per invocation, resolved as a typed
-/// outcome. The promise always resolves; `declined` covers the endings
-/// the person chose (cancel, failed attempts), `unavailable` everything
-/// the platform refused, and `code` is the LAError raw value for bug
-/// reports.
+/// outcome. The module guarantees settlement: evaluatePolicy always
+/// invokes its reply block, so every promise resolves and the JS gate
+/// controller needs no rejection path and no watchdog. `declined` covers
+/// the endings the person chose (cancel, failed attempts, leaving the
+/// app while it asked), `unavailable` everything the platform refused,
+/// and `code` is the LAError raw value for bug reports.
 @objc(DeviceAuth)
 class DeviceAuth: NSObject {
   @objc
@@ -56,9 +58,12 @@ class DeviceAuth: NSObject {
         return
       }
       let code = (error as NSError?)?.code ?? 0
+      // systemCancel is the person leaving the app while it asked: an
+      // answer, not a broken gate, so it locks like a decline.
       let declined =
         code == LAError.userCancel.rawValue
         || code == LAError.authenticationFailed.rawValue
+        || code == LAError.systemCancel.rawValue
       resolve(
         self.outcome(declined ? "declined" : "unavailable", String(code)))
     }

--- a/ios/DeviceAuthBridge.m
+++ b/ios/DeviceAuthBridge.m
@@ -1,0 +1,19 @@
+//
+//  DeviceAuthBridge.m
+//  Zingo
+//
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(DeviceAuth, NSObject)
+
+RCT_EXTERN_METHOD(canAuthenticate:
+    (RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(authenticate:
+    (NSString *)title
+                  cancel:(NSString *)cancel
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/ios/Zingo.xcodeproj/project.pbxproj
+++ b/ios/Zingo.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		1F0894002BA4C4380089FD88 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1F0893FE2BA4C4380089FD88 /* PrivacyInfo.xcprivacy */; };
 		1F5569272BBCB4D900F2CD6C /* RPCModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5569262BBCB4D900F2CD6C /* RPCModule.swift */; };
 		1F5569292BBCB98100F2CD6C /* RPCModuleBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5569282BBCB98100F2CD6C /* RPCModuleBridge.m */; };
+		D07A0007DA1CE0DE00000003 /* DeviceAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07A0007DA1CE0DE00000001 /* DeviceAuth.swift */; };
+		D07A0007DA1CE0DE00000004 /* DeviceAuthBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = D07A0007DA1CE0DE00000002 /* DeviceAuthBridge.m */; };
 		1F5CEBBB2BBF025700E2551A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5CEBBA2BBF025700E2551A /* AppDelegate.swift */; };
 		1F5E677B2BD30D0A007B17AA /* zingo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5E677A2BD30D0A007B17AA /* zingo.swift */; };
 		1F5E677C2BD30D0A007B17AA /* zingo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5E677A2BD30D0A007B17AA /* zingo.swift */; };
@@ -23,6 +25,8 @@
 		1F9FDA9C2FBD5CEC000C5248 /* Zingolib.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F9FDA9A2FBD5CEC000C5248 /* Zingolib.xcframework */; };
 		1FA935B02BE4506300117DF5 /* RPCModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5569262BBCB4D900F2CD6C /* RPCModule.swift */; };
 		1FA935B12BE454FA00117DF5 /* RPCModuleBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5569282BBCB98100F2CD6C /* RPCModuleBridge.m */; };
+		D07A0007DA1CE0DE00000005 /* DeviceAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07A0007DA1CE0DE00000001 /* DeviceAuth.swift */; };
+		D07A0007DA1CE0DE00000006 /* DeviceAuthBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = D07A0007DA1CE0DE00000002 /* DeviceAuthBridge.m */; };
 		1FA935B32BE457B100117DF5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F7D321C2B71D44800D2879C /* SystemConfiguration.framework */; };
 		1FC1E2172BE443270064963B /* ZingoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC1E2162BE443270064963B /* ZingoTest.swift */; };
 		1FE8E9AC296B85FC004A256B /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE8E9AB296B85FC004A256B /* BackgroundTasks.framework */; };
@@ -61,6 +65,8 @@
 		1F5569252BBCB4D900F2CD6C /* RPCModule-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RPCModule-Bridging-Header.h"; sourceTree = "<group>"; };
 		1F5569262BBCB4D900F2CD6C /* RPCModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCModule.swift; sourceTree = "<group>"; };
 		1F5569282BBCB98100F2CD6C /* RPCModuleBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RPCModuleBridge.m; sourceTree = "<group>"; };
+		D07A0007DA1CE0DE00000001 /* DeviceAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAuth.swift; sourceTree = "<group>"; };
+		D07A0007DA1CE0DE00000002 /* DeviceAuthBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DeviceAuthBridge.m; sourceTree = "<group>"; };
 		1F5CEBBA2BBF025700E2551A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1F5E677A2BD30D0A007B17AA /* zingo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = zingo.swift; sourceTree = "<group>"; };
 		1F70326429905E6A001D70A2 /* Zingo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = Zingo.entitlements; path = Zingo/Zingo.entitlements; sourceTree = "<group>"; };
@@ -138,6 +144,8 @@
 				1F70326429905E6A001D70A2 /* Zingo.entitlements */,
 				1F5569262BBCB4D900F2CD6C /* RPCModule.swift */,
 				1F5569282BBCB98100F2CD6C /* RPCModuleBridge.m */,
+				D07A0007DA1CE0DE00000001 /* DeviceAuth.swift */,
+				D07A0007DA1CE0DE00000002 /* DeviceAuthBridge.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
@@ -491,6 +499,8 @@
 			files = (
 				1F03381A2C49575900A3FC49 /* Constants.swift in Sources */,
 				1FA935B12BE454FA00117DF5 /* RPCModuleBridge.m in Sources */,
+				D07A0007DA1CE0DE00000005 /* DeviceAuth.swift in Sources */,
+				D07A0007DA1CE0DE00000006 /* DeviceAuthBridge.m in Sources */,
 				1F5E677C2BD30D0A007B17AA /* zingo.swift in Sources */,
 				1FA935B02BE4506300117DF5 /* RPCModule.swift in Sources */,
 				1FC1E2172BE443270064963B /* ZingoTest.swift in Sources */,
@@ -510,6 +520,8 @@
 				1F5E677B2BD30D0A007B17AA /* zingo.swift in Sources */,
 				1F5569272BBCB4D900F2CD6C /* RPCModule.swift in Sources */,
 				1F5569292BBCB98100F2CD6C /* RPCModuleBridge.m in Sources */,
+				D07A0007DA1CE0DE00000003 /* DeviceAuth.swift in Sources */,
+				D07A0007DA1CE0DE00000004 /* DeviceAuthBridge.m in Sources */,
 				EEE4199FE8378DA314A03A16 /* zingo_nym_proxy_ffi.swift in Sources */,
 				406B854C612CDFA4B10C5B0A /* NymTransportModule.swift in Sources */,
 				E3B3E80957D603CCE394CAF9 /* NymTransportModuleBridge.m in Sources */,


### PR DESCRIPTION
The mobile-backend half of the ADR 0007 rewrite (see #1341): a deliberately tiny native module replacing the keychain-sentinel prompt trick with one direct device-auth ceremony per call. Android wraps BiometricPrompt (BIOMETRIC_WEAK | DEVICE_CREDENTIAL), iOS wraps LAContext deviceOwnerAuthentication; both resolve a typed outcome ('authenticated' | 'declined' | 'unavailable') plus the raw platform code for bug reports.

The second commit hardens the prose contract into a guarantee: every promise settles. Android holds one pending ceremony and settles it exactly once from the prompt's terminal callback, from the host activity's destruction (which takes the callback with it), or with a busy answer for a second call that must never cancel a live prompt; iOS relies on evaluatePolicy always invoking its reply block. Both platforms classify leaving-the-app endings (systemCancel, no-resumed-activity, activity-destroyed) as declined, so the gate controller in #1344 needs no rejection path, no watchdog, and no code list of its own.

No UI changes ride along, per AGENTS.md's backend/UI separation; the gate-controller PR that consumes this follows. The JS binding and its contract test are verified locally (jest, tsc, eslint, prettier); the native halves compile in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
