### PR TITLE
fix(ios): stop the background sync running on a wallet that failed to load

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -37,6 +37,17 @@ struct SyncStatus: Decodable {
     let total_outputs: Int64?
 }
 
+/// What `loadWalletFile` found when preparing a background sync.
+private enum BackgroundWalletLoad {
+    /// The wallet file is open and the lightclient is initialized.
+    case loaded
+    /// The user is in offline mode (empty server URI); nothing to sync.
+    case offline
+    /// The wallet could not be loaded, carrying what went wrong so the
+    /// background report names the cause instead of the symptom.
+    case failed(String)
+}
+
 private struct BackgroundTaskResult: Encodable {
     let batches: String
     let message: String
@@ -411,9 +422,30 @@ extension AppDelegate {
       
         if exists == "true" {
             // load the wallet file
-            let shouldSync = self.loadWalletFile()
+            let walletLoad = self.loadWalletFile()
 
-            if !shouldSync {
+            if case .failed(let reason) = walletLoad {
+                NSLog("BGTask syncingProcessBackgroundTask - Load wallet KO: \(reason)")
+
+                // save the background file
+                let timeStampLoadError = Date().timeIntervalSince1970
+                let timeStampStrLoadError = String(format: "%.0f", timeStampLoadError)
+                let jsonBackgroundLoadError = self.buildBackgroundJSON(message: "Load wallet process KO.", dateEnd: timeStampStrLoadError, error: "Load wallet process KO. \(reason)")
+                do {
+                  try rpcmodule.saveBackgroundFile(jsonBackgroundLoadError)
+                  NSLog("BGTask syncingProcessBackgroundTask - Save background JSON \(jsonBackgroundLoadError)")
+                } catch {
+                  NSLog("BGTask syncingProcessBackgroundTask - Save background JSON \(jsonBackgroundLoadError) error: \(error.localizedDescription)")
+                }
+
+                if let task = self.bgTask {
+                  task.setTaskCompleted(success: false)
+                }
+                bgTask = nil
+                return
+            }
+
+            if case .offline = walletLoad {
                 NSLog("BGTask syncingProcessBackgroundTask - Offline mode, sync skipped")
                 let timeStampOffline = Date().timeIntervalSince1970
                 let timeStampStrOffline = String(format: "%.0f", timeStampOffline)
@@ -601,22 +633,25 @@ extension AppDelegate {
     }
 
     /// Reads settings.json and loads the wallet file when a server URI is
-    /// configured. Returns `true` to signal the caller may proceed with sync, or
-    /// `false` only when the user is explicitly in offline mode (empty server
-    /// URI) and sync must be skipped. On any other unexpected condition the
-    /// function returns `true` so the downstream sync path surfaces its own
-    /// error rather than masquerading as offline mode.
-    func loadWalletFile() -> Bool {
+    /// configured, reporting which of the three outcomes happened so the
+    /// caller can tell "loaded" from "offline" from "could not load".
+    ///
+    /// A failed load used to report the same "proceed" as a successful one,
+    /// on the reasoning that the sync would surface its own error. It does,
+    /// but that error is `LightclientNotInitialized`, which names the symptom
+    /// and hides the cause: an unreadable settings.json on a locked device
+    /// reads exactly like a wallet that loaded fine and then failed to sync.
+    private func loadWalletFile() -> BackgroundWalletLoad {
         let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
         guard let documentsDirectory = paths.first else {
             NSLog("Error: Unable to find documents directory")
-            return true
+            return .failed("unable to find the documents directory")
         }
 
         let fileName = "\(documentsDirectory)/settings.json"
         guard let content = try? String(contentsOfFile: fileName, encoding: .utf8) else {
             NSLog("Error: Unable to read file at path \(fileName)")
-            return true
+            return .failed("unable to read settings.json")
         }
 
         guard let contentData = content.data(using: .utf8),
@@ -625,12 +660,12 @@ extension AppDelegate {
               let serveruri = server["uri"] as? String,
               let chainhint = server["chainName"] as? String else {
             NSLog("Error: Unable to parse JSON object from file at path \(fileName)")
-            return true
+            return .failed("unable to parse settings.json")
         }
 
         if serveruri.isEmpty {
             NSLog("Offline mode detected (empty serveruri) - skipping wallet load")
-            return false
+            return .offline
         }
 
         NSLog("Opening the wallet file - No App active - serveruri: \(serveruri) chain: \(chainhint)")
@@ -639,8 +674,9 @@ extension AppDelegate {
           _ = try rpcmodule.fnLoadExistingWallet(serveruri: serveruri, chainhint: chainhint, performancelevel: "Medium", minconfirmations: "3")
         } catch {
           NSLog("Error: Unable to load the wallet. error: \(error.localizedDescription)")
+          return .failed(error.localizedDescription)
         }
-        return true
+        return .loaded
     }
 
     func cancelExecutingTask() {


### PR DESCRIPTION
## The report

From a user on **2.0.22 (313)**, iPhone 17 Pro / iOS 26.6:

```
Run sync process KO. Zingo.ZingolibError.LightclientNotInitialized(
message: "Error: Lightclient is not initialized")
```

## Cause

`loadWalletFile()` returns `true` on **every** path except offline mode:

- no documents directory → `true`
- `settings.json` unreadable → `true`
- `settings.json` unparseable, or missing `server.uri` / `server.chainName` → `true`
- `fnLoadExistingWallet` throws → logged, falls through to `true`

The BGTask reads that `true` as "the wallet is loaded, go sync" and calls `runSync()` on a lightclient that was never initialized — which is the error above.

Note the second bullet: when `settings.json` cannot be read, the function returns "proceed" **without even attempting to load the wallet**, so the failure is guaranteed. BGTasks routinely fire while the device is locked, where data protection makes exactly that file unreadable.

## What changes

The old contract was deliberate — the doc comment said a failure returns `true` "so the downstream sync path surfaces its own error rather than masquerading as offline mode". It does surface an error, but `LightclientNotInitialized` names the symptom and hides the cause: an unreadable settings.json on a locked device reads identically to a wallet that loaded fine and then failed to sync. That is why this report could not be diagnosed from its own text.

So `loadWalletFile` now reports which of three things happened, and the caller acts on it:

- `.offline` → skip the sync, complete the task successfully (unchanged behaviour)
- `.failed(reason)` → write a background report saying `Load wallet process KO. <reason>`, complete the task unsuccessfully, **do not attempt the sync**
- `.loaded` → proceed

The method becomes `private` because its return type is file-private, matching `buildBackgroundJSON` next to it.

## Not included

- **Deferring instead of failing when protected data is unavailable.** That is the likely trigger, but checking `isProtectedDataAvailable` and rescheduling the task is a behaviour change that deserves its own discussion. This PR stops the misleading report either way, and a `.failed("unable to read settings.json")` report will confirm the hypothesis from the field.

## Verification

Behaviour was not exercised on a device — reproducing it needs a BGTask firing against an unreadable `settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
