### PR TITLE
fix(android): keep the sync status data classes under R8

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -402,11 +402,10 @@ dependencies {
     // google truth testing framework
     androidTestImplementation("com.google.truth:truth:1.1.3")
 
-    // JSON parsing: the Kotlin module plus the core/databind classes the
-    // sources use directly (ObjectMapper, JsonNode, and friends).
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.3")
-    implementation("com.fasterxml.jackson.core:jackson-core:2.18.3")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
+    // JSON decoding in the instrumented tests.
+    androidTestImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.3")
+    androidTestImplementation("com.fasterxml.jackson.core:jackson-core:2.18.3")
+    androidTestImplementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
 
     // JVM unit tests for pure logic (no device or emulator)
     testImplementation("junit:junit:4.13.2")

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -24,29 +24,7 @@
 -keep class * implements com.sun.jna.Library { *; }
 -keepclassmembers class * extends com.sun.jna.Structure { *; }
 
-# Kotlin metadata and reflection — required by jackson-module-kotlin to introspect
-# data class primary constructors. Both main APK and test APK run in the same
-# process on Android; stripping kotlin.reflect causes jacksonObjectMapper() to
-# fail with "no Creators" on any Kotlin data class.
 -keepattributes *Annotation*, Signature, InnerClasses, EnclosingMethod
--keep class kotlin.Metadata { *; }
--keep class kotlin.reflect.** { *; }
--keep class kotlin.jvm.internal.** { *; }
-
-# Jackson Kotlin module — keep the module class and its ServiceLoader registration
--keep class com.fasterxml.jackson.module.kotlin.** { *; }
--keep class com.fasterxml.jackson.databind.** { *; }
-
-# Jackson core TypeReference — the inline reified `mapper.readValue<T>()` in
-# Kotlin generates anonymous subclasses whose generic Signature must survive
-# R8 optimisation, otherwise Jackson's TypeReference(...) constructor throws
-# "Internal error: TypeReference constructed without actual type information"
-# on release builds (seen in background sync on Play Store / signed APKs).
--keep class com.fasterxml.jackson.core.type.TypeReference { *; }
--keep class * extends com.fasterxml.jackson.core.type.TypeReference
--keepclassmembers class * extends com.fasterxml.jackson.core.type.TypeReference {
-    <init>(...);
-}
 
 # Guava — the androidTest APK asserts with Google Truth, which needs Guava
 # (e.g. ImmutableList) at runtime. Because the app ships Guava (a notifee
@@ -62,9 +40,6 @@
 -dontwarn java.awt.**
 -dontwarn com.sun.jna.Native$AWT
 
-# Jackson's Java7SupportImpl references java.beans annotations not present on Android
--dontwarn java.beans.**
-
 # kotlinx.datetime references kotlinx.serialization internally
 -dontwarn kotlinx.serialization.**
 
@@ -73,6 +48,3 @@
 -keepclassmembers class androidx.security.crypto.EncryptedFile {
     public java.io.FileOutputStream openFileOutput();
 }
-
--keep class org.ZingoLabs.Zingo.SyncStatus { *; }
--keep class org.ZingoLabs.Zingo.ScanRanges { *; }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -73,3 +73,6 @@
 -keepclassmembers class androidx.security.crypto.EncryptedFile {
     public java.io.FileOutputStream openFileOutput();
 }
+
+-keep class org.ZingoLabs.Zingo.SyncStatus { *; }
+-keep class org.ZingoLabs.Zingo.ScanRanges { *; }

--- a/android/app/proguard-test-rules.pro
+++ b/android/app/proguard-test-rules.pro
@@ -7,3 +7,16 @@
 # Keep all data classes in the test package used for Jackson deserialization.
 -keep class org.ZingoLabs.Zingo.** { *; }
 -keepclassmembers class org.ZingoLabs.Zingo.** { *; }
+
+# Jackson and Kotlin reflection, used by the instrumented tests only.
+-keep class kotlin.Metadata { *; }
+-keep class kotlin.reflect.** { *; }
+-keep class kotlin.jvm.internal.** { *; }
+-keep class com.fasterxml.jackson.module.kotlin.** { *; }
+-keep class com.fasterxml.jackson.databind.** { *; }
+-keep class com.fasterxml.jackson.core.type.TypeReference { *; }
+-keep class * extends com.fasterxml.jackson.core.type.TypeReference
+-keepclassmembers class * extends com.fasterxml.jackson.core.type.TypeReference {
+    <init>(...);
+}
+-dontwarn java.beans.**

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/BackgroundSyncWorker.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/BackgroundSyncWorker.kt
@@ -188,7 +188,9 @@ class BackgroundSyncWorker(private val context: Context, workerParams: WorkerPar
                 }
 
                 try {
-                    val percent = JSONObject(syncStatusJson).getDouble("percentage_total_outputs_scanned")
+                    val status = JSONObject(syncStatusJson)
+                    val percent = status.optDouble("percentage_total_outputs_scanned").takeUnless { it.isNaN() }
+                        ?: status.getDouble("percentage_total_blocks_scanned")
 
                     if (percent >= 100.0) {
                         Log.i("SCHEDULED_TASK_RUN", "sync COMPLETED %: $percent")
@@ -197,7 +199,7 @@ class BackgroundSyncWorker(private val context: Context, workerParams: WorkerPar
                         Log.i("SCHEDULED_TASK_RUN", "sync STATUS %: $percent")
                     }
                 } catch (e: Exception) {
-                    Log.e("SCHEDULED_TASK_RUN", "sync STATUS - parsing ERROR ${e.localizedMessage}")
+                    Log.e("SCHEDULED_TASK_RUN", "sync STATUS - parsing ERROR $e")
                     // save the background JSON file
                     val timeStampError = Date().time / 1000
                     val timeStampStrError = timeStampError.toString()
@@ -206,7 +208,7 @@ class BackgroundSyncWorker(private val context: Context, workerParams: WorkerPar
                         put("message", "Status sync parsing process KO.")
                         put("date", "$timeStampStrStart")
                         put("dateEnd", "$timeStampStrError")
-                        put("error", "Status sync parsing process KO. ${e.localizedMessage}")
+                        put("error", "Status sync parsing process KO. $e")
                     }
                     val jsonBackgroundError = payload.toString()
                     rpcModule.saveBackgroundFile(jsonBackgroundError)

--- a/android/app/src/main/java/org/ZingoLabs/Zingo/BackgroundSyncWorker.kt
+++ b/android/app/src/main/java/org/ZingoLabs/Zingo/BackgroundSyncWorker.kt
@@ -32,34 +32,6 @@ import kotlin.time.toDuration
 import kotlin.time.toJavaDuration
 import org.ZingoLabs.Zingo.Constants.*
 import java.io.FileInputStream
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
-
-data class ScanRanges (
-    val priority : String = "",
-    val start_block : String = "",
-    val end_block : String = ""
-)
-
-data class SyncStatus (
-    val scan_ranges : List<ScanRanges> = emptyList(),
-    val sync_start_height : Long = 0L,
-    val session_blocks_scanned : Long = 0L,
-    val total_blocks_scanned : Long = 0L,
-    val percentage_session_blocks_scanned : Double = 0.0,
-    val percentage_total_blocks_scanned : Double = 0.0,
-    val session_sapling_outputs_scanned : Long = 0L,
-    val total_sapling_outputs_scanned : Long = 0L,
-    val session_orchard_outputs_scanned : Long = 0L,
-    val total_orchard_outputs_scanned : Long = 0L,
-    val session_ironwood_outputs_scanned : Long = 0L,
-    val total_ironwood_outputs_scanned : Long = 0L,
-    val percentage_session_outputs_scanned : Double = 0.0,
-    val percentage_total_outputs_scanned : Double = 0.0,
-    val total_outputs_scanned : Long = 0L,
-    val total_outputs : Long = 0L
-)
 
 class BackgroundSyncWorker(private val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
     private val rpcModule = RPCModule(MainApplication.getAppReactContext())
@@ -83,11 +55,6 @@ class BackgroundSyncWorker(private val context: Context, workerParams: WorkerPar
     override fun doWork(): Result {
 
         Log.i("SCHEDULED_TASK_RUN", "Task running")
-
-        // zingolib adds sync-status fields as new pools land; an unknown field
-        // is not a reason to fail the background sync.
-        val mapper = jacksonObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
         // save the background JSON file
         val timeStampStart = Date().time / 1000
@@ -188,7 +155,6 @@ class BackgroundSyncWorker(private val context: Context, workerParams: WorkerPar
             val startTime = System.currentTimeMillis()
             val maxDurationMillis = 60 * 60 * 1000
 
-            var syncStatus: SyncStatus
             while (true) {
                 val elapsed = System.currentTimeMillis() - startTime
                 if (elapsed > maxDurationMillis) {
@@ -222,10 +188,7 @@ class BackgroundSyncWorker(private val context: Context, workerParams: WorkerPar
                 }
 
                 try {
-                    syncStatus = mapper.readValue(syncStatusJson)
-
-                    val percent = syncStatus.percentage_total_outputs_scanned
-                       ?: syncStatus.percentage_total_blocks_scanned
+                    val percent = JSONObject(syncStatusJson).getDouble("percentage_total_outputs_scanned")
 
                     if (percent >= 100.0) {
                         Log.i("SCHEDULED_TASK_RUN", "sync COMPLETED %: $percent")


### PR DESCRIPTION
Fixes the "Status sync parsing process KO." failure on every Android background sync since PR #971 enabled R8, which stripped the class the worker decoded the sync status into. The worker no longer depends on reflection to read it.