### PR TITLE
ci(ios): make the cargo cache actually restore

### DIFF
--- a/.github/workflows/ios-build.yaml
+++ b/.github/workflows/ios-build.yaml
@@ -70,21 +70,6 @@ jobs:
         with:
           repository: ${{ env.REPO-OWNER }}/zingo-mobile
 
-      # CARGO_HOME is workspace-relative (see env above), so these paths cover
-      # the registry, git checkouts, and the release artifacts for all three
-      # iOS targets. Keyed on the lockfile; the prefix fallback keeps stale
-      # caches useful after a zingolib rev bump.
-      - name: Cargo cache (registry, git, iOS targets)
-        uses: actions/cache@v6
-        with:
-          path: |
-            .cargo/registry
-            .cargo/git
-            rust/target
-          key: ios-cargo-${{ hashFiles('rust/Cargo.lock') }}
-          restore-keys: |
-            ios-cargo-
-
       - name: Cargo update for zingolib CI
         if: ${{ contains(github.repository, 'zingolib') }}
         run: |
@@ -117,6 +102,34 @@ jobs:
           rustup update
           rustup upgrade
           rustup default stable
+
+      # Placed after the toolchain steps on purpose: rust-cache reads
+      # `rustc -vV` into its key, and RUSTUP_HOME here is a workspace-relative
+      # dir that has no default toolchain until the step above installs one.
+      #
+      # Two workspaces: the shim is excluded from the main one (own lockfile,
+      # see rust/Cargo.toml), so its target dir needs listing separately. It
+      # was missing from the cache this replaces, which is why the 24 minutes
+      # of nym-sdk were never cacheable at all.
+      #
+      # What it replaces: a plain actions/cache over .cargo + rust/target that
+      # never once hit. It stored 4.6 GB unpruned, the repo's cache store
+      # evicted it before the next iOS build needed it, and every run logged
+      # "Cache not found for input keys: ios-cargo-..." and then spent 8m30
+      # re-uploading it. rust-cache prunes to dependency artifacts only, which
+      # is all this job needs: zingolib and nym-sdk are git/registry deps, not
+      # workspace members, and compiling them is nearly the whole 45 minutes.
+      #
+      # Saved from dev only. A cache written on refs/pull/N/merge is invisible
+      # to every other PR, so per-PR saves buy nothing and only add eviction
+      # pressure; the dev copy is readable by all of them.
+      - name: Cargo cache (registry, git, iOS targets)
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            rust
+            rust/nym-proxy-ffi
+          save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Install bindgen-cli (needed by aws-lc-sys, ring etc.)
         run: cargo install --force --locked bindgen-cli


### PR DESCRIPTION
The iOS xcframework job takes ~45-60 min every time it runs, and the cargo cache it already has has never once helped.

## Evidence

From [job 98905046581](https://github.com/zingolabs/zingo-mobile/actions/runs/33185518052) (dev, 28 Aug) and every other run where the job actually built:

```
15:59:05  Cache not found for input keys: ios-cargo-abd9c7aa…, ios-cargo-
16:01:14  Build iOS Rust xcframework  (46m46s)
16:48:36  Post Cargo cache            (8m30s, 4 579 109 008 bytes uploaded)
16:57:06  Cache saved with key: ios-cargo-abd9c7aa…
```

The restore step takes 0 seconds on every run. `gh cache list` today has no `ios-cargo-*` entry at all — the 4.6 GB one saved yesterday is already gone. The repo holds 69 caches / 34.8 GB active, dominated by ~1 GB gradle caches rewritten on every run; the iOS cache was the biggest single entry and the only one never read back, so it was always the first LRU victim. Net effect: 8m30 of upload per run for nothing.

Where the 46 min goes:

| | |
|---|---|
| uniffi-bindgen host | 4m05 |
| zingolib × 3 iOS targets | 15m07 |
| nym-proxy-ffi × 3 targets | 23m41 |
| zingo-uniffi-bindgen | 1m20 |

## What this changes

Swaps the plain `actions/cache` for `Swatinem/rust-cache@v2` — what zingolib's own CI uses throughout — with three corrections:

- **`rust/nym-proxy-ffi/target` is now cached.** It was not in the paths at all, so the 24 most expensive minutes could not have been restored even from a cache that survived. The shim is excluded from the main workspace (own lockfile), so it needs listing as a second workspace.
- **The cache is pruned before saving.** rust-cache keeps dependency artifacts and drops workspace crates, incremental dirs and unused registry sources. zingolib and nym-sdk are git/registry dependencies, not workspace members, so nearly the whole build is cacheable and only the workspace crates rebuild. Expect hundreds of MB instead of 4.6 GB, small enough to survive between builds.
- **Saving is limited to dev.** A cache written on `refs/pull/N/merge` is invisible to every other PR, so per-PR saves bought nothing and only added eviction pressure. One dev copy is readable by all PRs, and being restored keeps its last-access fresh.

The step also moves below the toolchain steps: rust-cache reads `rustc -vV` into its key, and `RUSTUP_HOME` here is workspace-relative with no default toolchain until `rustup default stable` runs.

## Expected effect

First dev build after merge is still cold and seeds the cache. After that a run whose `Cargo.lock` is unchanged should restore the dependency artifacts and rebuild only the workspace crates.

## Not in this PR

Deliberately left out to keep the change contained to caching:

- `codegen-units = 1` + `lto = "thin"` + `debug = 1` in `rust/Cargo.toml` — a CI-only profile would cut several more minutes, but the artifact would stop matching the release build.
- Dropping `x86_64-apple-ios` — removes a third of the compilations, breaks simulators on Intel Macs.
- `cargo install --force --locked bindgen-cli` costs ~1 min per run; dropping `--force` would let the now-cached `$CARGO_HOME/bin` short-circuit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
