### PR TITLE
fix(native): answer a zero spendable balance without pricing a payment

### DIFF
--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -2314,7 +2314,8 @@ pub fn remove_transaction(txid: String) -> Result<String, ZingolibError> {
     })
 }
 
-// we don't use this anymore...
+// The Send screen calls this on every address change, to size the amount field
+// against the address the user is typing.
 pub fn get_spendable_balance_with_address(
     address: String,
     zennies: String,
@@ -2326,6 +2327,27 @@ pub fn get_spendable_balance_with_address(
             ZingolibError::InvalidInput("failed to parse zennies setting".to_string())
         })?;
         RT.block_on(async move {
+            // `max_send_value` prices a trial payment of the whole shielded
+            // spendable balance to `address`. With nothing shielded to spend, that
+            // trial payment is zero-valued, and zip321 refuses a zero-valued output
+            // to a transparent recipient ("disallowed by consensus") -- so merely
+            // typing a transparent address on a wallet whose funds are all
+            // transparent, or still syncing, raised a consensus error out of what is
+            // only a balance query. Nothing to spend means a max of zero; answer
+            // that directly. Scoped so the read guard is released before
+            // `max_send_value` takes the wallet's write lock.
+            let spendable_balance = {
+                let wallet = lightclient.wallet().read().await;
+                wallet
+                    .shielded_spendable_balance(AccountId::ZERO, false)
+                    .map_err(ZingolibError::read)?
+            };
+            if spendable_balance == Zatoshis::ZERO {
+                return Ok(
+                    object! { "spendable_balance" => spendable_balance.into_u64() }.pretty(2),
+                );
+            }
+
             let bal = lightclient
                 .max_send_value(address, zennies, AccountId::ZERO)
                 .await


### PR DESCRIPTION
## Symptom

Users hit this, with no send attempted:

```
Error: send: Send error. Propose send error. Payment 0 is invalid:
zero-valued transparent outputs are disallowed by consensus
```

It fires the moment a **transparent** address is typed or pasted into Send, on a wallet whose shielded spendable balance is zero — funds all sitting in transparent UTXOs, or notes not yet spendable while syncing. A shielded address hides it, because zip321 allows zero-valued shielded outputs. That asymmetry is why it looks arbitrary from the outside.

## Cause

`Send.tsx` calls `calculateSpendableBalance(addressText)` on every address change → `getSpendableBalanceWithAddress` → this FFI → `lightclient.max_send_value(...)`.

`max_send_value` sizes the max by pricing a **trial payment of the whole shielded spendable balance** to that address:

```rust
let confirmed_balance = wallet.shielded_spendable_balance(account_id, false)?;
let mut spendable_balance = confirmed_balance;
loop {
    let mut receivers = vec![Receiver::new(address.clone(), spendable_balance, None)];
    ...
    let request = transaction_request_from_receivers(receivers)?;   // ← Zip321Error
```

With `confirmed_balance == 0` the first iteration builds a zero-valued payment, and `zip321::Payment::new` rejects it when the recipient `is_transparent_only()` (which also covers a UA carrying only a transparent receiver). The error surfaces verbatim in the snackbar via `setSpendableBalanceLastError`.

## Fix

Nothing to spend means a max of zero, so answer that directly instead of asking for a proposal. The read guard is scoped so it is released before `max_send_value` takes the wallet's write lock.

This is semantically inert for every healthy case: with a zero shielded spendable balance `max_send_value` cannot return anything but zero — today it just fails on the way there (zip321 for transparent recipients, `InsufficientFunds` for shielded ones, since there is nothing to cover the fee).

## Why here and not upstream

The real bug is in zingolib: `max_send_value` builds its trial request before checking that the balance it is sizing is non-zero, while `propose_send_all_paused` already guards the same case with `ZeroValueSendAll`. But zingolib comes in as a git dependency on `dev` pinned by the lockfile to `3a0f5a7e`, so fixing it there means a `cargo update -p zingolib` that drags in everything else landed on `dev`. This guards the one caller we own; the upstream fix can follow on its own schedule and this guard stays harmless when it lands.

## Also

Drops the `// we don't use this anymore...` comment above the function. It is false — the Send screen has been calling it all along — and it is probably what kept eyes off this path.

## Verification

- `cargo check --lib -p zingo` clean.
- `cargo fmt --check` clean.
- Not yet exercised on a device. The repro is easy to stage: a fresh wallet with zero balance, open Send, paste any `t1...` address — before this change the snackbar shows the consensus error, after it the amount field just sizes to zero.

No test added: this FFI needs an initialized lightclient, so covering it means the integration harness rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
